### PR TITLE
use newer versions of conda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
 
 install:
  - export CONDA_BASE=http://repo.continuum.io/miniconda/Miniconda3
- - wget ${CONDA_BASE}-4.3.30-Linux-x86_64.sh -O miniconda.sh;
+ - wget ${CONDA_BASE}-4.4.10-Linux-x86_64.sh -O miniconda.sh;
  - bash miniconda.sh -b -p $HOME/miniconda
  - export PATH="$HOME/miniconda/bin:$PATH"
  - conda config --set show_channel_urls True

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,11 @@ install:
  - export CONDA_BASE=http://repo.continuum.io/miniconda/Miniconda3
  - wget ${CONDA_BASE}-4.4.10-Linux-x86_64.sh -O miniconda.sh;
  - bash miniconda.sh -b -p $HOME/miniconda
- - export PATH="$HOME/miniconda/bin:$PATH"
+ - source "$HOME/miniconda/etc/profile.d/conda.sh"
+ - conda activate
  - conda config --set show_channel_urls True
  - conda config --add channels conda-forge
+ - conda update --yes conda
  - conda install --yes --quiet python=${python} --file conda-requirements.txt
  - mkdir -p ~/.conda-smithy/ && echo $GH_TOKEN > ~/.conda-smithy/github.token
  - python setup.py install

--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -21,9 +21,11 @@ export "CIRCLE_TOKEN=$(cat $env_dir/CIRCLE_TOKEN)"
 
 wget -q https://repo.continuum.io/miniconda/Miniconda3-4.4.10-Linux-x86_64.sh -O miniconda.sh
 bash miniconda.sh -b -p $HOME/.conda
-$HOME/.conda/bin/conda update conda --yes
-$HOME/.conda/bin/conda install -c conda-forge --yes conda-smithy conda-forge-pinning conda=4.5 python=3.6 tornado pygithub git statuspage
-$HOME/.conda/bin/conda clean --all --yes
+source $HOME/.conda/etc/profile.d/conda.sh
+conda activate
+conda update conda --yes
+conda install -c conda-forge --yes conda-smithy conda-forge-pinning conda=4.5 python=3.6 tornado pygithub git statuspage
+conda clean --all --yes
 
 mkdir -p "${STORAGE_LOCN}/.conda-smithy"
 ln -s "${STORAGE_LOCN}/.conda-smithy" "${HOME}/.conda-smithy"
@@ -34,7 +36,7 @@ cp -rf $HOME/.conda $STORAGE_LOCN/.conda
 
 mkdir -p $build/.profile.d
 cat <<-'EOF' > $build/.profile.d/conda.sh
-    # append to path variable
-    export PATH=$HOME/.conda/bin:$PATH
+    source $HOME/.conda/etc/profile.d/conda.sh
+    conda activate
 
 EOF

--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -19,10 +19,10 @@ export "CIRCLE_TOKEN=$(cat $env_dir/CIRCLE_TOKEN)"
 
 # -------
 
-wget -q https://repo.continuum.io/miniconda/Miniconda3-4.3.30-Linux-x86_64.sh -O miniconda.sh
+wget -q https://repo.continuum.io/miniconda/Miniconda3-4.4.10-Linux-x86_64.sh -O miniconda.sh
 bash miniconda.sh -b -p $HOME/.conda
 $HOME/.conda/bin/conda update conda --yes
-$HOME/.conda/bin/conda install -c conda-forge --yes conda-smithy conda=4.3 python=3.6 tornado pygithub git statuspage
+$HOME/.conda/bin/conda install -c conda-forge --yes conda-smithy conda=4.5 python=3.6 tornado pygithub git statuspage
 $HOME/.conda/bin/conda clean --all --yes
 
 mkdir -p "${STORAGE_LOCN}/.conda-smithy"

--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -22,7 +22,7 @@ export "CIRCLE_TOKEN=$(cat $env_dir/CIRCLE_TOKEN)"
 wget -q https://repo.continuum.io/miniconda/Miniconda3-4.4.10-Linux-x86_64.sh -O miniconda.sh
 bash miniconda.sh -b -p $HOME/.conda
 $HOME/.conda/bin/conda update conda --yes
-$HOME/.conda/bin/conda install -c conda-forge --yes conda-smithy conda=4.5 python=3.6 tornado pygithub git statuspage
+$HOME/.conda/bin/conda install -c conda-forge --yes conda-smithy conda-forge-pinning conda=4.5 python=3.6 tornado pygithub git statuspage
 $HOME/.conda/bin/conda clean --all --yes
 
 mkdir -p "${STORAGE_LOCN}/.conda-smithy"

--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -1,4 +1,4 @@
-conda-smithy>=2.4
+conda-smithy>=3
 tornado
 pygithub
 nose

--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -1,4 +1,5 @@
 conda-smithy>=3
+conda-forge-pinning
 tornado
 pygithub
 nose


### PR DESCRIPTION
I don't think this will actually change anything. But might as well update the version of `conda` to 4.5 instead of 4.3, and also verify we have `conda-smithy >=3` rather than just `>=2.4` – just to make sure that no weird constraints end up with us using an old `conda-smithy`.