### PR TITLE
Use a different token for feedstock updates (pt. 3)

### DIFF
--- a/conda_forge_webservices/update_feedstocks.py
+++ b/conda_forge_webservices/update_feedstocks.py
@@ -8,7 +8,7 @@ def update_feedstock(org_name, repo_name):
     if not repo_name.endswith("-feedstock"):
         return
 
-    gh = github.Github(os.environ['GH_TOKEN'])
+    gh = github.Github(os.environ['FEEDSTOCKS_GH_TOKEN'])
 
     repo_gh = gh.get_repo("{}/{}".format(org_name, repo_name))
     name = repo_name[:-len("-feedstock")]
@@ -16,7 +16,7 @@ def update_feedstock(org_name, repo_name):
     with tmp_directory() as tmp_dir:
         feedstocks_url = (
             "https://{}@github.com/conda-forge/feedstocks.git"
-            "".format(os.environ["GH_TOKEN"])
+            "".format(os.environ["FEEDSTOCKS_GH_TOKEN"])
         )
         feedstocks_repo = git.Repo.clone_from(
             feedstocks_url,


### PR DESCRIPTION
Still missing one after PR ( https://github.com/conda-forge/conda-forge-webservices/pull/130 ). 😱 This fixes it.