### PR TITLE
WIP: Auto upgrade status page

### DIFF
--- a/conda_forge_webservices/status.py
+++ b/conda_forge_webservices/status.py
@@ -10,8 +10,7 @@ def get_token(token=None):
 
 
 def update(token=None):
-    if token is None:
-        token = os.environ["STATUS_GH_TOKEN"]
+    token = get_token(token=token)
 
     subprocess.check_call([
         "statuspage",

--- a/conda_forge_webservices/status.py
+++ b/conda_forge_webservices/status.py
@@ -47,6 +47,7 @@ def main():
         description="Updates the status page.",
     )
 
+    upgrade(os.environ["STATUS_GH_TOKEN"])
     update(os.environ["STATUS_GH_TOKEN"])
 
 

--- a/conda_forge_webservices/status.py
+++ b/conda_forge_webservices/status.py
@@ -2,6 +2,13 @@ import os
 import subprocess
 
 
+def get_token(token=None):
+    if token is None:
+        token = os.environ["STATUS_GH_TOKEN"]
+
+    return token
+
+
 def update(token=None):
     if token is None:
         token = os.environ["STATUS_GH_TOKEN"]

--- a/conda_forge_webservices/status.py
+++ b/conda_forge_webservices/status.py
@@ -9,6 +9,21 @@ def get_token(token=None):
     return token
 
 
+def upgrade(token=None):
+    token = get_token(token=token)
+
+    subprocess.check_call([
+        "statuspage",
+        "upgrade",
+        "--org",
+        "conda-forge",
+        "--name",
+        "status",
+        "--token",
+        token
+    ])
+
+
 def update(token=None):
     token = get_token(token=token)
 


### PR DESCRIPTION
Periodically new releases of [`statuspage`]( https://github.com/jayfk/statuspage ) come out. To make use of them, we need to remember to run `statuspage upgrade`. However, it is easy to forget as I just did. It would be better if we could leverage our existing automation to do this upgrade for us. This change does exactly that.

Here we run `statuspage upgrade` on every change right before running `statuspage update`. This has a few issues ATM though.

First unlike `statuspage update`, `statuspage upgrade` will push commits even if no files are changed. To fix that we will need something like PR ( https://github.com/jayfk/statuspage/pull/107 ). The change seems to work ok from local testing. However, it still needs some work to get the tests passing.

Second, even with that change, `statuspage upgrade` will push a commit before `statuspage update` does. So it is possible that we can get into race conditions were the upgrade triggers a second job. However, this will be very rare as it will only occur when a new release of `statuspage` comes out and our status page needs non-trivial changes from it. Also it is likely the first job completes the upgrade and update before the second one has gotten a chance. Therefore it even though there is an extra job it should not make any changes or have issues. So, even though this does present a problem, it is infrequent enough not to deserve too much consideration.