### PR TITLE
add update-cb3 command, refactor commands a bit

### DIFF
--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -188,7 +188,7 @@ def issue_comment(org_name, repo_name, issue_num, title, comment):
 
                 c, cb3_changes = update_cb3(git_repo)
                 changed_anything |= c
-                if cb3_changes is False:
+                if not c:
                     cb3_changes = "There weren't any changes to make for conda-build 3."
                 extra_msg = '\n\n' + cb3_changes
 

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -34,13 +34,12 @@ def pr_detailed_comment(org_name, repo_name, pr_owner, pr_repo, pr_branch, pr_nu
     if not (repo_name.endswith("-feedstock") or is_staged_recipes):
         return
 
-    gh = github.Github(os.environ['GH_TOKEN'])
-    repo = gh.get_repo("{}/{}".format(org_name, repo_name))
-    pull = repo.get_pull(int(pr_num))
-
     if not is_staged_recipes and UPDATE_CIRCLECI_KEY_MSG.search(comment):
         update_circle(org_name, repo_name)
 
+        gh = github.Github(os.environ['GH_TOKEN'])
+        repo = gh.get_repo("{}/{}".format(org_name, repo_name))
+        pull = repo.get_pull(int(pr_num))
         message = textwrap.dedent("""
                 Hi! This is the friendly automated conda-forge-webservice.
 
@@ -95,6 +94,10 @@ def pr_detailed_comment(org_name, repo_name, pr_owner, pr_repo, pr_branch, pr_nu
                 expected_changes[-1] = 'and ' + expected_changes[-1]
             joiner = ", " if len(expected_changes) > 2 else " "
             changes_str = joiner.join(expected_changes)
+
+            gh = github.Github(os.environ['GH_TOKEN'])
+            repo = gh.get_repo("{}/{}".format(org_name, repo_name))
+            pull = repo.get_pull(int(pr_num))
 
             if changed_anything:
                 try:

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -65,7 +65,7 @@ def pr_detailed_comment(org_name, repo_name, pr_owner, pr_repo, pr_branch, pr_nu
             if ADD_NOARCH_MSG.search(comment):
                 make_noarch(repo)
                 rerender(repo, org_name, repo_name, pr_num)
-            if RERENDER_MSG.search(comment):
+            elif RERENDER_MSG.search(comment):
                 rerender(repo, org_name, repo_name, pr_num)
         if LINT_MSG.search(comment):
             relint(org_name, repo_name, pr_num)

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -269,7 +269,7 @@ def update_cb3(repo):
     repo.git.add(A=True)
     if repo.is_dirty():
         author = Actor("conda-forge-admin", "pelson.pub+conda-forge@gmail.com")
-        repo.index.commit("Add noarch:python option", author=author)
+        repo.index.commit("Update for conda-build 3", author=author)
         return True, output
     else:
         return False, output

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -35,14 +35,7 @@ def pr_detailed_comment(org_name, repo_name, pr_owner, pr_repo, pr_branch, pr_nu
     if not (repo_name.endswith("-feedstock") or is_staged_recipes):
         return
 
-    pr_commands = [LINT_MSG, UPDATE_CIRCLECI_KEY_MSG]
-    if not is_staged_recipes:
-        pr_commands += [ADD_NOARCH_MSG, RERENDER_MSG]
-
-    if not any(command.search(comment) for command in pr_commands):
-        return
-
-    if UPDATE_CIRCLECI_KEY_MSG.search(comment):
+    if not is_staged_recipes and UPDATE_CIRCLECI_KEY_MSG.search(comment):
         update_circle(org_name, repo_name)
 
         gh = github.Github(os.environ['GH_TOKEN'])
@@ -55,6 +48,12 @@ def pr_detailed_comment(org_name, repo_name, pr_owner, pr_repo, pr_branch, pr_nu
                 """)
         pull.create_issue_comment(message)
 
+    pr_commands = [LINT_MSG]
+    if not is_staged_recipes:
+        pr_commands += [ADD_NOARCH_MSG, RERENDER_MSG]
+
+    if not any(command.search(comment) for command in pr_commands):
+        return
 
     with tmp_directory() as tmp_dir:
         feedstock_dir = os.path.join(tmp_dir, repo_name)

--- a/conda_forge_webservices/tests/test_commands.py
+++ b/conda_forge_webservices/tests/test_commands.py
@@ -50,6 +50,7 @@ class TestCommands(unittest.TestCase):
             self, repo, gh, tmp_directory, update_cb3, update_circle,
             update_team, relint, make_noarch, rerender):
         tmp_directory.return_value.__enter__.return_value = '/tmp'
+        update_cb3.return_value = (True, "hi")
 
         commands = [
             (rerender, False, [
@@ -121,6 +122,7 @@ class TestCommands(unittest.TestCase):
             self, repo, gh, tmp_directory, update_cb3, update_circle,
             update_team, relint, make_noarch, rerender):
         tmp_directory.return_value.__enter__.return_value = '/tmp'
+        update_cb3.return_value = (True, "hi")
 
         commands = [
             (rerender, [
@@ -182,7 +184,7 @@ class TestCommands(unittest.TestCase):
                 issue.reset_mock()
                 issue_comment(title=msg, comment="As in title")
                 command.assert_called()
-                if command is rerender or command is make_noarch:
+                if command in (rerender, make_noarch, update_cb3):
                     assert "Fixes #" in repo.create_pull.call_args[0][1]
                 else:
                     issue.edit.assert_called_with(state="closed")

--- a/conda_forge_webservices/tests/test_commands.py
+++ b/conda_forge_webservices/tests/test_commands.py
@@ -42,11 +42,12 @@ class TestCommands(unittest.TestCase):
     @mock.patch('conda_forge_webservices.commands.relint')
     @mock.patch('conda_forge_webservices.commands.update_team')
     @mock.patch('conda_forge_webservices.commands.update_circle')
+    @mock.patch('conda_forge_webservices.commands.update_cb3')
     @mock.patch('conda_forge_webservices.commands.tmp_directory')
     @mock.patch('github.Github')
     @mock.patch('conda_forge_webservices.commands.Repo')
     def test_pr_command_triggers(
-            self, repo, gh, tmp_directory, update_circle,
+            self, repo, gh, tmp_directory, update_cb3, update_circle,
             update_team, relint, make_noarch, rerender):
         tmp_directory.return_value.__enter__.return_value = '/tmp'
 
@@ -71,6 +72,12 @@ class TestCommands(unittest.TestCase):
                 '@conda-forge-linter, please lint',
                 'sure wish @conda-forge-admin would please add noarch python',
              ]),
+            (update_cb3, False, [
+                '@conda-forge-admin, please update for CB3',
+                '@conda-forge-admin, please update for conda-build 3',
+            ], [
+                '@conda-forge-admin, please lint'
+            ]),
             (relint, True, [
                 '@conda-forge-admin, please lint',
                 '@CONDA-FORGE-LINTER, please relint',
@@ -106,11 +113,12 @@ class TestCommands(unittest.TestCase):
     @mock.patch('conda_forge_webservices.commands.relint')
     @mock.patch('conda_forge_webservices.commands.update_team')
     @mock.patch('conda_forge_webservices.commands.update_circle')
+    @mock.patch('conda_forge_webservices.commands.update_cb3')
     @mock.patch('conda_forge_webservices.commands.tmp_directory')
     @mock.patch('github.Github')
     @mock.patch('conda_forge_webservices.commands.Repo')
     def test_issue_command_triggers(
-            self, repo, gh, tmp_directory, update_circle,
+            self, repo, gh, tmp_directory, update_cb3, update_circle,
             update_team, relint, make_noarch, rerender):
         tmp_directory.return_value.__enter__.return_value = '/tmp'
 
@@ -135,6 +143,12 @@ class TestCommands(unittest.TestCase):
                 '@conda-forge-linter, please lint',
                 'sure wish @conda-forge-admin would please add noarch python',
              ]),
+            (update_cb3, False, [
+                '@conda-forge-admin, please update for cb-3',
+                'yo @conda-forge-admin: please update for conda build 3',
+            ], [
+                '@conda-forge-admin, please lint'
+            ]),
             (update_team, [
                 '@conda-forge-admin: please update team',
                 '@conda-forge-admin, please update the team',

--- a/conda_forge_webservices/tests/test_commands.py
+++ b/conda_forge_webservices/tests/test_commands.py
@@ -143,7 +143,7 @@ class TestCommands(unittest.TestCase):
                 '@conda-forge-linter, please lint',
                 'sure wish @conda-forge-admin would please add noarch python',
              ]),
-            (update_cb3, False, [
+            (update_cb3, [
                 '@conda-forge-admin, please update for cb-3',
                 'yo @conda-forge-admin: please update for conda build 3',
             ], [


### PR DESCRIPTION
Add a command to call `update-cb3`: fixes #210.

Includes and thus closes #213 because that reorganized `pr_detailed_comment` a bit already, and this does too.

Also reorganize the structure of `commands` a bit to make `pr_detailed_comment` and `issue_comment` responsible for commenting when nothing happens, rather than e.g. `rerender`. This helps avoid throwing out tons of comments depending on what needs to change or not.