### PR TITLE
ENH fix linting double comments

### DIFF
--- a/conda_forge_webservices/linting.py
+++ b/conda_forge_webservices/linting.py
@@ -29,6 +29,20 @@ def compute_lint_message(repo_owner, repo_name, pr_id, ignore_base=False):
             return {}
         mergeable = pull_request.mergeable
 
+    # I think the api reports False and then changes to 
+    # true later after it computes the mergeable status
+    # so if it came out false, let's wait a bit and try again
+    # up to 5 seconds
+    if not mergeable:
+        for _ in range(5):
+            time.sleep(1)
+            pull_request = remote_repo.get_pull(pr_id)
+            if pull_request.state != "open":
+                return {}
+            mergeable = pull_request.mergeable
+            if mergeable:
+                break
+
     with tmp_directory() as tmp_dir:
         repo = Repo.clone_from(remote_repo.clone_url, tmp_dir, depth=1)
 

--- a/conda_forge_webservices/linting.py
+++ b/conda_forge_webservices/linting.py
@@ -29,7 +29,7 @@ def compute_lint_message(repo_owner, repo_name, pr_id, ignore_base=False):
             return {}
         mergeable = pull_request.mergeable
 
-    # I think the api reports False and then changes to 
+    # I think the api reports False and then changes to
     # true later after it computes the mergeable status
     # so if it came out false, let's wait a bit and try again
     # up to 5 seconds

--- a/conda_forge_webservices/linting.py
+++ b/conda_forge_webservices/linting.py
@@ -39,8 +39,9 @@ def compute_lint_message(repo_owner, repo_name, pr_id, ignore_base=False):
             pull_request = remote_repo.get_pull(pr_id)
             if pull_request.state != "open":
                 return {}
-            mergeable = pull_request.mergeable
-            if mergeable:
+            _mergeable = pull_request.mergeable
+            if _mergeable:
+                mergeable = _mergeable
                 break
 
     with tmp_directory() as tmp_dir:


### PR DESCRIPTION
<!--
Thank you for the pull request. This repo's testing mechanism requires that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

If you have push access to this repo, please push directly to a branch in this repo and create
a PR from that branch

If you do not have push access to this repo, create a PR from your fork's branch and ask the
conda-forge/core team to push your commits to a branch on this repo. 

Note that the tests will not pass until the branch is on the main repo and not your fork!
-->

related to #349

Checklist
* [x] Pushed the branch to main repo
* [ ] CI passed on the branch

