### PR TITLE
ENH pass extra info to validation service

### DIFF
--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -558,6 +558,8 @@ def _do_copy(feedstock, outputs, channel, git_sha):
                 if not copied[dist]:
                     continue
 
+                _subdir, _pkg = os.path.split(dist)
+
                 if channel == "main":
                     _url = f"https://conda.anaconda.org/cf-staging/{dist}"
                 else:
@@ -571,6 +573,12 @@ def _do_copy(feedstock, outputs, channel, git_sha):
                     {
                         "artifact_url": _url,
                         "md5": outputs_to_copy[dist],
+                        "subdir": _subdir,
+                        "package": _pkg,
+                        "url": _url,
+                        "feedstock": feedstock,
+                        "label": channel,
+                        "git_sha": git_sha,
                     }
                 )
         except Exception as e:


### PR DESCRIPTION
<!--
Thank you for the pull request. This repo's testing mechanism requires that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

If you have push access to this repo, please push directly to a branch in this repo and create
a PR from that branch

If you do not have push access to this repo, create a PR from your fork's branch and ask the
conda-forge/core team to push your commits to a branch on this repo. 

Note that the tests will not pass until the branch is on the main repo and not your fork!
-->

Checklist
* [x] Pushed the branch to main repo
* [x] CI passed on the branch

