### PR TITLE
Update link to Feedstock doc for maintainers

### DIFF
--- a/conda_forge_webservices/update_teams.py
+++ b/conda_forge_webservices/update_teams.py
@@ -76,7 +76,7 @@ def update_team(org_name, repo_name, commit=None):
 
                     NOTE: Please make sure to not push to the repository directly.
                           Use branches in your fork for any changes and send a PR.
-                          More details [here](https://conda-forge.org/docs/conda-forge_gotchas.html#using-a-fork-vs-a-branch-when-updating-a-recipe)
+                          More details [here](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
                 """)
 
                 c = gh_repo.get_commit(commit)


### PR DESCRIPTION
This documentation page got moved yet the bot was commenting the old (404'd) one whenever someone received feedstock access.

<!--
Thank you for the pull request. This repo's testing mechanism requires that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

If you have push access to this repo, please push directly to a branch in this repo and create
a PR from that branch

If you do not have push access to this repo, create a PR from your fork's branch and ask the
conda-forge/core team to push your commits to a branch on this repo
-->

Checklist
* [ ] Pushed the branch to main repo
* [ ] CI passed on the branch

