### PR TITLE
REF clone to max depth of 1 for feedstocks

### DIFF
--- a/conda_forge_webservices/feedstocks_service.py
+++ b/conda_forge_webservices/feedstocks_service.py
@@ -23,7 +23,8 @@ def update_listing():
         )
         webpage_repo = git.Repo.clone_from(
             webpage_url,
-            os.path.join(tmp_dir, "webpage")
+            os.path.join(tmp_dir, "webpage"),
+            depth=1,
         )
         webpage_dir = os.path.dirname(webpage_repo.git_dir)
 
@@ -32,7 +33,8 @@ def update_listing():
         )
         feedstocks_repo = git.Repo.clone_from(
             feedstocks_url,
-            os.path.join(tmp_dir, "feedstocks")
+            os.path.join(tmp_dir, "feedstocks"),
+            depth=1,
         )
         feedstocks_dir = os.path.dirname(feedstocks_repo.git_dir)
 
@@ -43,7 +45,8 @@ def update_listing():
         feedstocks_page_repo = git.Repo.clone_from(
             feedstocks_page_url,
             os.path.join(tmp_dir, "feedstocks_page"),
-            branch="gh-pages"
+            branch="gh-pages",
+            depth=1,
         )
         feedstocks_page_dir = os.path.dirname(feedstocks_page_repo.git_dir)
 
@@ -98,7 +101,8 @@ def update_feedstock(org_name, repo_name):
         )
         feedstocks_repo = git.Repo.clone_from(
             feedstocks_url,
-            tmp_dir
+            tmp_dir,
+            depth=1,
         )
 
         # Get the submodule


### PR DESCRIPTION
This should reduce the load on the server.

<!--
Thank you for the pull request. This repo's testing mechanism requires that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

If you have push access to this repo, please push directly to a branch in this repo and create
a PR from that branch

If you do not have push access to this repo, create a PR from your fork's branch and ask the
conda-forge/core team to push your commits to a branch on this repo. 

Note that the tests will not pass until the branch is on the main repo and not your fork!
-->

Checklist
* [x] Pushed the branch to main repo
* [x] CI passed on the branch

