### PR TITLE
ENH added command to add the bot-rerun label

### DIFF
--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -74,28 +74,7 @@ def pr_detailed_comment(org_name, repo_name, pr_owner, pr_repo, pr_branch, pr_nu
     if not is_staged_recipes and RERUN_BOT.search(comment):
         gh = github.Github(os.environ['GH_TOKEN'])
         repo = gh.get_repo("{}/{}".format(org_name, repo_name))
-        
-        # try to add the label if it does not exist
-        # this makes things look nicer but is not needed
-        try:
-            # color and description are from the bot repo
-            repo.create_label(
-                'bot-rerun',
-                '#191970',
-                description=(
-                    'Apply this label if you want the bot '
-                    'to retry issuing a particular '
-                    'pull-request'))
-        except github.GithubException as e:
-            # an error here is not fatal so swallow it and 
-            # move on
-            pass
-
-        # now add the label
-        # this API call will work even if the label does not
-        # exist yet or is already on the PR
-        pull = repo.get_pull(int(pr_num))
-        pull.add_to_labels("bot-rerun")
+        add_bot_rerun_label(repo, pr_num)
 
     pr_commands = [LINT_MSG]
     if not is_staged_recipes:
@@ -356,3 +335,27 @@ def relint(owner, repo_name, pr_num):
     else:
         msg = comment_on_pr(owner, repo_name, pr, lint_info['message'], force=True)
         set_pr_status(owner, repo_name, lint_info, target_url=msg.html_url)
+
+
+def add_bot_rerun_label(repo, pr_num):
+    # try to add the label if it does not exist
+    # this makes things look nicer but is not needed
+    try:
+        # color and description are from the bot repo
+        repo.create_label(
+            'bot-rerun',
+            '#191970',
+            description=(
+                'Apply this label if you want the bot '
+                'to retry issuing a particular '
+                'pull-request'))
+    except github.GithubException:
+        # an error here is not fatal so swallow it and
+        # move on
+        pass
+
+    # now add the label
+    # this API call will work even if the label does not
+    # exist yet or is already on the PR
+    pull = repo.get_pull(int(pr_num))
+    pull.add_to_labels("bot-rerun")

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -21,6 +21,7 @@ UPDATE_TEAM_MSG = re.compile(pre + "(please )?(update|refresh) (the )?team", re.
 UPDATE_CIRCLECI_KEY_MSG = re.compile(pre + "(please )?(update|refresh) (the )?circle", re.I)
 UPDATE_CB3_MSG = re.compile(pre + "(please )?update (for )?(cb|conda[- ]build)[- ]?3", re.I)
 PING_TEAM = re.compile(pre + "(please )?ping team", re.I)
+RERUN_BOT = re.compile(pre + "(please )?rerun (the )?bot", re.I)
 
 
 def pr_comment(org_name, repo_name, issue_num, comment):
@@ -69,6 +70,12 @@ def pr_detailed_comment(org_name, repo_name, pr_owner, pr_repo, pr_branch, pr_nu
             I was asked to ping @conda-forge/%s and so here I am doing that.
             """ % team)
         pull.create_issue_comment(message)
+
+    if not is_staged_recipes and RERUN_BOT.search(comment):
+        gh = github.Github(os.environ['GH_TOKEN'])
+        repo = gh.get_repo("{}/{}".format(org_name, repo_name))
+        pull = repo.get_pull(int(pr_num))
+        pull.add_to_labels("bot-rerun")
 
     pr_commands = [LINT_MSG]
     if not is_staged_recipes:

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -74,6 +74,26 @@ def pr_detailed_comment(org_name, repo_name, pr_owner, pr_repo, pr_branch, pr_nu
     if not is_staged_recipes and RERUN_BOT.search(comment):
         gh = github.Github(os.environ['GH_TOKEN'])
         repo = gh.get_repo("{}/{}".format(org_name, repo_name))
+        
+        # try to add the label if it does not exist
+        # this makes things look nicer but is not needed
+        try:
+            # color and description are from the bot repo
+            repo.create_label(
+                'bot-rerun',
+                '#191970',
+                description=(
+                    'Apply this label if you want the bot '
+                    'to retry issuing a particular '
+                    'pull-request'))
+        except github.GithubException as e:
+            # an error here is not fatal to swallow it and 
+            # move on
+            pass
+
+        # now add the label
+        # this API call will work even if the label does not
+        # exist yet or is already on the PR
         pull = repo.get_pull(int(pr_num))
         pull.add_to_labels("bot-rerun")
 

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -87,7 +87,7 @@ def pr_detailed_comment(org_name, repo_name, pr_owner, pr_repo, pr_branch, pr_nu
                     'to retry issuing a particular '
                     'pull-request'))
         except github.GithubException as e:
-            # an error here is not fatal to swallow it and 
+            # an error here is not fatal so swallow it and 
             # move on
             pass
 

--- a/conda_forge_webservices/tests/test_commands.py
+++ b/conda_forge_webservices/tests/test_commands.py
@@ -37,6 +37,7 @@ class TestCommands(unittest.TestCase):
         if self.kill_token:
             del os.environ['GH_TOKEN']
 
+    @mock.patch('conda_forge_webservices.commands.add_bot_rerun_label')
     @mock.patch('conda_forge_webservices.commands.rerender')
     @mock.patch('conda_forge_webservices.commands.make_noarch')
     @mock.patch('conda_forge_webservices.commands.relint')
@@ -48,7 +49,7 @@ class TestCommands(unittest.TestCase):
     @mock.patch('conda_forge_webservices.commands.Repo')
     def test_pr_command_triggers(
             self, repo, gh, tmp_directory, update_cb3, update_circle,
-            update_team, relint, make_noarch, rerender):
+            update_team, relint, make_noarch, rerender, add_bot_rerun_label):
         tmp_directory.return_value.__enter__.return_value = '/tmp'
         update_cb3.return_value = (True, "hi")
 
@@ -104,6 +105,20 @@ class TestCommands(unittest.TestCase):
                 'hey @conda-forge-linter re-lint!',
              ], [
                 '@conda-forge-admin should probably lint again',
+             ]),
+            (add_bot_rerun_label, False, [
+                '@conda-forge-admin, please rerun the bot',
+                '@conda-forge-admin, rerun the bot',
+                '@conda-forge-admin, please rerun bot',
+                '@conda-forge-admin, rerun bot',
+                '@conda-forge-admin: RERUN BOT',
+                'something something. @conda-forge-admin: please rerun bot',
+             ], [
+                '@conda-forge admin is pretty cool. please rerun bot for me?',
+                '@conda-forge admin is pretty cool. rerun the bot for me?',
+                '@conda-forge-admin, go ahead and rerun the bot for me',
+                'please rerun the bot, @conda-forge-admin',
+                'rerun bot, @conda-forge-admin',
              ]),
         ]
 


### PR DESCRIPTION
<!--
Thank you for the pull request. This repo's testing mechanism requires that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

If you have push access to this repo, please push directly to a branch in this repo and create
a PR from that branch

If you do not have push access to this repo, create a PR from your fork's branch and ask the
conda-forge/core team to push your commits to a branch on this repo
-->

This PR adds a web services command to add the bot-rerun label to PRs.

Checklist
* [ ] Pushed the branch to main repo
* [ ] CI passed on the branch

@conda-forge/core @CJ-Wright for viz
