### PR TITLE
Add suggestion to re-render locally when an error is encountered

### DIFF
--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -126,11 +126,12 @@ def pr_detailed_comment(org_name, repo_name, pr_owner, pr_repo, pr_branch, pr_nu
                     pull.create_issue_comment(message)
             else:
                 if rerender_error:
+                    doc_url = 'https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-with-conda-smithy-locally'
                     message = textwrap.dedent("""
                         Hi! This is the friendly automated conda-forge-webservice.
 
-                        I tried to {} for you but ran into some issues, please ping conda-forge/core for further assistance.
-                        """).format(changes_str)
+                        I tried to {} for you but ran into some issues, please ping conda-forge/core for further assistance. You can also try [re-rendering locally]({}).
+                        """).format(changes_str, doc_url)
                 else:
                     message = textwrap.dedent("""
                         Hi! This is the friendly automated conda-forge-webservice.


### PR DESCRIPTION
<!--
Thank you for the pull request. This repo's testing mechanism requires that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

If you have push access to this repo, please push directly to a branch in this repo and create
a PR from that branch

If you do not have push access to this repo, create a PR from your fork's branch and ask the
conda-forge/core team to push your commits to a branch on this repo
-->

Checklist
* [ ] Pushed the branch to main repo
* [ ] CI passed on the branch

Following a [suggestion](https://github.com/conda-forge/python-neo-feedstock/pull/16#issuecomment-554542268) by @ocefpaf, I've added a sentence to the re-render error message that suggests re-rendering locally and provides a link to the documentation.

Since I don't have push access to this repo, someone at @conda-forge/core will need to push my commits to a branch here.