### PR TITLE
Add a webservice for updating feedstocks

### DIFF
--- a/conda_forge_webservices/update_feedstocks.py
+++ b/conda_forge_webservices/update_feedstocks.py
@@ -1,0 +1,60 @@
+import git
+import github
+import os
+from .utils import tmp_directory
+
+
+def update_feedstock(org_name, repo_name):
+    if not repo_name.endswith("-feedstock"):
+        return
+
+    gh = github.Github(os.environ['GH_TOKEN'])
+
+    gh.get_repo("{}/{}".format(org_name, repo_name))
+    name = repo_name[:-len("-feedstock")]
+
+    with tmp_directory() as tmp_dir:
+        feedstocks_url = (
+            "https://{}@github.com/conda-forge/feedstocks.git"
+            "".format(os.environ["GH_TOKEN"])
+        )
+        feedstocks_repo = git.Repo.clone_from(
+            feedstocks_url,
+            tmp_dir
+        )
+
+        # Get the submodule
+        try:
+            feedstock_submodule = feedstocks_repo.submodule(name)
+        except ValueError:
+            feedstock_submodule = feedstocks_repo.create_submodule(
+                name=name,
+                path=os.path.join("feedstocks", name),
+                url=repo_gh.clone_url,
+                branch="master"
+            )
+
+        # Update the feedstocks submodule
+        feedstock_submodule.update(init=True, recursive=False, force=True)
+        feedstock_submodule.branch.checkout(force=True)
+        feedstock_submodule.update(
+            init=True,
+            recursive=False,
+            force=True,
+            to_latest_revision=True
+        )
+
+        # Submit changes
+        if feedstocks_repo.is_dirty():
+            feedstocks_repo.index.commit("Updated feedstocks submodules. [ci skip]")
+            feedstocks_repo.remote().pull(rebase=True)
+            feedstocks_repo.remote().push()
+
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('org')
+    parser.add_argument('repo')
+    args = parser.parse_args()
+    update_team(args.org, args.repo)

--- a/conda_forge_webservices/update_feedstocks.py
+++ b/conda_forge_webservices/update_feedstocks.py
@@ -24,15 +24,16 @@ def update_feedstock(org_name, repo_name):
         )
 
         # Get the submodule
-        try:
-            feedstock_submodule = feedstocks_repo.submodule(name)
-        except ValueError:
-            feedstock_submodule = feedstocks_repo.create_submodule(
-                name=name,
-                path=os.path.join("feedstocks", name),
-                url=repo_gh.clone_url,
-                branch="master"
-            )
+        feedstock_submodule = feedstocks_repo.create_submodule(
+            name=name,
+            path=os.path.join("feedstocks", name),
+            url=repo_gh.clone_url,
+            branch="master"
+        )
+        # Hack needed if the submodule already exists.
+        # Borrows the fix accepted upstream.
+        # PR: https://github.com/gitpython-developers/GitPython/pull/679
+        feedstock_submodule._name = name
 
         # Update the feedstocks submodule
         feedstock_submodule.update(init=True, recursive=False, force=True)


### PR DESCRIPTION
Closes https://github.com/conda-forge/conda-forge-webservices/issues/63

Provides an asynchronous webservice, which listens to push events on the feedstocks. When a push event occurs on a feedstock, the webservice updates the commit that the appropriate submodule points to in the feedstocks repo. This way it is a lot easier to handle updates of various feedstocks throughout the organization on demand instead of running a massive batch script over all of the feedstocks (even when most haven't changed).

Note: This is adapted from the [batch feedstock update script]( https://github.com/conda-forge/conda-forge.github.io/blob/b44a39dbcd919222dee6cae3d7ee82bdf44986ec/scripts/update_feedstocks_submodules.py ).

cc @isuruf