### PR TITLE
ENH try no yield statements

### DIFF
--- a/conda_forge_webservices/feedstock_outputs.py
+++ b/conda_forge_webservices/feedstock_outputs.py
@@ -287,7 +287,7 @@ def is_valid_feedstock_output(project, outputs, register=True):
             except RuntimeError:
                 continue
 
-            pth = os.path.join("outputs", o + ".json")
+            pth = os.path.join(repo_path, "outputs", o + ".json")
 
             if not os.path.exists(pth):
                 # no output exists, so we can add it

--- a/conda_forge_webservices/feedstock_outputs.py
+++ b/conda_forge_webservices/feedstock_outputs.py
@@ -6,6 +6,8 @@ import json
 import hmac
 import urllib.parse
 import subprocess
+import shutil
+import tempfile
 
 from binstar_client.utils import get_server_api
 from binstar_client import BinstarError
@@ -13,7 +15,7 @@ import binstar_client.errors
 
 from conda_smithy.feedstock_tokens import is_valid_feedstock_token
 
-from .utils import pushd, parse_conda_pkg, tmp_directory
+from .utils import parse_conda_pkg
 
 STAGING = "cf-staging"
 PROD = "conda-forge"
@@ -21,18 +23,20 @@ OUTPUTS_REPO = "https://${GH_TOKEN}@github.com/conda-forge/feedstock-outputs.git
 TOKENS_REPO = "https://${GH_TOKEN}@github.com/conda-forge/feedstock-tokens.git"
 
 
-def _run_git_command(*args):
+def _run_git_command(*args, cwd=None):
     subprocess.run(
         " ".join(["git"] + list(args)),
         check=True,
         shell=True,
+        cwd=cwd,
     )
 
 
-def _run_smithy_command(*args):
+def _run_smithy_command(*args, cwd=None):
     subprocess.run(
         ["conda-smithy"] + list(args),
         check=True,
+        cwd=cwd,
     )
 
 
@@ -59,32 +63,38 @@ def register_feedstock_token_handler(feedstock):
         "~/.conda-smithy/conda-forge_%s_feedstock.token" % feedstock_name
     )
 
+    tmpdir = None
     try:
-        with tmp_directory() as tmpdir, pushd(tmpdir):
-            try:
-                _run_git_command("clone", "--depth=1", feedstock_url)
-            except subprocess.CalledProcessError:
-                print("    could not clone the feedstock")
-                return True
+        tmpdir = tempfile.mkdtemp('_recipe')
+        fspath = os.path.join(tmpdir, "%s-feedstock" % feedstock_name)
+        try:
+            _run_git_command(
+                "clone", "--depth=1",
+                feedstock_url, fspath,
+            )
+        except subprocess.CalledProcessError:
+            print("    could not clone the feedstock")
+            return True
 
-            with pushd(feedstock_name + "-feedstock"):
-                try:
-                    _run_smithy_command("generate-feedstock-token")
-                except subprocess.CalledProcessError:
-                    print("    could not generate feedstock token")
-                    return True
+        try:
+            _run_smithy_command("generate-feedstock-token", cwd=fspath)
+        except subprocess.CalledProcessError:
+            print("    could not generate feedstock token")
+            return True
 
-                try:
-                    _run_smithy_command("register-feedstock-token")
-                except subprocess.CalledProcessError:
-                    print("    could not register feedstock token")
-                    return True
+        try:
+            _run_smithy_command("register-feedstock-token", cwd=fspath)
+        except subprocess.CalledProcessError:
+            print("    could not register feedstock token")
+            return True
     finally:
+        if tmpdir is not None:
+            shutil.rmtree(tmpdir)
+
         try:
             os.remove(token_path)
         except Exception:
-            print("    could not delete the feedstock token")
-            return True
+            pass
 
     return False
 
@@ -256,51 +266,60 @@ def is_valid_feedstock_output(project, outputs, register=True):
     valid = {o: False for o in outputs}
     made_commit = False
 
-    with tmp_directory() as tmpdir, pushd(tmpdir):
-        _run_git_command("clone", "--depth=1", OUTPUTS_REPO)
+    tmpdir = None
+    try:
+        tmpdir = tempfile.mkdtemp('_recipe')
+        repo_path = os.path.join(tmpdir, "feedstock-outputs")
 
-        with pushd("feedstock-outputs"):
-            _run_git_command(
-                "remote",
-                "set-url",
-                "--push",
-                "origin",
-                OUTPUTS_REPO)
+        _run_git_command("clone", "--depth=1", OUTPUTS_REPO, repo_path)
 
-            for dist in outputs:
-                try:
-                    _, o, _, _ = parse_conda_pkg(dist)
-                except RuntimeError:
-                    continue
+        _run_git_command(
+            "remote",
+            "set-url",
+            "--push",
+            "origin",
+            OUTPUTS_REPO,
+            cwd=repo_path)
 
-                pth = os.path.join("outputs", o + ".json")
+        for dist in outputs:
+            try:
+                _, o, _, _ = parse_conda_pkg(dist)
+            except RuntimeError:
+                continue
 
-                if not os.path.exists(pth):
-                    # no output exists, so we can add it
-                    valid[dist] = True
+            pth = os.path.join("outputs", o + ".json")
 
-                    print("    does not exist|valid: %s|%s" % (o, valid[dist]))
-                    if register:
-                        print("    registered:", o)
-                        with open(pth, "w") as fp:
-                            json.dump({"feedstocks": [feedstock]}, fp)
-                        _run_git_command("add", pth)
-                        _run_git_command(
-                            "commit",
-                            "-m",
-                            "'added output %s for conda-forge/%s'" % (o, feedstock),
-                        )
-                        made_commit = True
-                else:
-                    # make sure feedstock is ok
-                    with open(pth, "r") as fp:
-                        data = json.load(fp)
-                    valid[dist] = feedstock in data["feedstocks"]
-                    print("    checked|valid: %s|%s" % (o, valid[dist]))
+            if not os.path.exists(pth):
+                # no output exists, so we can add it
+                valid[dist] = True
 
-            if register and made_commit:
-                _run_git_command("pull", "--commit", "--rebase")
-                _run_git_command("push")
+                print("    does not exist|valid: %s|%s" % (o, valid[dist]))
+                if register:
+                    print("    registered:", o)
+                    with open(pth, "w") as fp:
+                        json.dump({"feedstocks": [feedstock]}, fp)
+                    _run_git_command("add", pth, cwd=repo_path)
+                    _run_git_command(
+                        "commit",
+                        "-m",
+                        "'added output %s for conda-forge/%s'" % (o, feedstock),
+                        cwd=repo_path
+                    )
+                    made_commit = True
+            else:
+                # make sure feedstock is ok
+                with open(pth, "r") as fp:
+                    data = json.load(fp)
+                valid[dist] = feedstock in data["feedstocks"]
+                print("    checked|valid: %s|%s" % (o, valid[dist]))
+
+        if register and made_commit:
+            _run_git_command("pull", "--commit", "--rebase", cwd=repo_path)
+            _run_git_command("push", cwd=repo_path)
+
+    finally:
+        if tmpdir is not None:
+            shutil.rmtree(tmpdir)
 
     return valid
 

--- a/conda_forge_webservices/feedstocks_service.py
+++ b/conda_forge_webservices/feedstocks_service.py
@@ -2,9 +2,11 @@ import git
 import jinja2
 import os
 import time
+import tempfile
+import shutil
 
 from collections import namedtuple
-from .utils import tmp_directory
+# from .utils import tmp_directory
 
 
 def handle_feedstock_event(org_name, repo_name):
@@ -18,7 +20,10 @@ def handle_feedstock_event(org_name, repo_name):
 
 
 def update_listing():
-    with tmp_directory() as tmp_dir:
+    tmp_dir = None
+    try:
+        tmp_dir = tempfile.mkdtemp('_recipe')
+
         t0 = time.time()
         webpage_url = (
             "https://github.com/conda-forge/conda-forge.github.io.git"
@@ -97,11 +102,18 @@ def update_listing():
             feedstocks_page_repo.remote().push()
         print("    listing push:", time.time() - t0)
 
+    finally:
+        if tmp_dir is not None:
+            shutil.rmtree(tmp_dir)
+
 
 def update_feedstock(org_name, repo_name):
     name = repo_name[:-len("-feedstock")]
 
-    with tmp_directory() as tmp_dir:
+    tmp_dir = None
+    try:
+        tmp_dir = tempfile.mkdtemp('_recipe')
+
         t0 = time.time()
         feedstocks_url = (
             "https://{}@github.com/conda-forge/feedstocks.git"
@@ -147,6 +159,10 @@ def update_feedstock(org_name, repo_name):
             feedstocks_repo.remote().pull(rebase=True)
             feedstocks_repo.remote().push()
         print("    update push:", time.time() - t0)
+
+    finally:
+        if tmp_dir is not None:
+            shutil.rmtree(tmp_dir)
 
 
 if __name__ == '__main__':

--- a/conda_forge_webservices/tests/test_commands.py
+++ b/conda_forge_webservices/tests/test_commands.py
@@ -46,13 +46,13 @@ class TestCommands(unittest.TestCase):
     @mock.patch('conda_forge_webservices.commands.update_team')
     @mock.patch('conda_forge_webservices.commands.update_circle')
     @mock.patch('conda_forge_webservices.commands.update_cb3')
-    @mock.patch('conda_forge_webservices.commands.tmp_directory')
+    @mock.patch('conda_forge_webservices.commands.tempfile.mkdtemp')
     @mock.patch('github.Github')
     @mock.patch('conda_forge_webservices.commands.Repo')
     def test_pr_command_triggers(
             self, repo, gh, tmp_directory, update_cb3, update_circle,
             update_team, relint, make_noarch, rerender, add_bot_rerun_label):
-        tmp_directory.return_value.__enter__.return_value = '/tmp'
+        tmp_directory.return_value = '/tmp'
         update_cb3.return_value = (True, "hi")
 
         commands = [
@@ -160,14 +160,14 @@ class TestCommands(unittest.TestCase):
     @mock.patch('conda_forge_webservices.commands.update_team')
     @mock.patch('conda_forge_webservices.commands.update_circle')
     @mock.patch('conda_forge_webservices.commands.update_cb3')
-    @mock.patch('conda_forge_webservices.commands.tmp_directory')
+    @mock.patch('conda_forge_webservices.commands.tempfile.mkdtemp')
     @mock.patch('github.Github')
     @mock.patch('conda_forge_webservices.commands.Repo')
     def test_issue_command_triggers(
             self, git_repo, gh, tmp_directory, update_cb3, update_circle,
             update_team, relint, make_noarch, rerender, add_bot_automerge,
             rerender_dummy_commit, add_py):
-        tmp_directory.return_value.__enter__.return_value = '/tmp'
+        tmp_directory.return_value = '/tmp'
         update_cb3.return_value = (True, "hi")
         add_py.return_value = True
 
@@ -345,13 +345,13 @@ class TestCommands(unittest.TestCase):
     @mock.patch('conda_forge_webservices.commands.update_team')
     @mock.patch('conda_forge_webservices.commands.update_circle')
     @mock.patch('conda_forge_webservices.commands.update_cb3')
-    @mock.patch('conda_forge_webservices.commands.tmp_directory')
+    @mock.patch('conda_forge_webservices.commands.tempfile.mkdtemp')
     @mock.patch('github.Github')
     @mock.patch('conda_forge_webservices.commands.Repo')
     def test_rerender_failure(
             self, repo, gh, tmp_directory, update_cb3, update_circle,
             update_team, relint, make_noarch, rerender):
-        tmp_directory.return_value.__enter__.return_value = '/tmp'
+        tmp_directory.return_value = '/tmp'
         rerender.side_effect = RequestException
 
         repo = gh.return_value.get_repo.return_value

--- a/conda_forge_webservices/tests/test_commands.py
+++ b/conda_forge_webservices/tests/test_commands.py
@@ -46,13 +46,11 @@ class TestCommands(unittest.TestCase):
     @mock.patch('conda_forge_webservices.commands.update_team')
     @mock.patch('conda_forge_webservices.commands.update_circle')
     @mock.patch('conda_forge_webservices.commands.update_cb3')
-    @mock.patch('conda_forge_webservices.commands.tempfile.mkdtemp')
     @mock.patch('github.Github')
     @mock.patch('conda_forge_webservices.commands.Repo')
     def test_pr_command_triggers(
-            self, repo, gh, tmp_directory, update_cb3, update_circle,
+            self, repo, gh, update_cb3, update_circle,
             update_team, relint, make_noarch, rerender, add_bot_rerun_label):
-        tmp_directory.return_value = '/tmp'
         update_cb3.return_value = (True, "hi")
 
         commands = [
@@ -160,14 +158,12 @@ class TestCommands(unittest.TestCase):
     @mock.patch('conda_forge_webservices.commands.update_team')
     @mock.patch('conda_forge_webservices.commands.update_circle')
     @mock.patch('conda_forge_webservices.commands.update_cb3')
-    @mock.patch('conda_forge_webservices.commands.tempfile.mkdtemp')
     @mock.patch('github.Github')
     @mock.patch('conda_forge_webservices.commands.Repo')
     def test_issue_command_triggers(
-            self, git_repo, gh, tmp_directory, update_cb3, update_circle,
+            self, git_repo, gh, update_cb3, update_circle,
             update_team, relint, make_noarch, rerender, add_bot_automerge,
             rerender_dummy_commit, add_py):
-        tmp_directory.return_value = '/tmp'
         update_cb3.return_value = (True, "hi")
         add_py.return_value = True
 
@@ -345,13 +341,11 @@ class TestCommands(unittest.TestCase):
     @mock.patch('conda_forge_webservices.commands.update_team')
     @mock.patch('conda_forge_webservices.commands.update_circle')
     @mock.patch('conda_forge_webservices.commands.update_cb3')
-    @mock.patch('conda_forge_webservices.commands.tempfile.mkdtemp')
     @mock.patch('github.Github')
     @mock.patch('conda_forge_webservices.commands.Repo')
     def test_rerender_failure(
-            self, repo, gh, tmp_directory, update_cb3, update_circle,
+            self, repo, gh, update_cb3, update_circle,
             update_team, relint, make_noarch, rerender):
-        tmp_directory.return_value = '/tmp'
         rerender.side_effect = RequestException
 
         repo = gh.return_value.get_repo.return_value

--- a/conda_forge_webservices/tests/test_feedstock_outputs.py
+++ b/conda_forge_webservices/tests/test_feedstock_outputs.py
@@ -220,14 +220,12 @@ def test_is_valid_output_hash():
 @pytest.mark.parametrize(
     "project", ["foo", "foo-feedstock", "blah", "blarg", "boo"]
 )
-@mock.patch("conda_forge_webservices.feedstock_outputs.tmp_directory")
+@mock.patch("conda_forge_webservices.feedstock_outputs.tempfile.mkdtemp")
 @mock.patch("conda_forge_webservices.feedstock_outputs._run_git_command")
 def test_is_valid_feedstock_output(
     git_mock, tmp_mock, tmpdir, monkeypatch, project, register
 ):
-    tmp_mock.return_value.__enter__.return_value = str(
-        tmpdir
-    )
+    tmp_mock.return_value = tmpdir
     monkeypatch.setenv("GH_TOKEN", "abc123")
     os.makedirs(os.path.join(tmpdir, "feedstock-outputs", "outputs"), exist_ok=True)
     with open(


### PR DESCRIPTION
I am seeing odd errors where it appears one thread picks up at a yield statement but has forgotten is current working dir. I think this comes down to the use of relative paths w/ pushd. I am trying a fix here where we only use `try...finally` and no pushd calls.

<!--
Thank you for the pull request. This repo's testing mechanism requires that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

If you have push access to this repo, please push directly to a branch in this repo and create
a PR from that branch

If you do not have push access to this repo, create a PR from your fork's branch and ask the
conda-forge/core team to push your commits to a branch on this repo. 

Note that the tests will not pass until the branch is on the main repo and not your fork!
-->

Checklist
* [x] Pushed the branch to main repo
* [x] CI passed on the branch

