### PR TITLE
Skip linting via commit message

### DIFF
--- a/conda_forge_webservices/linting.py
+++ b/conda_forge_webservices/linting.py
@@ -56,6 +56,18 @@ def compute_lint_message(repo_owner, repo_name, pr_id, ignore_base=False):
             ref_head = repo.refs['pull/{pr}/head'.format(pr=pr_id)]
         sha = str(ref_head.commit.hexsha)
 
+        # Check if the linter is skipped via the commit message.
+        skip_msgs = [
+            "[ci skip]",
+            "[skip ci]",
+            "[lint skip]",
+            "[skip lint]",
+        ]
+        commit_msg = repo.commit(sha).message
+        should_skip = any([msg in commit_msg for msg in skip_msgs])
+        if should_skip:
+            return {}
+
         # Raise an error if the PR is not mergeable.
         if not mergeable:
             message = textwrap.dedent("""

--- a/conda_forge_webservices/tests/linting/test_compute_lint_message.py
+++ b/conda_forge_webservices/tests/linting/test_compute_lint_message.py
@@ -19,6 +19,22 @@ def tmp_directory():
 
 
 class Test_compute_lint_message(unittest.TestCase):
+    def test_skip_ci_recipe(self):
+        lint = compute_lint_message('conda-forge', 'conda-forge-webservices', 58)
+        self.assertFalse(lint)
+
+    def test_skip_lint_recipe(self):
+        lint = compute_lint_message('conda-forge', 'conda-forge-webservices', 59)
+        self.assertFalse(lint)
+
+    def test_ci_skip_recipe(self):
+        lint = compute_lint_message('conda-forge', 'conda-forge-webservices', 65)
+        self.assertFalse(lint)
+
+    def test_lint_skip_recipe(self):
+        lint = compute_lint_message('conda-forge', 'conda-forge-webservices', 66)
+        self.assertFalse(lint)
+
     def test_good_recipe(self):
         expected_message = textwrap.dedent("""
         Hi! This is the friendly automated conda-forge-linting service.

--- a/conda_forge_webservices/tests/linting/test_main.py
+++ b/conda_forge_webservices/tests/linting/test_main.py
@@ -7,6 +7,34 @@ import unittest
 
 
 class TestCLI_recipe_lint(unittest.TestCase):
+    def test_cli_skip_ci(self):
+        child = subprocess.Popen([sys.executable, '-m' 'conda_forge_webservices.linting',
+                                  'conda-forge/conda-forge-webservices', '58', '--enable-commenting'],
+                                 stdout=subprocess.PIPE, env=os.environ)
+        out, _ = child.communicate()
+        self.assertEqual(child.returncode, 0, out)
+
+    def test_cli_skip_lint(self):
+        child = subprocess.Popen([sys.executable, '-m' 'conda_forge_webservices.linting',
+                                  'conda-forge/conda-forge-webservices', '59', '--enable-commenting'],
+                                 stdout=subprocess.PIPE, env=os.environ)
+        out, _ = child.communicate()
+        self.assertEqual(child.returncode, 0, out)
+
+    def test_cli_ci_skip(self):
+        child = subprocess.Popen([sys.executable, '-m' 'conda_forge_webservices.linting',
+                                  'conda-forge/conda-forge-webservices', '65', '--enable-commenting'],
+                                 stdout=subprocess.PIPE, env=os.environ)
+        out, _ = child.communicate()
+        self.assertEqual(child.returncode, 0, out)
+
+    def test_cli_lint_skip(self):
+        child = subprocess.Popen([sys.executable, '-m' 'conda_forge_webservices.linting',
+                                  'conda-forge/conda-forge-webservices', '66', '--enable-commenting'],
+                                 stdout=subprocess.PIPE, env=os.environ)
+        out, _ = child.communicate()
+        self.assertEqual(child.returncode, 0, out)
+
     def test_cli_success_bad(self):
         child = subprocess.Popen([sys.executable, '-m' 'conda_forge_webservices.linting',
                                   'conda-forge/conda-forge-webservices', '17', '--enable-commenting'],

--- a/conda_forge_webservices/tests/linting/test_main.py
+++ b/conda_forge_webservices/tests/linting/test_main.py
@@ -14,27 +14,6 @@ class TestCLI_recipe_lint(unittest.TestCase):
         out, _ = child.communicate()
         self.assertEqual(child.returncode, 0, out)
 
-    def test_cli_skip_lint(self):
-        child = subprocess.Popen([sys.executable, '-m' 'conda_forge_webservices.linting',
-                                  'conda-forge/conda-forge-webservices', '59', '--enable-commenting'],
-                                 stdout=subprocess.PIPE, env=os.environ)
-        out, _ = child.communicate()
-        self.assertEqual(child.returncode, 0, out)
-
-    def test_cli_ci_skip(self):
-        child = subprocess.Popen([sys.executable, '-m' 'conda_forge_webservices.linting',
-                                  'conda-forge/conda-forge-webservices', '65', '--enable-commenting'],
-                                 stdout=subprocess.PIPE, env=os.environ)
-        out, _ = child.communicate()
-        self.assertEqual(child.returncode, 0, out)
-
-    def test_cli_lint_skip(self):
-        child = subprocess.Popen([sys.executable, '-m' 'conda_forge_webservices.linting',
-                                  'conda-forge/conda-forge-webservices', '66', '--enable-commenting'],
-                                 stdout=subprocess.PIPE, env=os.environ)
-        out, _ = child.communicate()
-        self.assertEqual(child.returncode, 0, out)
-
     def test_cli_success_bad(self):
         child = subprocess.Popen([sys.executable, '-m' 'conda_forge_webservices.linting',
                                   'conda-forge/conda-forge-webservices', '17', '--enable-commenting'],


### PR DESCRIPTION
Closes https://github.com/conda-forge/conda-forge-webservices/issues/46

Adds the ability to skip the linter if needed. Useful if the change doesn't affect the linter like maintenance or doc changes at staged-recipes. Could also include re-rendering PRs potentially. Looks for 4 possible things in the head commit of the PR:

* `[ci skip]`
* `[skip ci]`
* `[lint skip]`
* `[skip lint]`

If any of these 4 is found, then it won't lint that PR. Tests are added to cover all of these cases.

Testing All CIs PR: https://github.com/conda-forge/conda-forge-webservices/pull/58 https://github.com/conda-forge/conda-forge-webservices/pull/65
Testing Linter only PR: https://github.com/conda-forge/conda-forge-webservices/pull/59 https://github.com/conda-forge/conda-forge-webservices/pull/66