### PR TITLE
TST: Extra newline in bad recipe

### DIFF
--- a/conda_forge_webservices/tests/linting/test_compute_lint_message.py
+++ b/conda_forge_webservices/tests/linting/test_compute_lint_message.py
@@ -136,6 +136,7 @@ class Test_compute_lint_message(unittest.TestCase):
          * The recipe could do with some maintainers listed in the `extra/recipe-maintainers` section.
          * The recipe must have some tests.
          * The recipe must have a `build/number` section.
+         * There should be one empty line at the end of the file.
         """)
 
         lint = compute_lint_message('conda-forge', 'conda-forge-webservices', 17)


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-forge-webservices/issues/83

Fix unit test to take into account extra newline in bad recipe as part of the lint. Please see PR ( https://github.com/conda-forge/conda-smithy/pull/371 ) for details.