### PR TITLE
Stage changes and commit if the index is dirty

### DIFF
--- a/conda_forge_webservices/feedstocks_service.py
+++ b/conda_forge_webservices/feedstocks_service.py
@@ -65,16 +65,17 @@ def update_listing():
         with open(nojekyll, 'w') as fh:
             pass
 
-        if feedstocks_page_repo.is_dirty(untracked_files=True):
+        feedstocks_page_repo.index.add([os.path.relpath(
+            feedstocks_html, feedstocks_page_dir
+        )])
+        feedstocks_page_repo.index.add([os.path.relpath(
+            nojekyll, feedstocks_page_dir
+        )])
+
+        if feedstocks_page_repo.is_dirty(working_tree=False, untracked_files=True):
             author = git.Actor(
                 "conda-forge-coordinator", "conda.forge.coordinator@gmail.com"
             )
-            feedstocks_page_repo.index.add([os.path.relpath(
-                feedstocks_html, feedstocks_page_dir
-            )])
-            feedstocks_page_repo.index.add([os.path.relpath(
-                nojekyll, feedstocks_page_dir
-            )])
             feedstocks_page_repo.index.commit(
                 "Updated the feedstock listing.",
                 author=author,
@@ -118,13 +119,13 @@ def update_feedstock(org_name, repo_name):
             force=True,
             to_latest_revision=True
         )
+        feedstocks_repo.git.add([".gitmodules", feedstock_submodule.path])
 
         # Submit changes
-        if feedstocks_repo.is_dirty(untracked_files=True):
+        if feedstocks_page_repo.is_dirty(working_tree=False, untracked_files=True):
             author = git.Actor(
                 "conda-forge-coordinator", "conda.forge.coordinator@gmail.com"
             )
-            feedstocks_repo.git.add(update=True)
             feedstocks_repo.index.commit(
                 "Updated the {0} feedstock.".format(name),
                 author=author,


### PR DESCRIPTION
Make sure to stage changes first and only create a commit if there are changes staged in the index (not if there are ones in the working tree). It is possible to have changes that can't easily be staged if there are formatting issues (e.g. `.gitattributes` related changes) that need to be addressed in a feedstock for instance. This provides some extra assurance against creating empty commits.