### PR TITLE
BUG do not change sys.stderr or sys.stdout when threading

### DIFF
--- a/conda_forge_webservices/feedstock_outputs.py
+++ b/conda_forge_webservices/feedstock_outputs.py
@@ -284,7 +284,7 @@ def is_valid_feedstock_output(
         A dict keyed on output name with True if it is valid and False
         otherwise.
     """
-    feedstock = project.replace("-feedstock", "")
+    feedstock = project[:-len("-feedstock")]
 
     valid = {o: False for o in outputs}
     made_commit = False

--- a/conda_forge_webservices/feedstock_outputs.py
+++ b/conda_forge_webservices/feedstock_outputs.py
@@ -394,7 +394,7 @@ def validate_feedstock_outputs(
     valid_outputs = is_valid_feedstock_output(
         project,
         outputs_to_test,
-        register=True,
+        register=not win_only,
     )
 
     valid_hashes = _is_valid_output_hash(outputs_to_test)

--- a/conda_forge_webservices/tests/test_feedstock_outputs.py
+++ b/conda_forge_webservices/tests/test_feedstock_outputs.py
@@ -116,35 +116,9 @@ def test_copy_feedstock_outputs_does_no_exist(
 
 @mock.patch("conda_forge_webservices.feedstock_outputs._is_valid_output_hash")
 @mock.patch("conda_forge_webservices.feedstock_outputs.is_valid_feedstock_output")
-@mock.patch("conda_forge_webservices.feedstock_outputs.is_valid_feedstock_token")
-def test_validate_feedstock_outputs_badtoken(
-    valid_token, valid_out, valid_hash
-):
-    valid_token.return_value = False
-    valid, errs = validate_feedstock_outputs(
-        "bar-feedstock",
-        {
-            "noarch/a-0.1-py_0.tar.bz2": "sadas",
-            "noarch/b-0.2-py_0.tar.bz2": "sadKJHSAL",
-        },
-        "abc",
-        False,
-    )
-
-    assert not any(v for v in valid.values())
-    assert ["invalid feedstock token"] == errs
-
-    valid_out.assert_not_called()
-    valid_hash.assert_not_called()
-
-
-@mock.patch("conda_forge_webservices.feedstock_outputs._is_valid_output_hash")
-@mock.patch("conda_forge_webservices.feedstock_outputs.is_valid_feedstock_output")
-@mock.patch("conda_forge_webservices.feedstock_outputs.is_valid_feedstock_token")
 def test_validate_feedstock_outputs_badoutputhash(
-    valid_token, valid_out, valid_hash
+    valid_out, valid_hash
 ):
-    valid_token.return_value = True
     valid_out.return_value = {
         "noarch/a-0.1-py_0.tar.bz2": True,
         "noarch/b-0.1-py_0.tar.bz2": False,
@@ -188,11 +162,9 @@ def test_validate_feedstock_outputs_badoutputhash(
 
 @mock.patch("conda_forge_webservices.feedstock_outputs._is_valid_output_hash")
 @mock.patch("conda_forge_webservices.feedstock_outputs.is_valid_feedstock_output")
-@mock.patch("conda_forge_webservices.feedstock_outputs.is_valid_feedstock_token")
 def test_validate_feedstock_outputs_winonly(
-    valid_token, valid_out, valid_hash
+    valid_out, valid_hash
 ):
-    valid_token.return_value = True
     valid_out.return_value = {
         "noarch/a-0.1-py_0.tar.bz2": True,
         "noarch/b-0.1-py_0.tar.bz2": True,

--- a/conda_forge_webservices/tests/test_feedstock_outputs.py
+++ b/conda_forge_webservices/tests/test_feedstock_outputs.py
@@ -244,7 +244,7 @@ def test_is_valid_output_hash():
 @pytest.mark.parametrize("must_explicitly_exist", [True, False])
 @pytest.mark.parametrize("register", [True, False])
 @pytest.mark.parametrize(
-    "project", ["foo", "foo-feedstock", "blah", "blarg", "boo"]
+    "project", ["foo-feedstock", "blah-feedstock", "blarg-feedstock", "boo-feedstock"]
 )
 @mock.patch("conda_forge_webservices.feedstock_outputs.shutil.rmtree")
 @mock.patch("conda_forge_webservices.feedstock_outputs.tempfile.mkdtemp")

--- a/conda_forge_webservices/tests/test_feedstock_outputs.py
+++ b/conda_forge_webservices/tests/test_feedstock_outputs.py
@@ -193,7 +193,7 @@ def test_validate_feedstock_outputs_winonly(
 
     valid_out.assert_any_call(
         "bar-feedstock",
-        list(hashes.keys()),
+        hashes,
         register=False,
     )
 

--- a/conda_forge_webservices/tests/test_feedstock_outputs.py
+++ b/conda_forge_webservices/tests/test_feedstock_outputs.py
@@ -177,16 +177,24 @@ def test_validate_feedstock_outputs_winonly(
         "noarch/c-0.1-py_0.tar.bz2": True,
         "win-64/d-0.1-py_0.tar.bz2": True,
     }
+    hashes = {
+        "noarch/a-0.1-py_0.tar.bz2": "daD",
+        "noarch/b-0.1-py_0.tar.bz2": "safdsa",
+        "noarch/c-0.1-py_0.tar.bz2": "sadSA",
+        "win-64/d-0.1-py_0.tar.bz2": "SAdsa",
+    }
+
     valid, errs = validate_feedstock_outputs(
         "bar-feedstock",
-        {
-            "noarch/a-0.1-py_0.tar.bz2": "daD",
-            "noarch/b-0.1-py_0.tar.bz2": "safdsa",
-            "noarch/c-0.1-py_0.tar.bz2": "sadSA",
-            "win-64/d-0.1-py_0.tar.bz2": "SAdsa",
-        },
+        hashes,
         "abc",
         True,
+    )
+
+    valid_out.assert_any_call(
+        "bar-feedstock",
+        list(hashes.keys()),
+        register=False,
     )
 
     assert valid == {

--- a/conda_forge_webservices/update_teams.py
+++ b/conda_forge_webservices/update_teams.py
@@ -3,10 +3,6 @@ import github
 import os
 import shutil
 import tempfile
-import io
-import logging
-
-from contextlib import redirect_stderr, redirect_stdout
 
 # from .utils import tmp_directory
 from conda_smithy.github import configure_github_team
@@ -14,8 +10,6 @@ import textwrap
 from functools import lru_cache
 
 from ruamel.yaml import YAML
-
-LOGGER = logging.getLogger("conda_forge_webservices.update_teams")
 
 
 @lru_cache(maxsize=None)
@@ -72,19 +66,16 @@ def update_team(org_name, repo_name, commit=None):
                     keep_lines.append(line)
         meta = DummyMeta("".join(keep_lines))
 
-        with io.StringIO() as buf, redirect_stdout(buf), redirect_stderr(buf):
-            (
-                current_maintainers,
-                prev_maintainers,
-                new_conda_forge_members,
-            ) = configure_github_team(
-                meta,
-                gh_repo,
-                org,
-                repo_name.replace("-feedstock", ""),
-            )
-
-            LOGGER.info(buf.getvalue())
+        (
+            current_maintainers,
+            prev_maintainers,
+            new_conda_forge_members,
+        ) = configure_github_team(
+            meta,
+            gh_repo,
+            org,
+            repo_name.replace("-feedstock", ""),
+        )
 
         if commit:
             message = textwrap.dedent("""

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -20,13 +20,12 @@ import conda_forge_webservices.feedstocks_service as feedstocks_service
 import conda_forge_webservices.update_teams as update_teams
 import conda_forge_webservices.commands as commands
 from conda_forge_webservices.update_me import get_current_versions
-from conda_smithy.feedstock_tokens import is_valid_feedstock_token
 from conda_forge_webservices.feedstock_outputs import (
-    TOKENS_REPO,
     register_feedstock_token_handler,
     validate_feedstock_outputs,
     copy_feedstock_outputs,
     is_valid_feedstock_output,
+    is_valid_feedstock_token_process,
 )
 
 LOGGER = logging.getLogger("conda_forge_webservices")
@@ -548,8 +547,8 @@ class OutputsCopyHandler(tornado.web.RequestHandler):
             or outputs is None
             or channel is None
             or not (
-                is_valid_feedstock_token(
-                    "conda-forge", feedstock, feedstock_token, TOKENS_REPO)
+                is_valid_feedstock_token_process(
+                    "conda-forge", feedstock, feedstock_token)
                 or feedstock in appveyor_ok_list
             )
         ):
@@ -557,8 +556,8 @@ class OutputsCopyHandler(tornado.web.RequestHandler):
             self.set_status(403)
             self.write_error(403)
         else:
-            if is_valid_feedstock_token(
-                "conda-forge", feedstock, feedstock_token, TOKENS_REPO
+            if is_valid_feedstock_token_process(
+                "conda-forge", feedstock, feedstock_token
             ):
                 win_only = False
             else:
@@ -622,8 +621,8 @@ class RegisterFeedstockTokenHandler(tornado.web.RequestHandler):
         if (
             feedstock_token is None
             or feedstock is None
-            or not is_valid_feedstock_token(
-                "conda-forge", "staged-recipes", feedstock_token, TOKENS_REPO)
+            or not is_valid_feedstock_token_process(
+                "conda-forge", "staged-recipes", feedstock_token)
         ):
             LOGGER.warning('    invalid token registration request for %s!' % feedstock)
             self.set_status(403)

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -561,7 +561,7 @@ class OutputsCopyHandler(tornado.web.RequestHandler):
             self.write_error(403)
         else:
             if is_valid_feedstock_token_process(
-                "conda-forge", feedstock, feedstock_token, TOKENS_REPO
+                "conda-forge", feedstock, feedstock_token,
             ):
                 win_only = False
             else:

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -562,6 +562,7 @@ class OutputsCopyHandler(tornado.web.RequestHandler):
             ):
                 win_only = False
             else:
+                assert feedstock in appveyor_ok_list
                 # we have authenticated with the appveyor token, so we
                 # can only upload win packages
                 win_only = True

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -547,13 +547,15 @@ class OutputsCopyHandler(tornado.web.RequestHandler):
             or channel is None
             or len(feedstock) == 0
             or not _repo_exists(feedstock)
+            or feedstock_token is None
             or not (
-                (
-                    feedstock_token is not None
+                is_valid_feedstock_token_process(
+                    "conda-forge", feedstock, feedstock_token)
+                or (
+                    feedstock in appveyor_ok_list
                     and is_valid_feedstock_token_process(
-                        "conda-forge", feedstock, feedstock_token)
+                        "conda-forge", "appveyor-is-ok", feedstock_token)
                 )
-                or feedstock in appveyor_ok_list
             )
         ):
             LOGGER.warning('    invalid outputs copy request for %s!' % feedstock)
@@ -566,6 +568,9 @@ class OutputsCopyHandler(tornado.web.RequestHandler):
                 win_only = False
             else:
                 assert feedstock in appveyor_ok_list
+                assert is_valid_feedstock_token_process(
+                    "conda-forge", "appveyor-is-ok", feedstock_token
+                )
                 # we did not have a correct token but we are in the list, so
                 # win only
                 win_only = True

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -563,8 +563,8 @@ class OutputsCopyHandler(tornado.web.RequestHandler):
                 win_only = False
             else:
                 assert feedstock in appveyor_ok_list
-                # we have authenticated with the appveyor token, so we
-                # can only upload win packages
+                # we did not have a correct token but we are in the list, so
+                # win only
                 win_only = True
 
             valid, errors = await tornado.ioloop.IOLoop.current().run_in_executor(

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -600,8 +600,9 @@ class OutputsCopyHandler(tornado.web.RequestHandler):
 
             self.write(json.dumps({"errors": errors, "valid": valid, "copied": copied}))
 
-            LOGGER.info("    errors: %s\n    valid: %s\n    copied: %s" % (
-                errors, valid, copied))
+            LOGGER.info("    errors: %s", errors)
+            LOGGER.info("    valid: %s", valid)
+            LOGGER.info("    copied: %s", copied)
 
         return
 

--- a/scripts/test_cfep13_copy.py
+++ b/scripts/test_cfep13_copy.py
@@ -40,7 +40,7 @@ from conda_forge_webservices.feedstock_outputs import (
     _get_ac_api_staging
 )
 
-token_path = "${HOME}/.conda-smithy/conda-forge_staged-recipes_feedstock.token"
+token_path = "${HOME}/.conda-smithy/conda-forge_staged-recipes.token"
 with open(os.path.expandvars(token_path), "r") as fp:
     sr_token = fp.read().strip()
 

--- a/scripts/test_cfep13_endpoints.py
+++ b/scripts/test_cfep13_endpoints.py
@@ -157,6 +157,20 @@ def test_feedstock_outputs_copy_bad_token():
     assert r.status_code == 403, r.status_code
 
 
+def test_feedstock_outputs_copy_appveyor_ok_list():
+    r = requests.post(
+        "http://127.0.0.1:5000/feedstock-outputs/copy",
+        headers=headers,  # this has the staged recipes token
+        json={
+            "feedstock": "python-feedstock",
+            "outputs": {},
+            "channel": "main",
+        },
+    )
+
+    assert r.status_code == 200, r.status_code
+
+
 def test_feedstock_outputs_copy_missing_token():
     r = requests.post(
         "http://127.0.0.1:5000/feedstock-outputs/copy",

--- a/scripts/test_cfep13_endpoints.py
+++ b/scripts/test_cfep13_endpoints.py
@@ -66,7 +66,7 @@ def _clone_and_remove(repo, file_to_remove):
 
 
 def test_feedstock_tokens_register_works():
-    file_to_remove = "tokens/cf-autotick-bot-test-package.json"
+    file_to_remove = "tokens/cf-autotick-bot-test-package-feedstock.json"
     _clone_and_remove(TOKENS_REPO, file_to_remove)
 
     r = requests.post(

--- a/scripts/test_cfep13_endpoints.py
+++ b/scripts/test_cfep13_endpoints.py
@@ -171,6 +171,25 @@ def test_feedstock_outputs_copy_appveyor_ok_list():
     assert r.status_code == 200, r.status_code
 
 
+def test_feedstock_outputs_copy_appveyor_ok_list_badout():
+    r = requests.post(
+        "http://127.0.0.1:5000/feedstock-outputs/copy",
+        headers=headers,  # this has the staged recipes token
+        json={
+            "feedstock": "python-feedstock",
+            "outputs": {
+                "noarch/cf-autotick-bot-test-package-0.1-py_11.tar.bz2": "ababa",
+            },
+            "channel": "main",
+        },
+    )
+
+    assert r.status_code == 403, r.status_code
+
+    info = r.json()
+    assert any("win-64-only" in e for e in info["errors"])
+
+
 def test_feedstock_outputs_copy_missing_token():
     r = requests.post(
         "http://127.0.0.1:5000/feedstock-outputs/copy",

--- a/scripts/test_cfep13_endpoints.py
+++ b/scripts/test_cfep13_endpoints.py
@@ -190,6 +190,26 @@ def test_feedstock_outputs_copy_appveyor_ok_list_badout():
     assert any("win-64-only" in e for e in info["errors"])
 
 
+def test_feedstock_outputs_copy_appveyor_ok_list_badout_python():
+    r = requests.post(
+        "http://127.0.0.1:5000/feedstock-outputs/copy",
+        headers=headers,  # this has the staged recipes token
+        json={
+            "feedstock": "python-feedstock",
+            "outputs": {
+                "win-64/cf-autotick-bot-test-package-0.1-py_11.tar.bz2": "ababa",
+            },
+            "channel": "main",
+        },
+    )
+
+    assert r.status_code == 403, r.status_code
+
+    info = r.json()
+    assert any(
+        "not allowed for conda-forge/python-feedstock" in e for e in info["errors"])
+
+
 def test_feedstock_outputs_copy_missing_token():
     r = requests.post(
         "http://127.0.0.1:5000/feedstock-outputs/copy",


### PR DESCRIPTION
This PR makes sure to put calls that change stderr or stdout into other python processes so that they do not mess up other threads.

<!--
Thank you for the pull request. This repo's testing mechanism requires that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

If you have push access to this repo, please push directly to a branch in this repo and create
a PR from that branch

If you do not have push access to this repo, create a PR from your fork's branch and ask the
conda-forge/core team to push your commits to a branch on this repo. 

Note that the tests will not pass until the branch is on the main repo and not your fork!
-->

Checklist
* [x] Pushed the branch to main repo
* [x] CI passed on the branch

Do not merge until #373 is done.