### PR TITLE
Drop extra GitHub API call

### DIFF
--- a/conda_forge_webservices/linting.py
+++ b/conda_forge_webservices/linting.py
@@ -24,8 +24,6 @@ def compute_lint_message(repo_owner, repo_name, pr_id):
     owner = gh.get_user(repo_owner)
     repo = owner.get_repo(repo_name)
 
-    issue = repo.get_issue(pr_id)
-
     with tmp_directory() as tmp_dir:
         repo = Repo.clone_from(repo.clone_url, tmp_dir)
         repo.remotes.origin.fetch('pull/{pr}/head:pr/{pr}'.format(pr=pr_id))


### PR DESCRIPTION
In `compute_lint_message`, we are grabbing the issue/PR. However, we never use this object. Given how often the linter is run, there is no reason to find ourselves throttled for something that isn't useful to us. This PR proposes we drop that unneeded call.