### PR TITLE
ENH skip some commits

### DIFF
--- a/conda_forge_webservices/tests/test_webapp.py
+++ b/conda_forge_webservices/tests/test_webapp.py
@@ -157,6 +157,114 @@ class TestBucketHandler(TestHandlerBase):
                     else:
                         self.assertNotEqual(response.code, 200, msg=f"event: {event}, slug: {slug}, hook: {hook}")
 
+    @mock.patch(
+        'conda_forge_webservices.feedstocks_service.update_listing',
+        return_value=None,
+    )
+    @mock.patch(
+        'conda_forge_webservices.feedstocks_service.update_feedstock',
+        return_value=None,
+    )
+    @mock.patch(
+        'conda_forge_webservices.update_teams.update_team',
+        return_value=None,
+    )
+    @mock.patch(
+        'conda_forge_webservices.webapp.print_rate_limiting_info',
+        return_value=None,
+    )
+    @mock.patch('conda_forge_webservices.webapp.get_commit_message')
+    def test_skip_commits(self, commit_mock, *args):
+        for hook, accepted_repos, accepted_events, skip_slugs in [
+            ("/conda-forge-feedstocks/org-hook",
+             ["staged-recipes", "repo-feedstock", "conda-forge.github.io"],
+             ["push"],
+             ["[cf admin skip]", "[cf admin skip feedstocks]"],
+             ),
+            ("/conda-forge-teams/org-hook",
+             ["repo-feedstock"],
+             ["push"],
+             ["[cf admin skip]", "[cf admin skip teams]"],
+             ),
+        ]:
+            for commit_msg in (["blah"] + skip_slugs):
+                commit_mock.return_value = commit_msg
+
+                test_slugs = [
+                    "conda-forge/repo-feedstock",
+                    "conda-forge/staged-recipes",
+                    "conda-forge/conda-smithy",
+                    "dummy/repo-feedstock",
+                    "dummy/staged-recipes",
+                ]
+
+                for slug in test_slugs:
+                    owner, name = slug.split("/")
+                    body = {
+                        'repository': {
+                            'name': name,
+                            'full_name': '%s/%s' % (owner, name),
+                            'clone_url': 'repo_clone_url',
+                            'owner': {'login': owner},
+                        },
+                        'pull_request': {
+                            'number': 16,
+                            'state': 'open',
+                            'labels': [{'name': 'stale'}],
+                            'head': {
+                                'repo': {
+                                    'name': "pr_repo_name",
+                                    'owner': {'login': 'pr_repo_owner'},
+                                },
+                                'ref': 'ref',
+                            },
+                            'body': 'body',
+                        },
+                        'issue': {
+                            'number': 16,
+                            'body': 'body',
+                            'title': 'title',
+                        },
+                        'action': 'opened',
+                        'ref': 'refs/heads/master',
+                        'head': 'xyz',
+                    }
+
+                    hash = hmac.new(
+                        os.environ['CF_WEBSERVICES_TOKEN'].encode('utf-8'),
+                        json.dumps(body).encode('utf-8'),
+                        hashlib.sha1
+                    ).hexdigest()
+
+                    for event in ["push"]:
+
+                        response = self.fetch(
+                            hook,
+                            method='POST',
+                            body=json.dumps(body),
+                            headers={
+                                'X-GitHub-Event': event,
+                                'X-Hub-Signature': 'sha1=%s' % hash,
+                            },
+                        )
+
+                        if (
+                            owner == "conda-forge" and
+                            name in accepted_repos and
+                            event in accepted_events and
+                            all(s not in commit_msg for s in skip_slugs)
+                        ):
+                            self.assertEqual(
+                                response.code,
+                                200,
+                                msg=f"event: {event}, slug: {slug}, hook: {hook}",
+                            )
+                        else:
+                            self.assertNotEqual(
+                                response.code,
+                                200,
+                                msg=f"event: {event}, slug: {slug}, hook: {hook}",
+                            )
 
     @mock.patch('conda_forge_webservices.linting.compute_lint_message', return_value={'message': mock.sentinel.message})
     @mock.patch('conda_forge_webservices.linting.comment_on_pr', return_value=mock.MagicMock(html_url=mock.sentinel.html_url))

--- a/conda_forge_webservices/tests/test_webapp.py
+++ b/conda_forge_webservices/tests/test_webapp.py
@@ -254,6 +254,7 @@ class TestBucketHandler(TestHandlerBase):
                             event in accepted_events and
                             all(s not in commit_msg for s in skip_slugs)
                         ):
+                            assert commit_msg == "blah"
                             self.assertEqual(
                                 response.code,
                                 200,

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -17,6 +17,15 @@ import conda_forge_webservices.commands as commands
 import conda_forge_webservices.update_me as update_me
 
 
+def get_commit_message(full_name, commit):
+    return (
+        github.Github(os.environ['GH_TOKEN'])
+        .get_repo(full_name)
+        .get_commit(commit)
+        .commit
+        .message)
+
+
 def print_rate_limiting_info_for_token(token, user):
     # Compute some info about our GitHub API Rate Limit.
     # Note that it doesn't count against our limit to
@@ -204,12 +213,10 @@ class UpdateFeedstockHookHandler(tornado.web.RequestHandler):
             commit = body.get('head', None)
 
             if commit:
-                commit_msg = (
-                    github.GitHub(os.environ['GH_TOKEN'])
-                    .get_repo(body['repository']['full_name'])
-                    .get_commit(commit)
-                    .commit
-                    .message)
+                commit_msg = get_commit_message(
+                    body['repository']['full_name'],
+                    commit,
+                )
             else:
                 commit_msg = ""
 
@@ -262,12 +269,10 @@ class UpdateTeamHookHandler(tornado.web.RequestHandler):
             commit = body.get('head', None)
 
             if commit:
-                commit_msg = (
-                    github.GitHub(os.environ['GH_TOKEN'])
-                    .get_repo(body['repository']['full_name'])
-                    .get_commit(commit)
-                    .commit
-                    .message)
+                commit_msg = get_commit_message(
+                    body['repository']['full_name'],
+                    commit,
+                )
             else:
                 commit_msg = ""
 


### PR DESCRIPTION
This PR adds some ci skip slugs to the webservice to enable admin migrations.

<!--
Thank you for the pull request. This repo's testing mechanism requires that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

If you have push access to this repo, please push directly to a branch in this repo and create
a PR from that branch

If you do not have push access to this repo, create a PR from your fork's branch and ask the
conda-forge/core team to push your commits to a branch on this repo. 

Note that the tests will not pass until the branch is on the main repo and not your fork!
-->

Checklist
* [x] Pushed the branch to main repo
* [x] CI passed on the branch

