### PR TITLE
Comment about no re-rendering on no change

### DIFF
--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -133,7 +133,7 @@ def issue_comment(org_name, repo_name, issue_num, title, comment):
 def rerender(repo, org_name, repo_name, pr_num):
     curr_head = repo.active_branch.commit
     subprocess.call(["conda", "smithy", "rerender", "-c", "auto"], cwd=repo.working_dir)
-    if repo.active_branch.commit != curr_head:
+    if repo.active_branch.commit == curr_head:
         # conda-smithy didn't do anything
         message = textwrap.dedent("""
                 Hi! This is the friendly automated conda-forge-webservice.


### PR DESCRIPTION
Follow-up to PR ( https://github.com/conda-forge/conda-forge-webservices/pull/186 )

Appears we had the wrong comparison here (`!=` instead of `==`). We want `==` to check if the commit is the same before and after. Thus meaning the re-rendering was a no-op. Hence the need for mentioning that nothing changed.

cc @dougalsutherland