### PR TITLE
DOC add docs on tests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,9 @@ If you have push access to this repo, please push directly to a branch in this r
 a PR from that branch
 
 If you do not have push access to this repo, create a PR from your fork's branch and ask the
-conda-forge/core team to push your commits to a branch on this repo
+conda-forge/core team to push your commits to a branch on this repo. 
+
+Note that the tests will not pass until the branch is on the main repo and not your fork!
 -->
 
 Checklist

--- a/README.md
+++ b/README.md
@@ -17,3 +17,9 @@ It is then a case of adding the appropriate webhook to trigger the service on ``
 The buildpack for this repo comes from https://github.com/pl31/heroku-buildpack-conda, which allows a conda
 environment to be deployed as part of the slug.
 
+testing
+-------
+
+The tests for this repo require a GitHub API key which is not available on forks. Thus the tests only pass 
+for PRs made from a branch in this repo. If your PR is in a fork, please ask a member of `@conda-forge/core`
+to push your PR branch to the main repo to enable the tests.


### PR DESCRIPTION
<!--
Thank you for the pull request. This repo's testing mechanism requires that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

If you have push access to this repo, please push directly to a branch in this repo and create
a PR from that branch

If you do not have push access to this repo, create a PR from your fork's branch and ask the
conda-forge/core team to push your commits to a branch on this repo
-->

Checklist
* [ ] Pushed the branch to main repo
* [ ] CI passed on the branch

