### PR TITLE
TESTING BRANCH: Added a linter skipped commit `[lint skip]`

### DIFF
--- a/recipes/good_recipe/meta.yaml
+++ b/recipes/good_recipe/meta.yaml
@@ -10,7 +10,7 @@ test: {}
 about:
   home: https://github.com/conda-forge/conda-forge-linting-service
   license: BSD 3-clause
-  summary: A test recipe for linting
+  summary: A test recipe not for linting
 
 extra:
   recipe-maintainers:

--- a/recipes/good_recipe/meta.yaml
+++ b/recipes/good_recipe/meta.yaml
@@ -2,6 +2,9 @@ package:
   name: good_recipe
   version: 1
 
+build:
+  number: 0
+
 test: {}
 
 about:

--- a/recipes/good_recipe/meta.yaml
+++ b/recipes/good_recipe/meta.yaml
@@ -1,0 +1,14 @@
+package:
+  name: good_recipe
+  version: 1
+
+test: {}
+
+about:
+  home: https://github.com/conda-forge/conda-forge-linting-service
+  license: BSD 3-clause
+  summary: A test recipe for linting
+
+extra:
+  recipe-maintainers:
+    - pelson


### PR DESCRIPTION
Please unsubscribe from this PR - it is a testing branch and will be noisy.

This adds a commit to the `good_recipe` to skip CI completely. The linter should not run on this.