### PR TITLE
Prefer the conda-forge channel

### DIFF
--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -16,8 +16,9 @@ wget -q https://repo.continuum.io/miniconda/Miniconda3-4.4.10-Linux-x86_64.sh -O
 bash miniconda.sh -b -p $HOME/.conda
 source $HOME/.conda/etc/profile.d/conda.sh
 conda activate
+conda config --add channels conda-forge
 conda update conda --yes
-conda install -c conda-forge --yes conda-smithy conda-forge-pinning conda=4.5 python=3.6 tornado pygithub git statuspage
+conda install --yes conda-smithy conda-forge-pinning conda=4.5 python=3.6 tornado pygithub git statuspage
 conda clean --all --yes
 
 conda info


### PR DESCRIPTION
Previously we installed some select things from the conda-forge channel when configuring Heroku. This changes that by just installing everything from conda-forge if possible. Only if it is not possible, do we fallback to defaults.