### PR TITLE
BUG cannot skip ci on redeploy

### DIFF
--- a/conda_forge_webservices/update_me.py
+++ b/conda_forge_webservices/update_me.py
@@ -87,5 +87,5 @@ def main():
             repo.index.add(pth)
 
             msg_vers = ", ".join(["{}={}".format(k, v) for k, v in to_install.items()])
-            repo.index.commit("[ci skip] ***NO_CI*** redeploy for '%s'" % msg_vers)
+            repo.index.commit("redeploy for '%s'" % msg_vers)
             repo.git.push("origin", "master")


### PR DESCRIPTION
<!--
Thank you for the pull request. This repo's testing mechanism requires that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

If you have push access to this repo, please push directly to a branch in this repo and create
a PR from that branch

If you do not have push access to this repo, create a PR from your fork's branch and ask the
conda-forge/core team to push your commits to a branch on this repo. 

Note that the tests will not pass until the branch is on the main repo and not your fork!
-->

Checklist
* [x] Pushed the branch to main repo
* [x] CI passed on the branch

