### PR TITLE
Use Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ sudo: false
 
 env:
   matrix:
-    - python=2.7
-#    - python=3.5
+#    - python=2.7
+    - python=3.5
 
   global:
     # Adds a GH_TOKEN (pelson) for testing

--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -14,7 +14,7 @@ env_dir=$(cd "$3/" && pwd)
 
 wget -q https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 bash miniconda.sh -b -p $HOME/.conda
-$HOME/.conda/bin/conda install -c conda-forge --yes conda-smithy python=2 tornado pygithub statuspage
+$HOME/.conda/bin/conda install -c conda-forge --yes conda-smithy python=3 tornado pygithub statuspage
 
 cp -rf $HOME/.conda $STORAGE_LOCN/.conda
 

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
  - conda-forge
 
 dependencies:
- - python=2
+ - python=3
  - conda-smithy
  - tornado
  - pygithub


### PR DESCRIPTION
This is as much a question as an actual request. Is there a good reason not to use Python 3 (or for use of Python 2)? As Python 3 handles unicode much better, this may already help solve some annoying linter issues. Thus am proposing we use Python 3 for testing, building, and deployement.