### PR TITLE
Test with generic Travis VM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: python
+language: generic
 
 sudo: false
 


### PR DESCRIPTION
We don't actually care what VM we get from Travis CI or what comes with it as we install Miniconda and use its Python and assorted packages for constructing a testing environment. As a result, it would be better if we use one of the "cheap" Travis VM images to start as we don't care what comes with it. Here we propose using the `generic` image, which we have used successfully in a lot of other cases. Also it has very fast boot times. This should be helpful for iterating quickly on proposed changes.