### PR TITLE
Commit to feedstocks as @conda-forge-coordinator

### DIFF
--- a/conda_forge_webservices/update_feedstocks.py
+++ b/conda_forge_webservices/update_feedstocks.py
@@ -47,7 +47,14 @@ def update_feedstock(org_name, repo_name):
 
         # Submit changes
         if feedstocks_repo.is_dirty():
-            feedstocks_repo.index.commit("Updated feedstocks submodules. [ci skip]")
+            author = git.Actor(
+                "conda-forge-coordinator", "conda.forge.coordinator@gmail.com"
+            )
+            feedstocks_repo.index.commit(
+                "Updated feedstocks submodules. [ci skip]",
+                author=author,
+                committer=author
+            )
             feedstocks_repo.remote().pull(rebase=True)
             feedstocks_repo.remote().push()
 


### PR DESCRIPTION
Follow up to PR ( https://github.com/conda-forge/conda-forge-webservices/pull/115 ).

This is how we were committing to the feedstocks repo before. However we may want to switch out the GitHub token here to match this user. Will look into it.