### PR TITLE
Change variable `open` to `is_open`

### DIFF
--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -54,10 +54,10 @@ class HookHandler(tornado.web.RequestHandler):
             repo_url = body['repository']['clone_url']
             owner = body['repository']['owner']['login']
             pr_id = int(body['pull_request']['number'])
-            open = body['pull_request']['state'] == 'open'
+            is_open = body['pull_request']['state'] == 'open'
 
             # Only do anything if we are working with conda-forge, and an open PR.
-            if open and owner == 'conda-forge':
+            if is_open and owner == 'conda-forge':
                 lint_info = linting.compute_lint_message(owner, repo_name, pr_id)
                 msg = linting.comment_on_pr(owner, repo_name, pr_id, lint_info['message'])
                 linting.set_pr_status(owner, repo_name, lint_info, target_url=msg.html_url)


### PR DESCRIPTION
We don't want to be overriding keywords like `open`. So, change the variable to a different name. It is unfortunate that Python allows this at all.