### PR TITLE
Catch and raise merge conflicts

### DIFF
--- a/conda_forge_webservices/linting.py
+++ b/conda_forge_webservices/linting.py
@@ -28,6 +28,8 @@ def compute_lint_message(repo_owner, repo_name, pr_id):
 
     with tmp_directory() as tmp_dir:
         repo = Repo.clone_from(repo.clone_url, tmp_dir)
+
+        # Checkout the PR head and get the list of recipes.
         repo.remotes.origin.fetch('pull/{pr}/head:pr/{pr}'.format(pr=pr_id))
         repo.refs['pr/{}'.format(pr_id)].checkout()
         sha = str(repo.head.object.hexsha)
@@ -35,6 +37,8 @@ def compute_lint_message(repo_owner, repo_name, pr_id):
                    for y in glob(os.path.join(x[0], 'meta.yaml'))]
         all_pass = True
         messages = []
+
+        # Exclude some things from our list of recipes.
         recipe_dirs = [os.path.dirname(recipe) for recipe in recipes
                        if os.path.basename(os.path.dirname(recipe)) != 'example']
 

--- a/conda_forge_webservices/linting.py
+++ b/conda_forge_webservices/linting.py
@@ -24,13 +24,35 @@ def compute_lint_message(repo_owner, repo_name, pr_id):
     owner = gh.get_user(repo_owner)
     repo = owner.get_repo(repo_name)
 
+    pull_request = repo.get_pull(pr_id)
+
     with tmp_directory() as tmp_dir:
         repo = Repo.clone_from(repo.clone_url, tmp_dir)
 
-        # Checkout the PR head and get the list of recipes.
+        # Checkout the PR head.
         repo.remotes.origin.fetch('pull/{pr}/head:pr/{pr}'.format(pr=pr_id))
         repo.refs['pr/{}'.format(pr_id)].checkout()
         sha = str(repo.head.object.hexsha)
+
+        # Raise an error if the PR is not mergeable.
+        if not pull_request.mergeable:
+            message = textwrap.dedent("""
+                Hi! This is the friendly automated conda-forge-linting service.
+                
+                I was trying to look for recipes to lint for you, but it appears we have a merge conflict.
+                Please try to merge or rebase with the base branch to resolve this conflict.
+                
+                Please ping the 'conda-forge/core' team (using the @ notation in a comment) if you believe this is a bug.
+                """)
+            status = 'merge_conflict'
+
+            lint_info = {'message': message,
+                         'status': status,
+                         'sha': sha}
+
+            return lint_info
+
+        # Get the list of recipes and prep for linting.
         recipes = [y for x in os.walk(tmp_dir)
                    for y in glob(os.path.join(x[0], 'meta.yaml'))]
         all_pass = True

--- a/conda_forge_webservices/tests/linting/test_compute_lint_message.py
+++ b/conda_forge_webservices/tests/linting/test_compute_lint_message.py
@@ -30,6 +30,32 @@ class Test_compute_lint_message(unittest.TestCase):
         lint = compute_lint_message('conda-forge', 'conda-forge-webservices', 16)
         self.assertMultiLineEqual(expected_message, lint['message'])
 
+    def test_conflict_ok_recipe(self):
+        expected_message = textwrap.dedent("""
+        Hi! This is the friendly automated conda-forge-linting service.
+        
+        I was trying to look for recipes to lint for you, but it appears we have a merge conflict.
+        Please try to merge or rebase with the base branch to resolve this conflict.
+        
+        Please ping the 'conda-forge/core' team (using the @ notation in a comment) if you believe this is a bug.
+        """)
+
+        lint = compute_lint_message('conda-forge', 'conda-forge-webservices', 56)
+        self.assertMultiLineEqual(expected_message, lint['message'])
+
+    def test_conflict_2_ok_recipe(self):
+        expected_message = textwrap.dedent("""
+        Hi! This is the friendly automated conda-forge-linting service.
+        
+        I was trying to look for recipes to lint for you, but it appears we have a merge conflict.
+        Please try to merge or rebase with the base branch to resolve this conflict.
+        
+        Please ping the 'conda-forge/core' team (using the @ notation in a comment) if you believe this is a bug.
+        """)
+
+        lint = compute_lint_message('conda-forge', 'conda-forge-webservices', 57)
+        self.assertMultiLineEqual(expected_message, lint['message'])
+
     def test_bad_recipe(self):
         expected_message = textwrap.dedent("""
         Hi! This is the friendly automated conda-forge-linting service.

--- a/conda_forge_webservices/tests/linting/test_main.py
+++ b/conda_forge_webservices/tests/linting/test_main.py
@@ -14,6 +14,20 @@ class TestCLI_recipe_lint(unittest.TestCase):
         out, _ = child.communicate()
         self.assertEqual(child.returncode, 0, out)
 
+    def test_cli_success_conflict_ok(self):
+        child = subprocess.Popen([sys.executable, '-m' 'conda_forge_webservices.linting',
+                                  'conda-forge/conda-forge-webservices', '56', '--enable-commenting'],
+                                 stdout=subprocess.PIPE, env=os.environ)
+        out, _ = child.communicate()
+        self.assertEqual(child.returncode, 0, out)
+
+    def test_cli_success_conflict_2_ok(self):
+        child = subprocess.Popen([sys.executable, '-m' 'conda_forge_webservices.linting',
+                                  'conda-forge/conda-forge-webservices', '57', '--enable-commenting'],
+                                 stdout=subprocess.PIPE, env=os.environ)
+        out, _ = child.communicate()
+        self.assertEqual(child.returncode, 0, out)
+
     def test_cli_success_good(self):
         child = subprocess.Popen([sys.executable, '-m' 'conda_forge_webservices.linting',
                                   'conda-forge/conda-forge-webservices', '16', '--enable-commenting'],


### PR DESCRIPTION
Closes https://github.com/conda-forge/conda-forge-webservices/pull/51

This checks to see if a PR will have merge conflicts and raises an error if it does. This should help the occasional confused or git tormented person find their way back to a mergeable PR. It also saves us from linting things when they are in a non-functioning state. After all we would not otherwise know there was a merge conflict. Testing occurs in PRs ( https://github.com/conda-forge/conda-forge-webservices/pull/56 ) and ( https://github.com/conda-forge/conda-forge-webservices/pull/57 ).