### PR TITLE
BUG set proper requirements

### DIFF
--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -3,7 +3,7 @@ black
 conda=4.8
 conda-build
 conda-forge-pinning
-conda-smithy>=3.6.6  # this pin is for bot automerge
+conda-smithy>=3.7.6  # this pin is for bot automerge and maint. team bug fixes
 flake8
 git
 mock

--- a/conda_forge_webservices/update_teams.py
+++ b/conda_forge_webservices/update_teams.py
@@ -64,29 +64,17 @@ def update_team(org_name, repo_name, commit=None):
             keep_lines.append(line)
     meta = DummyMeta("\n".join(keep_lines))
 
-    try:
-        (
-            current_maintainers,
-            prev_maintainers,
-            new_conda_forge_members,
-        ) = configure_github_team(
-            meta,
-            gh_repo,
-            org,
-            repo_name.replace("-feedstock", ""),
-            remove=True,
-        )
-    except TypeError:
-        (
-            current_maintainers,
-            prev_maintainers,
-            new_conda_forge_members,
-        ) = configure_github_team(
-            meta,
-            gh_repo,
-            org,
-            repo_name.replace("-feedstock", ""),
-        )
+    (
+        current_maintainers,
+        prev_maintainers,
+        new_conda_forge_members,
+    ) = configure_github_team(
+        meta,
+        gh_repo,
+        org,
+        repo_name.replace("-feedstock", ""),
+        remove=True,
+    )
 
     if commit:
         message = textwrap.dedent("""


### PR DESCRIPTION
<!--
Thank you for the pull request. This repo's testing mechanism requires that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

If you have push access to this repo, please push directly to a branch in this repo and create
a PR from that branch

If you do not have push access to this repo, create a PR from your fork's branch and ask the
conda-forge/core team to push your commits to a branch on this repo. 

Note that the tests will not pass until the branch is on the main repo and not your fork!
-->

Checklist
* [ ] Pushed the branch to main repo
* [ ] CI passed on the branch

