### PR TITLE
Force Python 3.5

### DIFF
--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -12,9 +12,9 @@ env_dir=$(cd "$3/" && pwd)
 
 # -------
 
-wget -q https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+wget -q https://repo.continuum.io/miniconda/Miniconda3-4.2.12-Linux-x86_64.sh -O miniconda.sh
 bash miniconda.sh -b -p $HOME/.conda
-$HOME/.conda/bin/conda install -c conda-forge --yes conda-smithy python=3 tornado pygithub statuspage
+$HOME/.conda/bin/conda install -c conda-forge --yes conda-smithy python=3.5 tornado pygithub statuspage
 
 cp -rf $HOME/.conda $STORAGE_LOCN/.conda
 


### PR DESCRIPTION
As it appears some dependencies are not correctly satisfied on Python 3.6 and they are causing us some issues with getting proper re-renderings, switch to the latest Miniconda using Python 3.5 and pin the Python, during upgrade, to 3.5. At least on Python 3.5, we are confident that we have all the dependencies needed to update the status page and such. We can always revert this pinning once the underlying issues are fixed.