### PR TITLE
make bot commands more flexible / search more precise

### DIFF
--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -48,11 +48,12 @@ def pr_detailed_comment(org_name, repo_name, pr_owner, pr_repo, pr_branch, pr_nu
             pr_owner, pr_repo)
         repo = Repo.clone_from(repo_url, feedstock_dir, branch=pr_branch)
 
-        if ADD_NOARCH_MSG.search(comment):
-            make_noarch(repo)
-            rerender(repo, pr_num)
-        if RERENDER_MSG.search(comment):
-            rerender(repo, pr_num)
+        if not is_staged_recipes:
+            if ADD_NOARCH_MSG.search(comment):
+                make_noarch(repo)
+                rerender(repo, pr_num)
+            if RERENDER_MSG.search(comment):
+                rerender(repo, pr_num)
         if LINT_MSG.search(comment):
             relint(org_name, repo_name, pr_num)
 

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -13,12 +13,12 @@ import textwrap
 
 
 pre = r"@conda-forge-(admin|linter)\s*[,:]?\s*"
-COMMAND_PREFIX = re.compile(pre)
-ADD_NOARCH_MSG = re.compile(pre + "please (add|make) `?noarch:? python`?")
-RERENDER_MSG = re.compile(pre + "please re-?render")
-LINT_MSG = re.compile(pre + "please lint")
-UPDATE_TEAM_MSG = re.compile(pre + "please update team")
-UPDATE_CIRCLECI_KEY_MSG = re.compile(pre + "please update circle")
+COMMAND_PREFIX = re.compile(pre, re.I)
+ADD_NOARCH_MSG = re.compile(pre + "please (add|make) `?noarch:? python`?", re.I)
+RERENDER_MSG = re.compile(pre + "please re-?render", re.I)
+LINT_MSG = re.compile(pre + "please (re-?)?lint", re.I)
+UPDATE_TEAM_MSG = re.compile(pre + "please (update|refresh) (the )?team", re.I)
+UPDATE_CIRCLECI_KEY_MSG = re.compile(pre + "please (update|refresh) (the )?circle", re.I)
 
 
 def pr_comment(org_name, repo_name, issue_num, comment):
@@ -34,8 +34,6 @@ def pr_detailed_comment(org_name, repo_name, pr_owner, pr_repo, pr_branch, pr_nu
     is_staged_recipes = (repo_name == "staged-recipes")
     if not (repo_name.endswith("-feedstock") or is_staged_recipes):
         return
-
-    comment = comment.lower()
 
     pr_commands = [LINT_MSG]
     if not is_staged_recipes:
@@ -65,8 +63,6 @@ def issue_comment(org_name, repo_name, issue_num, title, comment):
     if not repo_name.endswith("-feedstock"):
         return
 
-    comment = comment.lower()
-    title = title.lower()
     text = comment + title
 
     issue_commands = [UPDATE_TEAM_MSG, ADD_NOARCH_MSG, UPDATE_CIRCLECI_KEY_MSG]

--- a/conda_forge_webservices/tests/test_commands.py
+++ b/conda_forge_webservices/tests/test_commands.py
@@ -1,0 +1,162 @@
+import os
+import unittest
+
+try:
+    import unittest.mock as mock
+except ImportError:
+    import mock
+
+from conda_forge_webservices.commands import (
+    pr_detailed_comment as _pr_detailed_comment,
+    issue_comment as _issue_comment)
+
+
+def pr_detailed_comment(comment, org_name='conda-forge',
+                        repo_name='python-feedstock', pr_repo=None,
+                        pr_owner='some-user', pr_branch='master', pr_num=1):
+    if pr_repo is None:
+        pr_repo = repo_name
+    return _pr_detailed_comment(org_name, repo_name,
+                                pr_owner, pr_repo, pr_branch, pr_num, comment)
+
+
+def issue_comment(title, comment, issue_num=1,
+                  org_name='conda-forge', repo_name='python-feedstock'):
+    return _issue_comment(org_name, repo_name, issue_num, title, comment)
+
+
+class TestCommands(unittest.TestCase):
+    def setUp(self):
+        if 'GH_TOKEN' not in os.environ:
+            os.environ['GH_TOKEN'] = 'fake'  # github access is mocked anyway
+            self.kill_token = True
+        else:
+            self.kill_token = False
+
+    def tearDown(self):
+        if self.kill_token:
+            del os.environ['GH_TOKEN']
+
+    @mock.patch('conda_forge_webservices.commands.rerender')
+    @mock.patch('conda_forge_webservices.commands.make_noarch')
+    @mock.patch('conda_forge_webservices.commands.relint')
+    @mock.patch('conda_forge_webservices.commands.update_team')
+    @mock.patch('conda_forge_webservices.commands.update_circle')
+    @mock.patch('conda_forge_webservices.commands.tmp_directory')
+    @mock.patch('github.Github')
+    @mock.patch('conda_forge_webservices.commands.Repo')
+    def test_pr_commands(self, repo, gh, tmp_directory, update_circle,
+                         update_team, relint, make_noarch, rerender):
+        tmp_directory.return_value.__enter__.return_value = '/tmp'
+
+        commands = [
+            (rerender, False, [
+                '@conda-forge-admin, please rerender',
+                '@conda-forge-admin, please re-render',
+                '@conda-forge-admin: PLEASE RERENDER',
+                'something something. @conda-forge-admin: please re-render',
+             ], [
+                '@conda-forge admin is pretty cool. please rerender for me?',
+                '@conda-forge-admin, go ahead and rerender for me',
+                'please re-render, @conda-forge-admin',
+                '@conda-forge-linter, please lint',
+             ]),
+            (make_noarch, False, [
+                '@conda-forge-admin, please add noarch python',
+                '@conda-forge-linter, please lint, and @conda-forge-admin, please make `noarch: python`',
+                '@CONDA-FORGE-ADMIN please add `noarch python`',
+                'hey @conda-forge-admin : please make noarch: python',
+             ], [
+                '@conda-forge-linter, please lint',
+                'sure wish @conda-forge-admin would please add noarch python',
+             ]),
+            (relint, True, [
+                '@conda-forge-admin, please lint',
+                '@CONDA-FORGE-LINTER, please relint',
+                'hey @conda-forge-linter please re-lint!',
+             ], [
+                '@conda-forge-admin should probably lint again',
+             ]),
+        ]
+
+        for command, on_sr, should, should_not in commands:
+            for msg in should:
+                command.reset_mock()
+                print(msg, end=' ' * 30 + '\r')
+                pr_detailed_comment(msg)
+                command.assert_called()
+
+                command.reset_mock()
+                print(msg, end=' ' * 30 + '\r')
+                pr_detailed_comment(msg, repo_name='staged-recipes')
+                if on_sr:
+                    command.assert_called()
+                else:
+                    command.assert_not_called()
+
+            for msg in should_not:
+                command.reset_mock()
+                print(msg, end=' ' * 30 + '\r')
+                pr_detailed_comment(msg)
+                command.assert_not_called()
+
+    @mock.patch('conda_forge_webservices.commands.rerender')
+    @mock.patch('conda_forge_webservices.commands.make_noarch')
+    @mock.patch('conda_forge_webservices.commands.relint')
+    @mock.patch('conda_forge_webservices.commands.update_team')
+    @mock.patch('conda_forge_webservices.commands.update_circle')
+    @mock.patch('conda_forge_webservices.commands.tmp_directory')
+    @mock.patch('github.Github')
+    @mock.patch('conda_forge_webservices.commands.Repo')
+    def test_issue_commands(self, repo, gh, tmp_directory, update_circle,
+                            update_team, relint, make_noarch, rerender):
+        tmp_directory.return_value.__enter__.return_value = '/tmp'
+
+        commands = [
+            (make_noarch, [
+                '@conda-forge-admin, please add noarch python',
+                '@conda-forge-admin, please make `noarch: python`',
+                '@conda-forge-admin please add `noarch python`',
+                'hey @conda-forge-admin : please make noarch: python',
+             ], [
+                '@conda-forge-linter, please lint',
+                'sure wish @conda-forge-admin would please add noarch python',
+             ]),
+            (update_team, [
+                '@conda-forge-admin: please update team',
+                '@conda-forge-admin, please update the team',
+                '@conda-forge-admin, please refresh team',
+             ], [
+                '@conda-forge-admin please make noarch: python',
+                '@conda-forge-linter, please lint. and can someone refresh the team?',
+             ]),
+            (update_circle, [
+                '@conda-forge-admin, please update circle',
+                'hey @conda-forge-admin, PLEASE update circle',
+                '@conda-forge-admin: please refresh the circle key',
+             ], [
+                '@conda-forge-admin, please lint',
+             ]),
+        ]
+
+        for command, should, should_not in commands:
+            for msg in should:
+                command.reset_mock()
+                print(msg, end=' ' * 30 + '\r')
+                issue_comment("hi", msg)
+                command.assert_called()
+
+                command.reset_mock()
+                print(msg, end=' ' * 30 + '\r')
+                issue_comment("hi", msg, repo_name='staged-recipes')
+                command.assert_not_called()
+
+            for msg in should_not:
+                command.reset_mock()
+                print(msg, end=' ' * 30 + '\r')
+                issue_comment("hi", msg)
+                command.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I never remember whether the command is "please rerender" or "please re-render"; this change makes both work. It also makes "please add `noarch: python`", "please make noarch python", etc valid too in addition to just "please add noarch: python".

While I was making that change, I realized that the current check was a little unintuitive. For example, if I tagged conda-forge-admin here, then it would actually add noarch (if this were a feedstock) because I said the command above (completely separated from the tag). That's not incredibly likely to happen, but still, this change stops that: you now have to tag the bot, optionally add a comma/colon/whitespace, then immediately say the command.

(I didn't add tests for these, since there weren't any for the commands in the first place.)