### PR TITLE
Lint PR merge commit

### DIFF
--- a/conda_forge_webservices/linting.py
+++ b/conda_forge_webservices/linting.py
@@ -39,10 +39,14 @@ def compute_lint_message(repo_owner, repo_name, pr_id):
     with tmp_directory() as tmp_dir:
         repo = Repo.clone_from(remote_repo.clone_url, tmp_dir)
 
-        # Checkout the PR head.
-        repo.remotes.origin.fetch('pull/{pr}/head:pr/{pr}'.format(pr=pr_id))
-        repo.refs['pr/{}'.format(pr_id)].checkout()
-        sha = str(repo.head.object.hexsha)
+        # Retrieve the PR refs.
+        repo.remotes.origin.fetch([
+            'pull/{pr}/head:pull/{pr}/head'.format(pr=pr_id),
+            'pull/{pr}/merge:pull/{pr}/merge'.format(pr=pr_id)
+        ])
+        ref_head = repo.refs['pull/{pr}/head'.format(pr=pr_id)]
+        ref_merge = repo.refs['pull/{pr}/merge'.format(pr=pr_id)]
+        sha = str(ref_head.commit.hexsha)
 
         # Raise an error if the PR is not mergeable.
         if not mergeable:
@@ -63,6 +67,7 @@ def compute_lint_message(repo_owner, repo_name, pr_id):
             return lint_info
 
         # Get the list of recipes and prep for linting.
+        ref_merge.checkout()
         recipes = find_recipes(tmp_dir)
         all_pass = True
         messages = []

--- a/conda_forge_webservices/tests/linting/test_compute_lint_message.py
+++ b/conda_forge_webservices/tests/linting/test_compute_lint_message.py
@@ -31,6 +31,28 @@ class Test_compute_lint_message(unittest.TestCase):
         self.assert_(lint)
         self.assertMultiLineEqual(expected_message, lint['message'])
 
+    def test_ok_recipe_above_good_recipe(self):
+        expected_message = textwrap.dedent("""
+        Hi! This is the friendly automated conda-forge-linting service.
+        
+        I just wanted to let you know that I linted all conda-recipes in your PR (```recipes/good_recipe```, ```recipes/ok_recipe```) and found it was in an excellent condition.
+        
+        """)
+
+        lint = compute_lint_message('conda-forge', 'conda-forge-webservices', 54)
+        self.assertMultiLineEqual(expected_message, lint['message'])
+
+    def test_ok_recipe_beside_good_recipe(self):
+        expected_message = textwrap.dedent("""
+        Hi! This is the friendly automated conda-forge-linting service.
+        
+        I just wanted to let you know that I linted all conda-recipes in your PR (```recipes/good_recipe```, ```recipes/ok_recipe```) and found it was in an excellent condition.
+        
+        """)
+
+        lint = compute_lint_message('conda-forge', 'conda-forge-webservices', 62)
+        self.assertMultiLineEqual(expected_message, lint['message'])
+
     def test_conflict_ok_recipe(self):
         expected_message = textwrap.dedent("""
         Hi! This is the friendly automated conda-forge-linting service.


### PR DESCRIPTION
Switches to linting the merge commit of PRs instead of the head commit. This is inline with what many other CIs are doing (like Travis CI and AppVeyor). The main reason to do this is to ensure we are not getting false positives from the linter. For example, imagine our PR has an error due to some part of the recipe that is unchanged, but the base branch contains a correction to this issue. We don't want this linting error as it is a false positive and will go away with a simple merge into the base branch.

It is possible to do this now as we correctly raise merge conflicts as an error thanks to PR ( https://github.com/conda-forge/conda-forge-webservices/pull/55 ). The functionality presented here is a smaller piece of the functionality already in PR ( https://github.com/conda-forge/conda-forge-webservices/pull/53 ) to optionally ignore recipes from the base branch. A test is provided to ensure we are getting the intended behavior by using PR ( https://github.com/conda-forge/conda-forge-webservices/pull/54 ).