### PR TITLE
ENH pinging the team

### DIFF
--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -20,6 +20,7 @@ LINT_MSG = re.compile(pre + "(please )?(re-?)?lint", re.I)
 UPDATE_TEAM_MSG = re.compile(pre + "(please )?(update|refresh) (the )?team", re.I)
 UPDATE_CIRCLECI_KEY_MSG = re.compile(pre + "(please )?(update|refresh) (the )?circle", re.I)
 UPDATE_CB3_MSG = re.compile(pre + "(please )?update (for )?(cb|conda[- ]build)[- ]?3", re.I)
+PING_TEAM = re.compile(pre + "(please )?ping team", re.I)
 
 
 def pr_comment(org_name, repo_name, issue_num, comment):
@@ -56,6 +57,18 @@ def pr_detailed_comment(org_name, repo_name, pr_owner, pr_repo, pr_branch, pr_nu
         pull.edit(state='closed')
         time.sleep(1)  # wait a bit to be sure things are ok
         pull.edit(state='open')
+
+    if PING_TEAM.search(comment):
+        gh = github.Github(os.environ['GH_TOKEN'])
+        repo = gh.get_repo("{}/{}".format(org_name, repo_name))
+        pull = repo.get_pull(int(pr_num))
+        team = repo_name.replace('-feedstock', '')
+        message = textwrap.dedent(""""
+            Hi! This is the friendly automated conda-forge-webservice.
+
+            I was asked to ping @conda-forge/%s and so here I am doing that.
+            """ % team)
+        pull.create_issue_comment(message)
 
     pr_commands = [LINT_MSG]
     if not is_staged_recipes:


### PR DESCRIPTION
This PR adds a command to ping the team of a feedstock. It is mainly useful on staged recipes for people who are not yet a part of conda-forge, but can be used on feedstocks as well.

Closes #278 

<!--
Thank you for the pull request. This repo's testing mechanism requires that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

If you have push access to this repo, please push directly to a branch in this repo and create
a PR from that branch

If you do not have push access to this repo, create a PR from your fork's branch and ask the
conda-forge/core team to push your commits to a branch on this repo
-->

Checklist
* [ ] Pushed the branch to main repo
* [ ] CI passed on the branch

