### PR TITLE
Temporarily pin `conda` to `4.1.x`

### DIFF
--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -1,3 +1,4 @@
+conda >=4.1,<4.2
 conda-smithy
 tornado
 pygithub


### PR DESCRIPTION
Temporarily pin `conda` to `4.1.x` on CI so that `conda-smithy` works.

Working on a fix in PR ( https://github.com/conda-forge/conda-smithy/pull/394 ). Can revert after we have a patch release with a fix.