### PR TITLE
Stage all changes to feedstocks

### DIFF
--- a/conda_forge_webservices/update_feedstocks.py
+++ b/conda_forge_webservices/update_feedstocks.py
@@ -50,6 +50,7 @@ def update_feedstock(org_name, repo_name):
             author = git.Actor(
                 "conda-forge-coordinator", "conda.forge.coordinator@gmail.com"
             )
+            feedstocks_repo.git.add(update=True)
             feedstocks_repo.index.commit(
                 "Updated feedstocks submodules. [ci skip]",
                 author=author,


### PR DESCRIPTION
Follow up to PR ( https://github.com/conda-forge/conda-forge-webservices/pull/115 ).

As the change to the submodules are not staged automatically, just stage all changes to the feedstocks repo.