### PR TITLE
REF less api calls for stale

### DIFF
--- a/conda_forge_webservices/linting.py
+++ b/conda_forge_webservices/linting.py
@@ -11,14 +11,6 @@ import conda_smithy.lint_recipe
 from .utils import tmp_directory
 
 
-def is_pr_stale(owner, repo_name, pr_id):
-    gh = github.Github(os.environ['GH_TOKEN'])
-    user = gh.get_user(owner)
-    repo = user.get_repo(repo_name)
-    pr = repo.get_pull(pr_id)
-    return any(l.name == 'stale' for l in pr.get_labels())
-
-
 def find_recipes(a_dir):
     return [os.path.dirname(y) for x in os.walk(a_dir)
             for y in glob(os.path.join(x[0], 'meta.yaml'))]

--- a/conda_forge_webservices/tests/test_webapp.py
+++ b/conda_forge_webservices/tests/test_webapp.py
@@ -69,9 +69,6 @@ class TestBucketHandler(TestHandlerBase):
                               headers={'X-GitHub-Event': 'pull_request'})
 
         self.assertEqual(response.code, 200)
-        is_pr_stale.assert_called_once_with('conda-forge', 'staged-recipes',
-                                            PR_number)
-
         compute_lint_message.assert_called_once_with('conda-forge', 'staged-recipes',
                                                      PR_number, True)
 

--- a/conda_forge_webservices/tests/test_webapp.py
+++ b/conda_forge_webservices/tests/test_webapp.py
@@ -33,7 +33,7 @@ class TestBucketHandler(TestHandlerBase):
                                'owner': {'login': 'conda-forge'}},
                 'pull_request': {'number': PR_number,
                                  'state': 'open',
-                                 'labels': [{'name': 'stale'},]}}
+                                 'labels': [{'name': 'stale'}]}}
 
         response = self.fetch('/conda-linting/hook', method='POST',
                               body=json.dumps(body),

--- a/conda_forge_webservices/tests/test_webapp.py
+++ b/conda_forge_webservices/tests/test_webapp.py
@@ -33,7 +33,7 @@ class TestBucketHandler(TestHandlerBase):
                                'owner': {'login': 'conda-forge'}},
                 'pull_request': {'number': PR_number,
                                  'state': 'open',
-                                 'labels': [{'name': 'stale'}]}}
+                                 'labels': [{'name': 'stale'},]}}
 
         response = self.fetch('/conda-linting/hook', method='POST',
                               body=json.dumps(body),

--- a/conda_forge_webservices/tests/test_webapp.py
+++ b/conda_forge_webservices/tests/test_webapp.py
@@ -23,7 +23,6 @@ class TestBucketHandler(TestHandlerBase):
                               body=urlencode({'a': 1}))
         self.assertEqual(response.code, 404)
 
-    @mock.patch('conda_forge_webservices.linting.is_pr_stale', return_value=False)
     @mock.patch('conda_forge_webservices.linting.compute_lint_message', return_value={'message': mock.sentinel.message})
     @mock.patch('conda_forge_webservices.linting.comment_on_pr', return_value=mock.MagicMock(html_url=mock.sentinel.html_url))
     @mock.patch('conda_forge_webservices.linting.set_pr_status')
@@ -33,14 +32,14 @@ class TestBucketHandler(TestHandlerBase):
                                'clone_url': 'repo_clone_url',
                                'owner': {'login': 'conda-forge'}},
                 'pull_request': {'number': PR_number,
-                                 'state': 'open'}}
+                                 'state': 'open',
+                                 'labels': [{'name': 'stale'}]}}
 
         response = self.fetch('/conda-linting/hook', method='POST',
                               body=json.dumps(body),
                               headers={'X-GitHub-Event': 'pull_request'})
 
         self.assertEqual(response.code, 200)
-        is_pr_stale.assert_not_called()
 
         compute_lint_message.assert_called_once_with('conda-forge', 'repo_name',
                                                      PR_number, False)
@@ -53,7 +52,6 @@ class TestBucketHandler(TestHandlerBase):
                                               {'message': mock.sentinel.message},
                                               target_url=mock.sentinel.html_url)
 
-    @mock.patch('conda_forge_webservices.linting.is_pr_stale', return_value=False)
     @mock.patch('conda_forge_webservices.linting.compute_lint_message', return_value={'message': mock.sentinel.message})
     @mock.patch('conda_forge_webservices.linting.comment_on_pr', return_value=mock.MagicMock(html_url=mock.sentinel.html_url))
     @mock.patch('conda_forge_webservices.linting.set_pr_status')
@@ -63,7 +61,8 @@ class TestBucketHandler(TestHandlerBase):
                                'clone_url': 'repo_clone_url',
                                'owner': {'login': 'conda-forge'}},
                 'pull_request': {'number': PR_number,
-                                 'state': 'open'}}
+                                 'state': 'open',
+                                 'labels': [{'name': 'blah'}]}}
 
         response = self.fetch('/conda-linting/hook', method='POST',
                               body=json.dumps(body),
@@ -84,7 +83,6 @@ class TestBucketHandler(TestHandlerBase):
                                               {'message': mock.sentinel.message},
                                               target_url=mock.sentinel.html_url)
 
-    @mock.patch('conda_forge_webservices.linting.is_pr_stale', return_value=True)
     @mock.patch('conda_forge_webservices.linting.compute_lint_message', return_value={'message': mock.sentinel.message})
     @mock.patch('conda_forge_webservices.linting.comment_on_pr', return_value=mock.MagicMock(html_url=mock.sentinel.html_url))
     @mock.patch('conda_forge_webservices.linting.set_pr_status')
@@ -94,16 +92,14 @@ class TestBucketHandler(TestHandlerBase):
                                'clone_url': 'repo_clone_url',
                                'owner': {'login': 'conda-forge'}},
                 'pull_request': {'number': PR_number,
-                                 'state': 'open'}}
+                                 'state': 'open',
+                                 'labels': [{'name': 'stale'}]}}
 
         response = self.fetch('/conda-linting/hook', method='POST',
                               body=json.dumps(body),
                               headers={'X-GitHub-Event': 'pull_request'})
 
         self.assertEqual(response.code, 200)
-        is_pr_stale.assert_called_once_with('conda-forge', 'staged-recipes',
-                                            PR_number)
-
         compute_lint_message.assert_not_called()
 
         comment_on_pr.assert_not_called()

--- a/conda_forge_webservices/tests/test_webapp.py
+++ b/conda_forge_webservices/tests/test_webapp.py
@@ -26,7 +26,7 @@ class TestBucketHandler(TestHandlerBase):
     @mock.patch('conda_forge_webservices.linting.compute_lint_message', return_value={'message': mock.sentinel.message})
     @mock.patch('conda_forge_webservices.linting.comment_on_pr', return_value=mock.MagicMock(html_url=mock.sentinel.html_url))
     @mock.patch('conda_forge_webservices.linting.set_pr_status')
-    def test_good_header(self, set_pr_status, comment_on_pr, compute_lint_message, is_pr_stale):
+    def test_good_header(self, set_pr_status, comment_on_pr, compute_lint_message):
         PR_number = 16
         body = {'repository': {'name': 'repo_name',
                                'clone_url': 'repo_clone_url',
@@ -55,7 +55,7 @@ class TestBucketHandler(TestHandlerBase):
     @mock.patch('conda_forge_webservices.linting.compute_lint_message', return_value={'message': mock.sentinel.message})
     @mock.patch('conda_forge_webservices.linting.comment_on_pr', return_value=mock.MagicMock(html_url=mock.sentinel.html_url))
     @mock.patch('conda_forge_webservices.linting.set_pr_status')
-    def test_staged_recipes(self, set_pr_status, comment_on_pr, compute_lint_message, is_pr_stale):
+    def test_staged_recipes(self, set_pr_status, comment_on_pr, compute_lint_message):
         PR_number = 16
         body = {'repository': {'name': 'staged-recipes',
                                'clone_url': 'repo_clone_url',
@@ -86,7 +86,7 @@ class TestBucketHandler(TestHandlerBase):
     @mock.patch('conda_forge_webservices.linting.compute_lint_message', return_value={'message': mock.sentinel.message})
     @mock.patch('conda_forge_webservices.linting.comment_on_pr', return_value=mock.MagicMock(html_url=mock.sentinel.html_url))
     @mock.patch('conda_forge_webservices.linting.set_pr_status')
-    def test_staged_recipes_stale(self, set_pr_status, comment_on_pr, compute_lint_message, is_pr_stale):
+    def test_staged_recipes_stale(self, set_pr_status, comment_on_pr, compute_lint_message):
         PR_number = 16
         body = {'repository': {'name': 'staged-recipes',
                                'clone_url': 'repo_clone_url',

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -126,7 +126,10 @@ class LintingHookHandler(tornado.web.RequestHandler):
             is_open = body['pull_request']['state'] == 'open'
 
             if repo_name == 'staged-recipes':
-                stale = linting.is_pr_stale(owner, repo_name, pr_id)
+                stale = any(
+                    label['name'] == 'stale'
+                    for label in body['pull_request']['labels']
+                )
             else:
                 stale = False
 


### PR DESCRIPTION
<!--
Thank you for the pull request. This repo's testing mechanism requires that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

If you have push access to this repo, please push directly to a branch in this repo and create
a PR from that branch

If you do not have push access to this repo, create a PR from your fork's branch and ask the
conda-forge/core team to push your commits to a branch on this repo. 

Note that the tests will not pass until the branch is on the main repo and not your fork!
-->

Checklist
* [x] Pushed the branch to main repo
* [x] CI passed on the branch

