### PR TITLE
Handle an empty lint

### DIFF
--- a/conda_forge_webservices/linting.py
+++ b/conda_forge_webservices/linting.py
@@ -151,13 +151,14 @@ def set_pr_status(owner, repo_name, lint_info, target_url=None):
 
     user = gh.get_user(owner)
     repo = user.get_repo(repo_name)
-    commit = repo.get_commit(lint_info['sha'])
-    if lint_info['status'] == 'good':
-        commit.create_status("success", description="All recipes are excellent.",
-                             context="conda-forge-linter", target_url=target_url)
-    else:
-        commit.create_status("failure", description="Some recipes need some changes.",
-                             context="conda-forge-linter", target_url=target_url)
+    if lint_info:
+        commit = repo.get_commit(lint_info['sha'])
+        if lint_info['status'] == 'good':
+            commit.create_status("success", description="All recipes are excellent.",
+                                 context="conda-forge-linter", target_url=target_url)
+        else:
+            commit.create_status("failure", description="Some recipes need some changes.",
+                                 context="conda-forge-linter", target_url=target_url)
 
 
 def main():
@@ -173,7 +174,9 @@ def main():
 
     lint_info = compute_lint_message(owner, repo_name, args.pr)
 
-    if args.enable_commenting:
+    if not lint_info:
+        print('Linting was skipped.')
+    elif args.enable_commenting:
         msg = comment_on_pr(owner, repo_name, args.pr, lint_info['message'])
         set_pr_status(owner, repo_name, lint_info, target_url=msg.html_url)
     else:

--- a/conda_forge_webservices/tests/linting/test_compute_lint_message.py
+++ b/conda_forge_webservices/tests/linting/test_compute_lint_message.py
@@ -28,6 +28,7 @@ class Test_compute_lint_message(unittest.TestCase):
         """)
 
         lint = compute_lint_message('conda-forge', 'conda-forge-webservices', 16)
+        self.assert_(lint)
         self.assertMultiLineEqual(expected_message, lint['message'])
 
     def test_conflict_ok_recipe(self):
@@ -41,6 +42,7 @@ class Test_compute_lint_message(unittest.TestCase):
         """)
 
         lint = compute_lint_message('conda-forge', 'conda-forge-webservices', 56)
+        self.assert_(lint)
         self.assertMultiLineEqual(expected_message, lint['message'])
 
     def test_conflict_2_ok_recipe(self):
@@ -54,6 +56,7 @@ class Test_compute_lint_message(unittest.TestCase):
         """)
 
         lint = compute_lint_message('conda-forge', 'conda-forge-webservices', 57)
+        self.assert_(lint)
         self.assertMultiLineEqual(expected_message, lint['message'])
 
     def test_bad_recipe(self):
@@ -76,6 +79,7 @@ class Test_compute_lint_message(unittest.TestCase):
         """)
 
         lint = compute_lint_message('conda-forge', 'conda-forge-webservices', 17)
+        self.assert_(lint)
         self.assertMultiLineEqual(expected_message, lint['message'])
 
     def test_no_recipe(self):
@@ -87,6 +91,7 @@ class Test_compute_lint_message(unittest.TestCase):
         """)
 
         lint = compute_lint_message('conda-forge', 'conda-forge-webservices', 18)
+        self.assert_(lint)
         self.assertMultiLineEqual(expected_message, lint['message'])
 
 

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -76,8 +76,9 @@ class LintingHookHandler(tornado.web.RequestHandler):
             # Only do anything if we are working with conda-forge, and an open PR.
             if is_open and owner == 'conda-forge':
                 lint_info = linting.compute_lint_message(owner, repo_name, pr_id)
-                msg = linting.comment_on_pr(owner, repo_name, pr_id, lint_info['message'])
-                linting.set_pr_status(owner, repo_name, lint_info, target_url=msg.html_url)
+                if lint_info:
+                    msg = linting.comment_on_pr(owner, repo_name, pr_id, lint_info['message'])
+                    linting.set_pr_status(owner, repo_name, lint_info, target_url=msg.html_url)
         else:
             print('Unhandled event "{}".'.format(event))
             self.set_status(404)


### PR DESCRIPTION
Broken out from PR ( https://github.com/conda-forge/conda-forge-webservices/pull/60 ).

There are some cases where we don't know whether there will be a need to lint until we have started to compute the lint. Examples include commit messages with notes to skip ci explicitly and PRs closed during linting. To handle the case of an empty lint, we updated the code and tests to check to make sure the lint did happen before proceeding further. This will help prepare for the possibility of a lint being skipped while in progress.