### PR TITLE
Wait up to 1 second before linting

### DIFF
--- a/conda_forge_webservices/linting.py
+++ b/conda_forge_webservices/linting.py
@@ -22,7 +22,7 @@ def compute_lint_message(repo_owner, repo_name, pr_id, ignore_base=False):
 
     mergeable = None
     while mergeable is None:
-        time.sleep(0.1)
+        time.sleep(1.0)
         pull_request = remote_repo.get_pull(pr_id)
         if pull_request.state != "open":
             return {}


### PR DESCRIPTION
Closes https://github.com/conda-forge/conda-forge-webservices/issues/30
Closes https://github.com/conda-forge/conda-forge-webservices/issues/43
Closes https://github.com/conda-forge/conda-forge-webservices/issues/126

Appears the webhooks for PRs fire a bit in advance of when the merge ref shows up. While this was solved by sleeping for 0.1 seconds at a time, it appears that is no longer enough. This sleeps for 1 second at a time in the hope that will be enough time for the merge ref to show up.

cc @isuruf