### PR TITLE
ENH add CDN sync message

### DIFF
--- a/conda_forge_webservices/update_teams.py
+++ b/conda_forge_webservices/update_teams.py
@@ -103,12 +103,15 @@ def update_team(org_name, repo_name, commit=None):
         if addm or newm:
             message += textwrap.dedent("""
                 You should get push access to this feedstock and CI services.
+                
+                Your package won't be available for installation locally until it is built
+                and synced to the anaconda.org CDN (takes 1-2 hours after the build).
 
                 Feel free to join the community [chat room](https://gitter.im/conda-forge/conda-forge.github.io).
 
                 NOTE: Please make sure to not push to the repository directly.
                       Use branches in your fork for any changes and send a PR.
-                      More details [here](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
+                      More details on this are [here](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests).
             """)  # noqa
 
             c = gh_repo.get_commit(commit)

--- a/conda_forge_webservices/update_teams.py
+++ b/conda_forge_webservices/update_teams.py
@@ -105,7 +105,7 @@ def update_team(org_name, repo_name, commit=None):
                 You should get push access to this feedstock and CI services.
                 
                 Your package won't be available for installation locally until it is built
-                and synced to the anaconda.org CDN (takes 1-2 hours after the build).
+                and synced to the anaconda.org CDN (takes 1-2 hours after the build finishes).
 
                 Feel free to join the community [chat room](https://gitter.im/conda-forge/conda-forge.github.io).
 


### PR DESCRIPTION
<!--
Thank you for the pull request. This repo's testing mechanism requires that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

If you have push access to this repo, please push directly to a branch in this repo and create
a PR from that branch

If you do not have push access to this repo, create a PR from your fork's branch and ask the
conda-forge/core team to push your commits to a branch on this repo. 

Note that the tests will not pass until the branch is on the main repo and not your fork!
-->

Checklist
* [x] Pushed the branch to main repo
* [ ] CI passed on the branch

