### PR TITLE
WIP: Purges merged recipes from PRs for linting

### DIFF
--- a/conda_forge_webservices/linting.py
+++ b/conda_forge_webservices/linting.py
@@ -28,6 +28,8 @@ def compute_lint_message(repo_owner, repo_name, pr_id):
 
     with tmp_directory() as tmp_dir:
         repo = Repo.clone_from(repo.clone_url, tmp_dir)
+
+        # Checkout the PR head and get the list of recipes.
         repo.remotes.origin.fetch('pull/{pr}/head:pr/{pr}'.format(pr=pr_id))
         repo.refs['pr/{}'.format(pr_id)].checkout()
         sha = str(repo.head.object.hexsha)
@@ -35,6 +37,8 @@ def compute_lint_message(repo_owner, repo_name, pr_id):
                    for y in glob(os.path.join(x[0], 'meta.yaml'))]
         all_pass = True
         messages = []
+
+        # Exclude some things from our list of recipes.
         recipe_dirs = [os.path.dirname(recipe) for recipe in recipes
                        if os.path.basename(os.path.dirname(recipe)) != 'example']
 

--- a/conda_forge_webservices/tests/test_webapp.py
+++ b/conda_forge_webservices/tests/test_webapp.py
@@ -40,7 +40,7 @@ class TestBucketHandler(TestHandlerBase):
 
         self.assertEqual(response.code, 200)
         compute_lint_message.assert_called_once_with('conda-forge', 'repo_name',
-                                                     PR_number)
+                                                     PR_number, False)
 
         comment_on_pr.assert_called_once_with('conda-forge', 'repo_name',
                                               PR_number, mock.sentinel.message)

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -75,7 +75,8 @@ class LintingHookHandler(tornado.web.RequestHandler):
 
             # Only do anything if we are working with conda-forge, and an open PR.
             if is_open and owner == 'conda-forge':
-                lint_info = linting.compute_lint_message(owner, repo_name, pr_id)
+                lint_info = linting.compute_lint_message(owner, repo_name, pr_id,
+                                                         repo_name == 'staged-recipes')
                 msg = linting.comment_on_pr(owner, repo_name, pr_id, lint_info['message'])
                 linting.set_pr_status(owner, repo_name, lint_info, target_url=msg.html_url)
         else:


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-forge-webservices/issues/45

I'm trying to decide how much value this has. Right now we are grabbing the PR's `head` ref. As such, it is not already merged with `master`. This differs from what the CIs generally due, which is checkout the PR's `merge` ref. As a result, recipes are not really going to *sneak* into one's PR. They will definitely be visible locally in one's recipe directory. Though maybe this will help avoid the impulse of deleting them, which can make the diffs noise. It should also be more flexible as we add more examples or rename existing ones.

xref: https://github.com/conda-forge/staged-recipes/pull/1373