### PR TITLE
ENH warn with comment for PRs from branches

### DIFF
--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -71,6 +71,26 @@ def pr_detailed_comment(
     if not (repo_name.endswith("-feedstock") or is_staged_recipes):
         return
 
+    if not is_staged_recipes:
+        gh = github.Github(os.environ['GH_TOKEN'])
+        repo = gh.get_repo("{}/{}".format(org_name, repo_name))
+        pull = repo.get_pull(int(pr_num))
+        if pull.head.repo.full_name.split("/")[0] == "conda-forge":
+            message = textwrap.dedent("""
+                    Hi! This is the friendly automated conda-forge-webservice.
+                    
+                    It appears you are making a pull request from a branch in your feedstock
+                    and not a fork. This procedure will generate a separate build for each 
+                    push to the branch and is thus not allowed. See our [documentation](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
+                    for more details. 
+                    
+                    Please close this pull request and remake it from a fork of this feedstock.
+                    
+                    Have a great day!
+                    """)
+            pull.create_issue_comment(message)
+        
+    
     if not is_staged_recipes and UPDATE_CIRCLECI_KEY_MSG.search(comment):
         update_circle(org_name, repo_name)
 

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -78,19 +78,15 @@ def pr_detailed_comment(
         if pull.head.repo.full_name.split("/")[0] == "conda-forge":
             message = textwrap.dedent("""
                     Hi! This is the friendly automated conda-forge-webservice.
-                    
-                    It appears you are making a pull request from a branch in your feedstock
-                    and not a fork. This procedure will generate a separate build for each 
-                    push to the branch and is thus not allowed. See our [documentation](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
-                    for more details. 
-                    
+
+                    It appears you are making a pull request from a branch in your feedstock and not a fork. This procedure will generate a separate build for each push to the branch and is thus not allowed. See our [documentation](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests) for more details.
+
                     Please close this pull request and remake it from a fork of this feedstock.
-                    
+
                     Have a great day!
-                    """)
+                    """)  # noqa
             pull.create_issue_comment(message)
-        
-    
+
     if not is_staged_recipes and UPDATE_CIRCLECI_KEY_MSG.search(comment):
         update_circle(org_name, repo_name)
 


### PR DESCRIPTION
<!--
Thank you for the pull request. This repo's testing mechanism requires that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

If you have push access to this repo, please push directly to a branch in this repo and create
a PR from that branch

If you do not have push access to this repo, create a PR from your fork's branch and ask the
conda-forge/core team to push your commits to a branch on this repo. 

Note that the tests will not pass until the branch is on the main repo and not your fork!
-->

Checklist
* [x] Pushed the branch to main repo
* [x] CI passed on the branch

