### PR TITLE
Use `git add -A` to update feedstocks

### DIFF
--- a/conda_forge_webservices/feedstocks_service.py
+++ b/conda_forge_webservices/feedstocks_service.py
@@ -124,7 +124,7 @@ def update_feedstock(org_name, repo_name):
             author = git.Actor(
                 "conda-forge-coordinator", "conda.forge.coordinator@gmail.com"
             )
-            feedstocks_repo.git.add(update=True)
+            feedstocks_repo.git.add(all=True)
             feedstocks_repo.index.commit(
                 "Updated the {0} feedstock.".format(name),
                 author=author,


### PR DESCRIPTION
Was previously using `git add -u`. However that might miss some things that need to be added, which `git add -A` should catch (e.g. previously untracked changes).