### PR TITLE
Update feedstocks listing on webpage update

### DIFF
--- a/conda_forge_webservices/feedstocks_service.py
+++ b/conda_forge_webservices/feedstocks_service.py
@@ -7,7 +7,7 @@ from .utils import tmp_directory
 
 
 def handle_feedstock_event(org_name, repo_name):
-    if repo_name == "staged-recipes":
+    if repo_name in ["conda-forge.github.io", "staged-recipes"]:
         update_listing()
     elif repo_name.endswith("-feedstock"):
         update_feedstock(org_name, repo_name)


### PR DESCRIPTION
If the webpage repo is updated, also update the feedstocks listing. This is done because the feedstocks listing template could be updated in the webpage repo, which could result in changes to the feedstocks listing. Hence we should try regenerating the feedstocks listing in this case so as to make any needed changes to the format.