### PR TITLE
REF don't make as many statuses

### DIFF
--- a/conda_forge_webservices/linting.py
+++ b/conda_forge_webservices/linting.py
@@ -225,6 +225,7 @@ def set_pr_status(owner, repo_name, lint_info, target_url=None):
         commit = repo.get_commit(lint_info['sha'])
 
         # get the last github status by the linter, if any
+        # API emmits these in reverse time order so first is latest
         statuses = commit.get_statuses()
         last_state = None
         for status in statuses:

--- a/conda_forge_webservices/linting.py
+++ b/conda_forge_webservices/linting.py
@@ -223,16 +223,33 @@ def set_pr_status(owner, repo_name, lint_info, target_url=None):
     repo = user.get_repo(repo_name)
     if lint_info:
         commit = repo.get_commit(lint_info['sha'])
-        if lint_info['status'] == 'good':
-            commit.create_status("success", description="All recipes are excellent.",
-                                 context="conda-forge-linter", target_url=target_url)
-        elif lint_info['status'] == 'mixed':
-            commit.create_status("success", description="Some recipes have hints.",
-                                 context="conda-forge-linter", target_url=target_url)
-        else:
-            commit.create_status(
-                "failure", description="Some recipes need some changes.",
-                context="conda-forge-linter", target_url=target_url)
+
+        # get the last github status by the linter, if any
+        statuses = commit.get_statuses()
+        last_state = None
+        for status in statuses:
+            if status.context == "conda-forge-linter":
+                last_state = status.state
+
+        # convert the linter status to a state
+        lint_status_to_state = {"good": "success", "mixed": "success"}
+        lint_last_state = lint_status_to_state.get(lint_info['status'], "failure")
+
+        # make a status only if it is different or we have not ever done it
+        # for this commit
+        if last_state is None or last_state != lint_last_state:
+            if lint_info['status'] == 'good':
+                commit.create_status(
+                    "success", description="All recipes are excellent.",
+                    context="conda-forge-linter", target_url=target_url)
+            elif lint_info['status'] == 'mixed':
+                commit.create_status(
+                    "success", description="Some recipes have hints.",
+                    context="conda-forge-linter", target_url=target_url)
+            else:
+                commit.create_status(
+                    "failure", description="Some recipes need some changes.",
+                    context="conda-forge-linter", target_url=target_url)
 
 
 def main():


### PR DESCRIPTION
Right now we make what appears to be more than one status per commit. This PR puts in a check to make sure only make a new status if it is different or we have not done it before.

<!--
Thank you for the pull request. This repo's testing mechanism requires that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

If you have push access to this repo, please push directly to a branch in this repo and create
a PR from that branch

If you do not have push access to this repo, create a PR from your fork's branch and ask the
conda-forge/core team to push your commits to a branch on this repo. 

Note that the tests will not pass until the branch is on the main repo and not your fork!
-->

Checklist
* [x] Pushed the branch to main repo
* [x] CI passed on the branch

