### PR TITLE
trying to make the rerender command not fail silently

### DIFF
--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -118,7 +118,7 @@ def pr_detailed_comment(org_name, repo_name, pr_owner, pr_repo, pr_branch, pr_nu
                     message = textwrap.dedent("""
                         Hi! This is the friendly automated conda-forge-webservice.
 
-                        I tried to {} for you but ran into some issues, try doing these actions locally instead.
+                        I tried to {} for you but ran into some issues, please ping conda-forge/core for further assistance.
                         """)
                 else:
                     message = textwrap.dedent("""

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -64,6 +64,7 @@ def pr_detailed_comment(org_name, repo_name, pr_owner, pr_repo, pr_branch, pr_nu
             relint(org_name, repo_name, pr_num)
 
         changed_anything = False
+        rerender_error = False
         expected_changes = []
         extra_msg = ''
         if not is_staged_recipes:
@@ -87,7 +88,10 @@ def pr_detailed_comment(org_name, repo_name, pr_owner, pr_repo, pr_branch, pr_nu
                 extra_msg += '\n\n' + cb3_changes
 
             if do_rerender:
-                changed_anything |= rerender(repo)
+                try:
+                    changed_anything |= rerender(repo)
+                except RuntimeError:
+                    rerender_error = True
 
         if expected_changes:
             if len(expected_changes) > 1:
@@ -110,11 +114,18 @@ def pr_detailed_comment(org_name, repo_name, pr_owner, pr_repo, pr_branch, pr_nu
                         """).format(pr_branch, pr_owner, pr_repo, changes_str)
                     pull.create_issue_comment(message)
             else:
-                message = textwrap.dedent("""
-                    Hi! This is the friendly automated conda-forge-webservice.
+                if rerender_error:
+                    message = textwrap.dedent("""
+                        Hi! This is the friendly automated conda-forge-webservice.
 
-                    I tried to {} for you, but it looks like there was nothing to do.
-                    """).format(changes_str)
+                        I tried to {} for you but ran into some issues, try doing these actions locally instead.
+                        """)
+                else:
+                    message = textwrap.dedent("""
+                        Hi! This is the friendly automated conda-forge-webservice.
+
+                        I tried to {} for you, but it looks like there was nothing to do.
+                        """).format(changes_str)
                 pull.create_issue_comment(message)
 
 
@@ -245,8 +256,12 @@ def issue_comment(org_name, repo_name, issue_num, title, comment):
 
 def rerender(repo):
     curr_head = repo.active_branch.commit
-    subprocess.call(["conda", "smithy", "rerender", "-c", "auto"], cwd=repo.working_dir)
-    return repo.active_branch.commit != curr_head
+    ret = subprocess.call(["conda", "smithy", "rerender", "-c", "auto"], cwd=repo.working_dir)
+
+    if ret:
+        raise RuntimeError
+    else:
+        return repo.active_branch.commit != curr_head
 
 
 def make_noarch(repo):

--- a/conda_forge_webservices/tests/test_commands.py
+++ b/conda_forge_webservices/tests/test_commands.py
@@ -270,8 +270,8 @@ class TestCommands(unittest.TestCase):
 
         rerender.assert_called()
 
-        assert 'ran into some issues' in pull_create_issue_comment.call_args[0][0]
-        assert 'try doing these actions locally' in pull_create_issue_comment.call_args[0][0]
+        assert 'ran into some issues' in pull_create_issue.call_args[0][0]
+        assert 'try doing these actions locally' in pull_create_issue.call_args[0][0]
 
 if __name__ == '__main__':
     unittest.main()

--- a/conda_forge_webservices/tests/test_commands.py
+++ b/conda_forge_webservices/tests/test_commands.py
@@ -247,6 +247,31 @@ class TestCommands(unittest.TestCase):
                 command.assert_not_called()
                 issue.edit.assert_not_called()
 
+    @mock.patch('conda_forge_webservices.commands.rerender')
+    @mock.patch('conda_forge_webservices.commands.make_noarch')
+    @mock.patch('conda_forge_webservices.commands.relint')
+    @mock.patch('conda_forge_webservices.commands.update_team')
+    @mock.patch('conda_forge_webservices.commands.update_circle')
+    @mock.patch('conda_forge_webservices.commands.update_cb3')
+    @mock.patch('conda_forge_webservices.commands.tmp_directory')
+    @mock.patch('github.Github')
+    @mock.patch('conda_forge_webservices.commands.Repo')
+    def test_rerender_failure(
+            self, repo, gh, tmp_directory, update_cb3, update_circle,
+            update_team, relint, make_noarch, rerender):
+        rerender.side_effect = RuntimeError
+
+        repo = gh.return_value.get_repo.return_value
+        pull_create_issue = repo.get_pull.return_value.create_issue_comment
+
+        msg = '@conda-forge-admin, please rerender'
+
+        pr_detailed_comment(msg)
+
+        rerender.assert_called()
+
+        assert 'ran into some issues' in pull_create_issue_comment.call_args[0][0]
+        assert 'try doing these actions locally' in pull_create_issue_comment.call_args[0][0]
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I ran into a weird state where 'conda forge please rerender' would say that nothing needed doing, when in fact it had actually just failed (and therefore didn't see a change in the repo).

I think by checking the return code of the subprocess call you can at least see when this happens and advise.