### PR TITLE
Skip closed PRs

### DIFF
--- a/conda_forge_webservices/tests/linting/test_compute_lint_message.py
+++ b/conda_forge_webservices/tests/linting/test_compute_lint_message.py
@@ -94,6 +94,11 @@ class Test_compute_lint_message(unittest.TestCase):
         self.assert_(lint)
         self.assertMultiLineEqual(expected_message, lint['message'])
 
+    def test_closed_pr(self):
+        lint = compute_lint_message('conda-forge', 'conda-forge-webservices', 52)
+        self.assertFalse(lint)
+        self.assertEqual(lint, {})
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
If a PR turns out to be closed (perhaps it was open and then closed during linting), simply don't lint the PR. Uses PR ( https://github.com/conda-forge/conda-forge-webservices/pull/69 ) as part of its implementation. 