### PR TITLE
Fix feedstock update CLI

### DIFF
--- a/conda_forge_webservices/update_feedstocks.py
+++ b/conda_forge_webservices/update_feedstocks.py
@@ -66,4 +66,4 @@ if __name__ == '__main__':
     parser.add_argument('org')
     parser.add_argument('repo')
     args = parser.parse_args()
-    update_team(args.org, args.repo)
+    update_feedstock(args.org, args.repo)


### PR DESCRIPTION
Make sure to call `update_feedstock` not `update_team` in the CLI.