### PR TITLE
Handle force push in a feedstock

### DIFF
--- a/conda_forge_webservices/feedstocks_service.py
+++ b/conda_forge_webservices/feedstocks_service.py
@@ -107,8 +107,6 @@ def update_feedstock(org_name, repo_name):
         )
 
         # Update the feedstocks submodule
-        feedstock_submodule.update(init=True, recursive=False, force=True)
-        feedstock_submodule.branch.checkout(force=True)
         feedstock_submodule.update(
             init=True,
             recursive=False,

--- a/conda_forge_webservices/feedstocks_service.py
+++ b/conda_forge_webservices/feedstocks_service.py
@@ -105,10 +105,6 @@ def update_feedstock(org_name, repo_name):
             url="https://github.com/{0}/{1}.git".format(org_name, repo_name),
             branch="master"
         )
-        # Hack needed if the submodule already exists.
-        # Borrows the fix accepted upstream.
-        # PR: https://github.com/gitpython-developers/GitPython/pull/679
-        feedstock_submodule._name = name
 
         # Update the feedstocks submodule
         feedstock_submodule.update(init=True, recursive=False, force=True)


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-forge-webservices/issues/139
Fixes https://github.com/conda-forge/conda-forge-webservices/issues/172

Adjusts the `feedstocks` update webservice to handle force pushes in a feedstock. Checked to make sure it still handles all the other cases (e.g. adding a new feedstock and handling a non-force pushed feedstock). Also drops a hack that is no longer needed for GitPython 2.1.8+.