### PR TITLE
Use a different token for feedstock updates (pt. 2)

### DIFF
--- a/conda_forge_webservices/update_feedstocks.py
+++ b/conda_forge_webservices/update_feedstocks.py
@@ -8,7 +8,7 @@ def update_feedstock(org_name, repo_name):
     if not repo_name.endswith("-feedstock"):
         return
 
-    gh = github.Github(os.environ['GH_TOKEN'])
+    gh = github.Github(os.environ['FEEDSTOCKS_GH_TOKEN'])
 
     repo_gh = gh.get_repo("{}/{}".format(org_name, repo_name))
     name = repo_name[:-len("-feedstock")]


### PR DESCRIPTION
Missed one in PR ( https://github.com/conda-forge/conda-forge-webservices/pull/129 ). This fixes it.