### PR TITLE
ENH cleanup cron job

### DIFF
--- a/.circleci/clean_cf_staging.py
+++ b/.circleci/clean_cf_staging.py
@@ -1,0 +1,52 @@
+import os
+from datetime import timezone, datetime, timedelta
+
+from dateutil.parser import parse
+import requests
+import urllib
+
+
+def parse_conda_pkg(pkg):
+    """Parse a conda package into its parts.
+    code due to Isuru F. and CJ Wright
+    Returns platform, name, version and build string
+    """
+    if not pkg.endswith(".tar.bz2"):
+        raise RuntimeError("Package must end with .tar.bz2!")
+    pkg = pkg[:-8]
+    plat, pkg_name = pkg.split(os.path.sep)
+    name_ver, build = pkg_name.rsplit('-', 1)
+    name, ver = name_ver.rsplit('-', 1)
+    return plat, name, ver, build
+
+
+if __name__ == "__main__":
+    header = {'Authorization': 'token {}'.format(os.environ["STAGING_BINSTAR_TOKEN"])}
+    rc = requests.get(
+        "https://api.anaconda.org/channels/cf-staging",
+        headers=header
+    )
+
+    now = datetime.utcnow()
+    now = now.replace(tzinfo=timezone.utc)
+
+    for channel in rc.json():
+        r = requests.get(
+            "https://api.anaconda.org/channels/cf-staging/main",
+            headers=header,
+        )
+
+        for f in r.json()['files']:
+            updt = parse(f["upload_time"])
+            dt = now - updt
+            if dt > timedelta(days=5):
+                print("deleting:", f['basename'], dt)
+                _, name, version, _ = parse_conda_pkg(f["basename"])
+                r = requests.delete(
+                    "https://api.anaconda.org/dist/cf-staging/%s/%s/%s" % (
+                        name,
+                        version,
+                        urllib.parse.quote(f["basename"], safe="")
+                    ),
+                    headers=header,
+                )

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,13 @@ jobs:
             source .circleci/install_miniconda.sh
 
       - run:
+          name: clean cf-staging
+          command: |
+            export PATH=${HOME}/miniconda/bin:$PATH
+            source activate base
+            python .circleci/clean_cf_staging.py
+
+      - run:
           name: update
           command: |
             export PATH=${HOME}/miniconda/bin:$PATH
@@ -26,7 +33,7 @@ workflows:
       - build
     triggers:
       - schedule:
-          cron: "0 * * * *"
+          cron: "15 * * * *"
           filters:
             branches:
               only:


### PR DESCRIPTION
<!--
Thank you for the pull request. This repo's testing mechanism requires that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

If you have push access to this repo, please push directly to a branch in this repo and create
a PR from that branch

If you do not have push access to this repo, create a PR from your fork's branch and ask the
conda-forge/core team to push your commits to a branch on this repo. 

Note that the tests will not pass until the branch is on the main repo and not your fork!
-->

Checklist
* [ ] Pushed the branch to main repo
* [ ] CI passed on the branch

This PR adds a cron job that delets outputs on cf-staging that are older than 5 days.
