### PR TITLE
Use backticks for maintainers section

### DIFF
--- a/conda_forge_webservices/tests/linting/test_compute_lint_message.py
+++ b/conda_forge_webservices/tests/linting/test_compute_lint_message.py
@@ -44,7 +44,7 @@ class Test_compute_lint_message(unittest.TestCase):
          * The home item is expected in the about section.
          * The license item is expected in the about section.
          * The summary item is expected in the about section.
-         * The recipe could do with some maintainers listed in the "extra/recipe-maintainers" section.
+         * The recipe could do with some maintainers listed in the `extra/recipe-maintainers` section.
          * The recipe must have some tests.
          * The recipe must have a `build/number` section.
         """)


### PR DESCRIPTION
Follow-up on PR ( https://github.com/conda-forge/conda-smithy/pull/225 ) to ensure the tests correctly allow for `extra/recipe-maintainers` (with backticks).