### PR TITLE
Purges recipes in base of PRs before linting

### DIFF
--- a/conda_forge_webservices/linting.py
+++ b/conda_forge_webservices/linting.py
@@ -22,7 +22,7 @@ def find_recipes(a_dir):
     return [os.path.dirname(y) for x in os.walk(a_dir)
             for y in glob(os.path.join(x[0], 'meta.yaml'))]
 
-def compute_lint_message(repo_owner, repo_name, pr_id):
+def compute_lint_message(repo_owner, repo_name, pr_id, ignore_base=False):
     gh = github.Github(os.environ['GH_TOKEN'])
 
     owner = gh.get_user(repo_owner)
@@ -74,6 +74,19 @@ def compute_lint_message(repo_owner, repo_name, pr_id):
 
             return lint_info
 
+        # Collect recipes from base that should be ignored.
+        base_recipes = []
+        if ignore_base:
+            num_parents = len(ref_merge.commit.parents)
+            assert num_parents == 2, textwrap.dedent("""
+                   Expected merging our PR with the base branch would have two parents.
+                   Instead there were %i parents found. :/
+                   """ % num_parents)
+            base_commit = (set(ref_merge.commit.parents) - {ref_head.commit}).pop()
+            ref_base = repo.create_head("pull/{pr}/base".format(pr=pr_id), base_commit)
+            ref_base.checkout()
+            base_recipes = find_recipes(tmp_dir)
+
         # Get the list of recipes and prep for linting.
         ref_merge.checkout()
         recipes = find_recipes(tmp_dir)
@@ -81,16 +94,13 @@ def compute_lint_message(repo_owner, repo_name, pr_id):
         messages = []
 
         # Exclude some things from our list of recipes.
-        recipe_dirs = [recipe for recipe in recipes
-                       if os.path.basename(recipe) != 'example']
-
         # Sort the recipes for consistent linting order (which glob doesn't give us).
-        recipe_dirs = sorted(recipe_dirs)
+        pr_recipes = sorted(set(recipes) - set(base_recipes))
 
-        rel_recipe_dirs = []
-        for recipe_dir in recipe_dirs:
+        rel_pr_recipes = []
+        for recipe_dir in pr_recipes:
             rel_path = os.path.relpath(recipe_dir, tmp_dir)
-            rel_recipe_dirs.append(rel_path)
+            rel_pr_recipes.append(rel_path)
             try:
                 lints = conda_smithy.lint_recipe.main(recipe_dir)
             except Exception as err:
@@ -102,7 +112,7 @@ def compute_lint_message(repo_owner, repo_name, pr_id):
                                                              '\n'.join(' * {}'.format(lint) for lint in lints)))
 
     # Put the recipes in the form "```recipe/a```, ```recipe/b```".
-    recipe_code_blocks = ', '.join('```{}```'.format(r) for r in rel_recipe_dirs)
+    recipe_code_blocks = ', '.join('```{}```'.format(r) for r in rel_pr_recipes)
 
     good = textwrap.dedent("""
     Hi! This is the friendly automated conda-forge-linting service.
@@ -121,7 +131,7 @@ def compute_lint_message(repo_owner, repo_name, pr_id):
     {{}}
     """.format(recipe_code_blocks)).format('\n'.join(messages))
 
-    if not recipe_dirs:
+    if not pr_recipes:
         message = textwrap.dedent("""
             Hi! This is the friendly automated conda-forge-linting service.
             
@@ -192,11 +202,14 @@ def main():
     parser.add_argument('pr', type=int)
     parser.add_argument('--enable-commenting', help='Turn on PR commenting',
                         action='store_true')
+    parser.add_argument('--ignore-base',
+                        help='Ignore recipes in the base branch of the PR',
+                        action='store_true')
 
     args = parser.parse_args()
     owner, repo_name = args.repo.split('/')
 
-    lint_info = compute_lint_message(owner, repo_name, args.pr)
+    lint_info = compute_lint_message(owner, repo_name, args.pr, args.ignore_base)
 
     if not lint_info:
         print('Linting was skipped.')

--- a/conda_forge_webservices/tests/linting/test_compute_lint_message.py
+++ b/conda_forge_webservices/tests/linting/test_compute_lint_message.py
@@ -53,6 +53,28 @@ class Test_compute_lint_message(unittest.TestCase):
         lint = compute_lint_message('conda-forge', 'conda-forge-webservices', 62)
         self.assertMultiLineEqual(expected_message, lint['message'])
 
+    def test_ok_recipe_above_ignored_good_recipe(self):
+        expected_message = textwrap.dedent("""
+        Hi! This is the friendly automated conda-forge-linting service.
+        
+        I just wanted to let you know that I linted all conda-recipes in your PR (```recipes/ok_recipe```) and found it was in an excellent condition.
+        
+        """)
+
+        lint = compute_lint_message('conda-forge', 'conda-forge-webservices', 54, True)
+        self.assertMultiLineEqual(expected_message, lint['message'])
+
+    def test_ok_recipe_beside_ignored_good_recipe(self):
+        expected_message = textwrap.dedent("""
+        Hi! This is the friendly automated conda-forge-linting service.
+        
+        I just wanted to let you know that I linted all conda-recipes in your PR (```recipes/ok_recipe```) and found it was in an excellent condition.
+        
+        """)
+
+        lint = compute_lint_message('conda-forge', 'conda-forge-webservices', 62, True)
+        self.assertMultiLineEqual(expected_message, lint['message'])
+
     def test_conflict_ok_recipe(self):
         expected_message = textwrap.dedent("""
         Hi! This is the friendly automated conda-forge-linting service.

--- a/conda_forge_webservices/tests/linting/test_main.py
+++ b/conda_forge_webservices/tests/linting/test_main.py
@@ -14,6 +14,22 @@ class TestCLI_recipe_lint(unittest.TestCase):
         out, _ = child.communicate()
         self.assertEqual(child.returncode, 0, out)
 
+    def test_cli_success_ok_above_ignored_good(self):
+        child = subprocess.Popen([sys.executable, '-m' 'conda_forge_webservices.linting',
+                                  'conda-forge/conda-forge-webservices', '54',
+                                  '--enable-commenting', '--ignore-base'],
+                                 stdout=subprocess.PIPE, env=os.environ)
+        out, _ = child.communicate()
+        self.assertEqual(child.returncode, 0, out)
+
+    def test_cli_success_ok_beside_ignored_good(self):
+        child = subprocess.Popen([sys.executable, '-m' 'conda_forge_webservices.linting',
+                                  'conda-forge/conda-forge-webservices', '62',
+                                  '--enable-commenting', '--ignore-base'],
+                                 stdout=subprocess.PIPE, env=os.environ)
+        out, _ = child.communicate()
+        self.assertEqual(child.returncode, 0, out)
+
     def test_cli_success_conflict_ok(self):
         child = subprocess.Popen([sys.executable, '-m' 'conda_forge_webservices.linting',
                                   'conda-forge/conda-forge-webservices', '56', '--enable-commenting'],

--- a/conda_forge_webservices/tests/test_webapp.py
+++ b/conda_forge_webservices/tests/test_webapp.py
@@ -49,3 +49,28 @@ class TestBucketHandler(TestHandlerBase):
                                               {'message': mock.sentinel.message},
                                               target_url=mock.sentinel.html_url)
 
+    @mock.patch('conda_forge_webservices.linting.compute_lint_message', return_value={'message': mock.sentinel.message})
+    @mock.patch('conda_forge_webservices.linting.comment_on_pr', return_value=mock.MagicMock(html_url=mock.sentinel.html_url))
+    @mock.patch('conda_forge_webservices.linting.set_pr_status')
+    def test_staged_recipes(self, set_pr_status, comment_on_pr, compute_lint_message):
+        PR_number = 16
+        body = {'repository': {'name': 'staged-recipes',
+                               'clone_url': 'repo_clone_url',
+                               'owner': {'login': 'conda-forge'}},
+                'pull_request': {'number': PR_number,
+                                 'state': 'open'}}
+
+        response = self.fetch('/conda-linting/hook', method='POST',
+                              body=json.dumps(body),
+                              headers={'X-GitHub-Event': 'pull_request'})
+
+        self.assertEqual(response.code, 200)
+        compute_lint_message.assert_called_once_with('conda-forge', 'staged-recipes',
+                                                     PR_number, True)
+
+        comment_on_pr.assert_called_once_with('conda-forge', 'staged-recipes',
+                                              PR_number, mock.sentinel.message)
+
+        set_pr_status.assert_called_once_with('conda-forge', 'staged-recipes',
+                                              {'message': mock.sentinel.message},
+                                              target_url=mock.sentinel.html_url)

--- a/conda_forge_webservices/tests/test_webapp.py
+++ b/conda_forge_webservices/tests/test_webapp.py
@@ -40,7 +40,7 @@ class TestBucketHandler(TestHandlerBase):
 
         self.assertEqual(response.code, 200)
         compute_lint_message.assert_called_once_with('conda-forge', 'repo_name',
-                                                     PR_number)
+                                                     PR_number, False)
 
         comment_on_pr.assert_called_once_with('conda-forge', 'repo_name',
                                               PR_number, mock.sentinel.message)

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -75,7 +75,8 @@ class LintingHookHandler(tornado.web.RequestHandler):
 
             # Only do anything if we are working with conda-forge, and an open PR.
             if is_open and owner == 'conda-forge':
-                lint_info = linting.compute_lint_message(owner, repo_name, pr_id)
+                lint_info = linting.compute_lint_message(owner, repo_name, pr_id,
+                                                         repo_name == 'staged-recipes')
                 if lint_info:
                     msg = linting.comment_on_pr(owner, repo_name, pr_id, lint_info['message'])
                     linting.set_pr_status(owner, repo_name, lint_info, target_url=msg.html_url)


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-forge-webservices/issues/45
Closes https://github.com/conda-forge/conda-forge-webservices/pull/47

Initially I had written PR ( https://github.com/conda-forge/conda-forge-webservices/pull/47 ) and it quickly got wildly unmanageable by attempting to handle all the use cases of the linter (staged-recipes and feedstocks) as well as providing a testable interface. Ultimately looking at it filled me with such a level of disgust 😝 that I had to just rewrite this from scratch.

In this PR, we take advantage of remote refs in the same way the linter already does, but we go one step further. Instead of simply getting the PR `head` ref, we also get the PR `merge` ref. The latter is provided in particular for use by CIs so that they can checkout the PR as if it were already merged into the base branch. In the event that we do want to remove recipes that are in the base branch (now referred to as `base`, we can now determine what the latest commit in the `base` is (pre-merge). As there should only be two parent commits of the merge, there should be no confusion as to which one is in `base`. If there is some confusion about what `base` is, we should be sure to raise an error explain what that confusion is.

However, there are some cases we do need to be aware of that are problematic. One is the case where the `merge` ref is not defined. For now this is limited to the case of a PR that was created in conflict. The other is the case where the PR has come to be in conflict. In this latter case, the `merge` ref may be defined (if the PR was ever mergeable), but would be out-of-date. The first case could easily be solved by trying to retrieve it and then erroring out. The second case however cannot be easily caught via `git` as the `merge` ref is still present. As a result, we simply query the GitHub API if the PR is mergeable. This way we can be sure to cover both cases without issue. Since we like to provide comments for the user it seems nice to do so in this case. As this seemed like useful functionality on its own, it has been broken out into a separate PR ( https://github.com/conda-forge/conda-forge-webservices/pull/55 ) and merged back into here. For more details on this point please read issue ( https://github.com/isaacs/github/issues/757 ).

Once `base` has been determined, it is a simple matter to get the recipes from it and exclude those recipes from the list we find in `head`. The result being the list proposed in this PR.

After writing this, I noticed that there were a bunch of small useful usable pieces that could be broken out and addressed separately even if this attempt doesn't take. These include PRs ( https://github.com/conda-forge/conda-forge-webservices/pull/49 ), ( https://github.com/conda-forge/conda-forge-webservices/pull/50 ), ( https://github.com/conda-forge/conda-forge-webservices/pull/51 ), and ( https://github.com/conda-forge/conda-forge-webservices/pull/55 ). Hopefully those can be merged independently of this.

Have tried to set up PR ( https://github.com/conda-forge/conda-forge-webservices/pull/54 ) for testing purging. Merge conflict issues are tested in PRs ( https://github.com/conda-forge/conda-forge-webservices/pull/56 ) and ( https://github.com/conda-forge/conda-forge-webservices/pull/57 ). Also have written a few tests for this functionality. Hopefully we can get a good idea of whether this works or not. If you are subscribed to that testing PR, please unsubscribe yourself as it will be very noisy.

xref: https://github.com/conda-forge/staged-recipes/pull/1373