### PR TITLE
Handle some other status page events

### DIFF
--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -91,12 +91,12 @@ class StatusHookHandler(tornado.web.RequestHandler):
 
         if event == 'ping':
             self.write('pong')
-        elif event == 'issues':
+        elif event == 'issues' or event == 'issue_comment' or event == 'push':
             body = tornado.escape.json_decode(self.request.body)
             repo_name = body['repository']['name']
             owner = body['repository']['owner']['login']
 
-            # Only do something if it is an issue on the status page
+            # Only do something if it involves the status page
             if owner == 'conda-forge' and repo_name == 'status':
                 status.update()
         else:


### PR DESCRIPTION
There are a few other events that appear to result in the status page updating. One of them is if there is a comment on an issue. In this case, the comments will show up under the active issue in the status page. The other is if a commit is pushed to the repo. So if someone updates the logo or the templates, it should change what the webpage looks like. In both cases, we do the exact same thing as if an issue is opened/closed. As a result we just do an update for all of these cases.