### PR TITLE
Temporarily pin `conda` to `4.1.x`

### DIFF
--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -14,7 +14,7 @@ env_dir=$(cd "$3/" && pwd)
 
 wget -q https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 bash miniconda.sh -b -p $HOME/.conda
-$HOME/.conda/bin/conda install -c conda-forge --yes conda-smithy python=3 tornado pygithub statuspage
+$HOME/.conda/bin/conda install -c conda-forge --yes conda=4.1 conda-smithy python=3 tornado pygithub statuspage
 
 cp -rf $HOME/.conda $STORAGE_LOCN/.conda
 


### PR DESCRIPTION
Temporarily pin `conda` to `4.1.x` so that `conda-smithy` works.

Working on a fix in PR ( https://github.com/conda-forge/conda-smithy/pull/394 ). Can revert after we have a patch release with a fix.