### PR TITLE
Add status page

### DIFF
--- a/conda_forge_webservices/status.py
+++ b/conda_forge_webservices/status.py
@@ -1,0 +1,32 @@
+import os
+import subprocess
+
+
+def update(token=None):
+    if token is None:
+        token = os.environ["GH_TOKEN"]
+
+    subprocess.check_call([
+        "statuspage",
+        "update",
+        "--org",
+        "conda-forge",
+        "--name",
+        "status",
+        "--token",
+        token
+    ])
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="status",
+        description="Updates the status page.",
+    )
+
+    update(os.environ["GH_TOKEN"])
+
+
+if __name__ == '__main__':
+    main()

--- a/conda_forge_webservices/status.py
+++ b/conda_forge_webservices/status.py
@@ -4,7 +4,7 @@ import subprocess
 
 def update(token=None):
     if token is None:
-        token = os.environ["GH_TOKEN"]
+        token = os.environ["STATUS_GH_TOKEN"]
 
     subprocess.check_call([
         "statuspage",

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -94,10 +94,7 @@ class StatusHookHandler(tornado.web.RequestHandler):
         elif event == 'issues':
             body = tornado.escape.json_decode(self.request.body)
             repo_name = body['repository']['name']
-            repo_url = body['repository']['clone_url']
             owner = body['repository']['owner']['login']
-            issue_num = int(body['issue']['number'])
-            open = body['issue']['state'] == 'open'
 
             # Only do something if it is an issue on the status page
             if owner == 'conda-forge' and repo_name == 'status':

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -17,6 +17,7 @@ from contextlib import contextmanager
 
 
 import conda_forge_webservices.linting as linting
+import conda_forge_webservices.status as status
 
 
 class RegisterHandler(tornado.web.RequestHandler):
@@ -38,10 +39,26 @@ class RegisterHandler(tornado.web.RequestHandler):
               }
             }
 
-        r = requests.post(url, json=payload, headers=headers)
+        r1 = requests.post(url, json=payload, headers=headers)
+
+        url = 'https://api.github.com/repos/conda-forge/status/hooks'
+
+        payload = {
+              "name": "web",
+              "active": True,
+              "events": [
+                "issues"
+              ],
+              "config": {
+                "url": "http://conda-forge-status.herokuapp.com/hook",
+                "content_type": "json"
+              }
+            }
+
+        r2 = requests.post(url, json=payload, headers=headers)
 
 
-class HookHandler(tornado.web.RequestHandler):
+class LintingHookHandler(tornado.web.RequestHandler):
     def post(self):
         headers = self.request.headers
         event = headers.get('X-GitHub-Event', None)
@@ -67,9 +84,34 @@ class HookHandler(tornado.web.RequestHandler):
             self.write_error(404)
 
 
+class StatusHookHandler(tornado.web.RequestHandler):
+    def post(self):
+        headers = self.request.headers
+        event = headers.get('X-GitHub-Event', None)
+
+        if event == 'ping':
+            self.write('pong')
+        elif event == 'issues':
+            body = tornado.escape.json_decode(self.request.body)
+            repo_name = body['repository']['name']
+            repo_url = body['repository']['clone_url']
+            owner = body['repository']['owner']['login']
+            issue_num = int(body['issue']['number'])
+            open = body['issue']['state'] == 'open'
+
+            # Only do something if it is an issue on the status page
+            if owner == 'conda-forge' and repo_name == 'status':
+                status.update()
+        else:
+            print('Unhandled event "{}".'.format(event))
+            self.set_status(404)
+            self.write_error(404)
+
+
 def create_webapp():
     application = tornado.web.Application([
-        (r"/conda-linting/hook", HookHandler),
+        (r"/conda-linting/hook", LintingHookHandler),
+        (r"/conda-forge-status/hook", StatusHookHandler),
     ])
     return application
 

--- a/environment.yml
+++ b/environment.yml
@@ -8,3 +8,4 @@ dependencies:
  - conda-smithy
  - tornado
  - pygithub
+ - statuspage


### PR DESCRIPTION
This requires the `statuspage` package be created. Though it looks like that recipe should be ready to go. It may be worth a final review as much has changed since the last one. See PR ( https://github.com/conda-forge/staged-recipes/pull/775 ).

Using `statuspage` is really simple. We just point it at repo, give it a token, and tell it to run `update`. This is basically what `status.py` below is. Right now we are using `GH_TOKEN` as the environment variable. However, I don't really like this as I don't want the status page to potentially get throttled by the linter's rate limit. I already have another bot setup ( @conda-forge-status ) for this task. So we should discuss how we want to do this.

The rest of the code in `webapp.py` is just trying to register us for issue update events on the status page. We may find this is too frequent and need to tone it down. However, I don't have a good feel for that right now without see this in action. So, it may just be easiest to start with this and optimize later. Please review this part carefully.