### PR TITLE
ENH remove specific branch name for feedstock outputs

### DIFF
--- a/conda_forge_webservices/feedstock_outputs.py
+++ b/conda_forge_webservices/feedstock_outputs.py
@@ -268,7 +268,6 @@ def _is_valid_feedstock_output(
                                 "[ci skip] [skip ci] [cf admin skip] ***NO_CI*** added "
                                 "output %s for conda-forge/%s" % (un, feedstock)),
                             "content": edata,
-                            "branch": "master",
                         }
                     )
                     if r.status_code != 201:


### PR DESCRIPTION
<!--
Thank you for the pull request. This repo's testing mechanism requires that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

If you have push access to this repo, please push directly to a branch in this repo and create
a PR from that branch

If you do not have push access to this repo, create a PR from your fork's branch and ask the
conda-forge/core team to push your commits to a branch on this repo. 

Note that the tests will not pass until the branch is on the main repo and not your fork!
-->

Checklist
* [x] Pushed the branch to main repo
* [x] CI passed on the branch

This will force github to use the default branch so that when we change it from master to main, it will just work. 