### PR TITLE
Fix push event handling

### DIFF
--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -93,11 +93,10 @@ class StatusHookHandler(tornado.web.RequestHandler):
             self.write('pong')
         elif event == 'issues' or event == 'issue_comment' or event == 'push':
             body = tornado.escape.json_decode(self.request.body)
-            repo_name = body['repository']['name']
-            owner = body['repository']['owner']['login']
+            repo_full_name = body['repository']['full_name']
 
             # Only do something if it involves the status page
-            if owner == 'conda-forge' and repo_name == 'status':
+            if repo_full_name == 'conda-forge/status':
                 status.update()
         else:
             print('Unhandled event "{}".'.format(event))


### PR DESCRIPTION
Handle the slightly different response for a `push` event. It uses `name` instead of `login` used by `issues` or `issue_comment` events. This is a minor tweak to the changes presented in PR ( https://github.com/conda-forge/conda-forge-webservices/pull/37 ).