### PR TITLE
Unpin conda-build 3.16

### DIFF
--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -18,7 +18,7 @@ source $HOME/.conda/etc/profile.d/conda.sh
 conda activate
 conda config --add channels conda-forge
 conda update conda --yes
-conda install --yes conda-smithy conda-forge-pinning conda=4.5 conda-build=3.16 python=3.6 tornado pygithub git statuspage
+conda install --yes conda-smithy conda-forge-pinning conda=4.5 conda-build python=3.6 tornado pygithub git statuspage
 conda clean --all --yes
 
 conda info


### PR DESCRIPTION
This was pinned due to a change in conda-build 3.17 that broke conda-smithy. Since then conda-smithy has been fixed to work with both 3.16 and 3.17. Hence we can relax this pin.

xref: https://github.com/conda-forge/conda-smithy/pull/962