### PR TITLE
Unpin conda

### DIFF
--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -14,7 +14,7 @@ env_dir=$(cd "$3/" && pwd)
 
 wget -q https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 bash miniconda.sh -b -p $HOME/.conda
-$HOME/.conda/bin/conda install -c conda-forge --yes conda=4.1 conda-smithy python=3 tornado pygithub statuspage
+$HOME/.conda/bin/conda install -c conda-forge --yes conda-smithy python=3 tornado pygithub statuspage
 
 cp -rf $HOME/.conda $STORAGE_LOCN/.conda
 

--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -1,4 +1,3 @@
-conda >=4.1,<4.2
 conda-smithy
 tornado
 pygithub


### PR DESCRIPTION
Reverts https://github.com/conda-forge/conda-forge-webservices/pull/84
Reverts https://github.com/conda-forge/conda-forge-webservices/pull/85

Requires a new version of `conda-smithy` be released with PR ( https://github.com/conda-forge/conda-smithy/pull/394 ) included before proceeding forward.

Unpins `conda` during feedstock conversion so as to allow the latest version of `conda` be used.