### PR TITLE
Use a different token for feedstock updates

### DIFF
--- a/conda_forge_webservices/update_feedstocks.py
+++ b/conda_forge_webservices/update_feedstocks.py
@@ -8,7 +8,7 @@ def update_feedstock(org_name, repo_name):
     if not repo_name.endswith("-feedstock"):
         return
 
-    gh = github.Github(os.environ['GH_TOKEN'])
+    gh = github.Github(os.environ['FEEDSTOCKS_GH_TOKEN'])
 
     repo_gh = gh.get_repo("{}/{}".format(org_name, repo_name))
     name = repo_name[:-len("-feedstock")]


### PR DESCRIPTION
Partially addresses issue ( https://github.com/conda-forge/conda-forge-webservices/issues/122 ).

Instead of using the token that is associated with the linter use a token associated with the coordinator. This matches more closely to the behavior that was present when feedstock updates were performed by the webpage repo's CI. Should help mitigate rate limiting for the linter and other services due to feedstock updates.

cc @isuruf