### PR TITLE
ENH add appveyor is ok list handling

### DIFF
--- a/conda_forge_webservices/feedstock_outputs.py
+++ b/conda_forge_webservices/feedstock_outputs.py
@@ -284,8 +284,10 @@ def is_valid_feedstock_output(
         A dict keyed on output name with True if it is valid and False
         otherwise.
     """
-    assert feedstock.endswith("-feedstock")
-    feedstock = project[:-len("-feedstock")]
+    if project.endswith("-feedstock"):
+        feedstock = project[:-len("-feedstock")]
+    else:
+        feedstock = project
 
     valid = {o: False for o in outputs}
     made_commit = False

--- a/conda_forge_webservices/feedstock_outputs.py
+++ b/conda_forge_webservices/feedstock_outputs.py
@@ -284,6 +284,7 @@ def is_valid_feedstock_output(
         A dict keyed on output name with True if it is valid and False
         otherwise.
     """
+    assert feedstock.endswith("-feedstock")
     feedstock = project[:-len("-feedstock")]
 
     valid = {o: False for o in outputs}

--- a/conda_forge_webservices/feedstock_outputs.py
+++ b/conda_forge_webservices/feedstock_outputs.py
@@ -284,7 +284,7 @@ def is_valid_feedstock_output(
         A dict keyed on output name with True if it is valid and False
         otherwise.
     """
-    feedstock = project.replace("-feedstock", "")
+    feedstock = project[:-len("-feedstock")]
 
     valid = {o: False for o in outputs}
     made_commit = False

--- a/conda_forge_webservices/feedstock_outputs.py
+++ b/conda_forge_webservices/feedstock_outputs.py
@@ -394,7 +394,7 @@ def validate_feedstock_outputs(
     valid_outputs = is_valid_feedstock_output(
         project,
         outputs_to_test,
-        register=True,
+        register=not win_only,
     )
 
     valid_hashes = _is_valid_output_hash(outputs_to_test)

--- a/conda_forge_webservices/tests/test_feedstock_outputs.py
+++ b/conda_forge_webservices/tests/test_feedstock_outputs.py
@@ -116,35 +116,9 @@ def test_copy_feedstock_outputs_does_no_exist(
 
 @mock.patch("conda_forge_webservices.feedstock_outputs._is_valid_output_hash")
 @mock.patch("conda_forge_webservices.feedstock_outputs.is_valid_feedstock_output")
-@mock.patch("conda_forge_webservices.feedstock_outputs.is_valid_feedstock_token")
-def test_validate_feedstock_outputs_badtoken(
-    valid_token, valid_out, valid_hash
-):
-    valid_token.return_value = False
-    valid, errs = validate_feedstock_outputs(
-        "bar-feedstock",
-        {
-            "noarch/a-0.1-py_0.tar.bz2": "sadas",
-            "noarch/b-0.2-py_0.tar.bz2": "sadKJHSAL",
-        },
-        "abc",
-        False,
-    )
-
-    assert not any(v for v in valid.values())
-    assert ["invalid feedstock token"] == errs
-
-    valid_out.assert_not_called()
-    valid_hash.assert_not_called()
-
-
-@mock.patch("conda_forge_webservices.feedstock_outputs._is_valid_output_hash")
-@mock.patch("conda_forge_webservices.feedstock_outputs.is_valid_feedstock_output")
-@mock.patch("conda_forge_webservices.feedstock_outputs.is_valid_feedstock_token")
 def test_validate_feedstock_outputs_badoutputhash(
-    valid_token, valid_out, valid_hash
+    valid_out, valid_hash
 ):
-    valid_token.return_value = True
     valid_out.return_value = {
         "noarch/a-0.1-py_0.tar.bz2": True,
         "noarch/b-0.1-py_0.tar.bz2": False,
@@ -188,11 +162,9 @@ def test_validate_feedstock_outputs_badoutputhash(
 
 @mock.patch("conda_forge_webservices.feedstock_outputs._is_valid_output_hash")
 @mock.patch("conda_forge_webservices.feedstock_outputs.is_valid_feedstock_output")
-@mock.patch("conda_forge_webservices.feedstock_outputs.is_valid_feedstock_token")
 def test_validate_feedstock_outputs_winonly(
-    valid_token, valid_out, valid_hash
+    valid_out, valid_hash
 ):
-    valid_token.return_value = True
     valid_out.return_value = {
         "noarch/a-0.1-py_0.tar.bz2": True,
         "noarch/b-0.1-py_0.tar.bz2": True,

--- a/conda_forge_webservices/tests/test_feedstock_outputs.py
+++ b/conda_forge_webservices/tests/test_feedstock_outputs.py
@@ -244,7 +244,7 @@ def test_is_valid_output_hash():
 @pytest.mark.parametrize("must_explicitly_exist", [True, False])
 @pytest.mark.parametrize("register", [True, False])
 @pytest.mark.parametrize(
-    "project", ["foo", "foo-feedstock", "blah", "blarg", "boo"]
+    "project", ["foo-feedstock", "blah-feedstock", "blarg-feedstock", "boo-feedstock"]
 )
 @mock.patch("conda_forge_webservices.feedstock_outputs.shutil.rmtree")
 @mock.patch("conda_forge_webservices.feedstock_outputs.tempfile.mkdtemp")

--- a/conda_forge_webservices/tests/test_feedstock_outputs.py
+++ b/conda_forge_webservices/tests/test_feedstock_outputs.py
@@ -193,7 +193,7 @@ def test_validate_feedstock_outputs_winonly(
 
     valid_out.assert_any_call(
         "bar-feedstock",
-        list(hashes.keys()),
+        hashes,
         register=False,
     )
 

--- a/conda_forge_webservices/tests/test_feedstock_outputs.py
+++ b/conda_forge_webservices/tests/test_feedstock_outputs.py
@@ -244,7 +244,7 @@ def test_is_valid_output_hash():
 @pytest.mark.parametrize("must_explicitly_exist", [True, False])
 @pytest.mark.parametrize("register", [True, False])
 @pytest.mark.parametrize(
-    "project", ["foo-feedstock", "blah-feedstock", "blarg-feedstock", "boo-feedstock"]
+    "project", ["foo-feedstock", "blah", "foo", "blarg-feedstock", "boo-feedstock"]
 )
 @mock.patch("conda_forge_webservices.feedstock_outputs.shutil.rmtree")
 @mock.patch("conda_forge_webservices.feedstock_outputs.tempfile.mkdtemp")

--- a/conda_forge_webservices/tests/test_feedstock_outputs.py
+++ b/conda_forge_webservices/tests/test_feedstock_outputs.py
@@ -177,16 +177,24 @@ def test_validate_feedstock_outputs_winonly(
         "noarch/c-0.1-py_0.tar.bz2": True,
         "win-64/d-0.1-py_0.tar.bz2": True,
     }
+    hashes = {
+        "noarch/a-0.1-py_0.tar.bz2": "daD",
+        "noarch/b-0.1-py_0.tar.bz2": "safdsa",
+        "noarch/c-0.1-py_0.tar.bz2": "sadSA",
+        "win-64/d-0.1-py_0.tar.bz2": "SAdsa",
+    }
+
     valid, errs = validate_feedstock_outputs(
         "bar-feedstock",
-        {
-            "noarch/a-0.1-py_0.tar.bz2": "daD",
-            "noarch/b-0.1-py_0.tar.bz2": "safdsa",
-            "noarch/c-0.1-py_0.tar.bz2": "sadSA",
-            "win-64/d-0.1-py_0.tar.bz2": "SAdsa",
-        },
+        hashes,
         "abc",
         True,
+    )
+
+    valid_out.assert_any_call(
+        "bar-feedstock",
+        list(hashes.keys()),
+        register=False,
     )
 
     assert valid == {

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -562,6 +562,7 @@ class OutputsCopyHandler(tornado.web.RequestHandler):
             ):
                 win_only = False
             else:
+                assert feedstock in appveyor_ok_list
                 # we have authenticated with the appveyor token, so we
                 # can only upload win packages
                 win_only = True

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -547,6 +547,7 @@ class OutputsCopyHandler(tornado.web.RequestHandler):
             or feedstock is None
             or outputs is None
             or channel is None
+            or not _repo_exists(feedstock)
             or not (
                 is_valid_feedstock_token(
                     "conda-forge", feedstock, feedstock_token, TOKENS_REPO)

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -563,8 +563,8 @@ class OutputsCopyHandler(tornado.web.RequestHandler):
                 win_only = False
             else:
                 assert feedstock in appveyor_ok_list
-                # we have authenticated with the appveyor token, so we
-                # can only upload win packages
+                # we did not have a correct token but we are in the list, so
+                # win only
                 win_only = True
 
             valid, errors = await tornado.ioloop.IOLoop.current().run_in_executor(

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -600,8 +600,9 @@ class OutputsCopyHandler(tornado.web.RequestHandler):
 
             self.write(json.dumps({"errors": errors, "valid": valid, "copied": copied}))
 
-            LOGGER.info("    errors: %s\n    valid: %s\n    copied: %s" % (
-                errors, valid, copied))
+            LOGGER.info("    errors: %s", errors)
+            LOGGER.info("    valid: %s", valid)
+            LOGGER.info("    copied: %s", copied)
 
         return
 

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -543,14 +543,17 @@ class OutputsCopyHandler(tornado.web.RequestHandler):
         LOGGER.info("===================================================")
 
         if (
-            feedstock_token is None
-            or feedstock is None
+            feedstock is None
             or outputs is None
             or channel is None
+            or len(feedstock) == 0
             or not _repo_exists(feedstock)
             or not (
-                is_valid_feedstock_token(
-                    "conda-forge", feedstock, feedstock_token, TOKENS_REPO)
+                (
+                    feedstock_token is not None
+                    and is_valid_feedstock_token(
+                        "conda-forge", feedstock, feedstock_token, TOKENS_REPO)
+                )
                 or feedstock in appveyor_ok_list
             )
         ):
@@ -623,6 +626,8 @@ class RegisterFeedstockTokenHandler(tornado.web.RequestHandler):
         if (
             feedstock_token is None
             or feedstock is None
+            or len(feedstock) == 0
+            or not _repo_exists(feedstock)
             or not is_valid_feedstock_token(
                 "conda-forge", "staged-recipes", feedstock_token, TOKENS_REPO)
         ):

--- a/scripts/test_cfep13_endpoints.py
+++ b/scripts/test_cfep13_endpoints.py
@@ -157,6 +157,20 @@ def test_feedstock_outputs_copy_bad_token():
     assert r.status_code == 403, r.status_code
 
 
+def test_feedstock_outputs_copy_appveyor_ok_list():
+    r = requests.post(
+        "http://127.0.0.1:5000/feedstock-outputs/copy",
+        headers=headers,  # this has the staged recipes token
+        json={
+            "feedstock": "python-feedstock",
+            "outputs": {},
+            "channel": "main",
+        },
+    )
+
+    assert r.status_code == 200, r.status_code
+
+
 def test_feedstock_outputs_copy_missing_token():
     r = requests.post(
         "http://127.0.0.1:5000/feedstock-outputs/copy",


### PR DESCRIPTION
This PR implements the appveyor is ok list.

We do the following

1. For any feedstock in the whitelist, they can make copy requests without a valid feedstock token.
2. These requests cannot create new outputs that have not already been registered.
3. These requests only work on win-64.

<!--
Thank you for the pull request. This repo's testing mechanism requires that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

If you have push access to this repo, please push directly to a branch in this repo and create
a PR from that branch

If you do not have push access to this repo, create a PR from your fork's branch and ask the
conda-forge/core team to push your commits to a branch on this repo. 

Note that the tests will not pass until the branch is on the main repo and not your fork!
-->

Checklist
* [x] Pushed the branch to main repo
* [x] CI passed on the branch

