### PR TITLE
ENH add a github app token for rerendering

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,11 +47,6 @@ jobs:
           # maybe later...
           # black --check conda_forge_webservices
           flake8 conda_forge_webservices
-        env:
-          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
-          PROD_BINSTAR_TOKEN: ${{ secrets.PROD_BINSTAR_TOKEN }}
-          STAGING_BINSTAR_TOKEN: ${{ secrets.HEROKU_ONLY_STAGING_BINSTAR_TOKEN }}
-          CF_WEBSERVICES_TOKEN: ${{ secrets.CF_WEBSERVICES_TOKEN }}
 
       - name: run test suite
         shell: bash -l {0}
@@ -62,6 +57,8 @@ jobs:
           PROD_BINSTAR_TOKEN: ${{ secrets.PROD_BINSTAR_TOKEN }}
           STAGING_BINSTAR_TOKEN: ${{ secrets.HEROKU_ONLY_STAGING_BINSTAR_TOKEN }}
           CF_WEBSERVICES_TOKEN: ${{ secrets.CF_WEBSERVICES_TOKEN }}
+          CF_WEBSERVICES_APP_ID: ${{ secrets.CF_WEBSERVICES_APP_ID }}
+          CF_WEBSERVICES_PRIVATE_KEY: ${{ secrets.CF_WEBSERVICES_PRIVATE_KEY }}
 
       - name: run package upload tests
         shell: bash -l {0}
@@ -72,3 +69,5 @@ jobs:
           PROD_BINSTAR_TOKEN: ${{ secrets.PROD_BINSTAR_TOKEN }}
           STAGING_BINSTAR_TOKEN: ${{ secrets.HEROKU_ONLY_STAGING_BINSTAR_TOKEN }}
           CF_WEBSERVICES_TOKEN: ${{ secrets.CF_WEBSERVICES_TOKEN }}
+          CF_WEBSERVICES_APP_ID: ${{ secrets.CF_WEBSERVICES_APP_ID }}
+          CF_WEBSERVICES_PRIVATE_KEY: ${{ secrets.CF_WEBSERVICES_PRIVATE_KEY }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,8 @@ jobs:
           channels: conda-forge,defaults
           channel-priority: strict
           show-channel-urls: true
+          miniforge-version: latest
+          miniforge-variant: Mambaforge
 
       - name: generate token
         id: generate_token
@@ -29,7 +31,7 @@ jobs:
         run: |
           conda config --set show_channel_urls True
           conda config --add channels conda-forge
-          conda install --yes --quiet --file conda-requirements.txt
+          mamba install --yes --quiet --file conda-requirements.txt
           git config --global user.name "conda-forge-linter"
           git config --global user.email conda.forge.linter@gmail.com
           mkdir -p ~/.conda-smithy/ && echo $GH_TOKEN > ~/.conda-smithy/github.token

--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -5,6 +5,7 @@ conda
 conda-build
 conda-forge-pinning
 conda-smithy>=3.7.6  # this pin is for bot automerge and maint. team bug fixes
+cryptography
 python-dateutil
 flake8
 git
@@ -13,6 +14,8 @@ mock
 nose
 parameterized
 pygithub>=1.54  # for GHA repo disptach
+pyjwt
+pynacl
 pytest
 python=3.8.*
 pytz

--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -13,7 +13,7 @@ lxml
 mock
 nose
 parameterized
-pygithub>=1.54  # for GHA repo disptach
+pygithub>=1.55  # for GHA repo disptach
 pyjwt
 pynacl
 pytest

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -18,6 +18,7 @@ from .linting import compute_lint_message, comment_on_pr, set_pr_status
 from .update_teams import update_team
 from .circle_ci import update_circle
 from .utils import ALLOWED_CMD_NON_FEEDSTOCKS
+from .tokens import generate_app_token
 import textwrap
 
 LOGGER = logging.getLogger("conda_forge_webservices.commands")
@@ -807,6 +808,18 @@ def make_rerender_dummy_commit(repo):
 
 
 def rerender(full_name, pr_num):
+    # this is for testing - will turn it on for all repos later
+    if full_name.endswith("/cf-autotick-bot-test-package-feedstock"):
+        org_name, repo_name = full_name.split("/")
+        token = generate_app_token(
+            os.environ["CF_WEBSERVICES_APP_ID"],
+            os.environ["CF_WEBSERVICES_PRIVATE_KEY"].encode(),
+            repo_name,
+        )
+        gh = github.Github(os.environ['GH_TOKEN'])
+        repo = gh.get_repo("conda-forge/" + repo_name)
+        repo.create_secret("RERENDERING_GITHUB_TOKEN", token)
+
     # dispatch events do not seem to be in the pygithub API
     # so we are rolling the API request by hand
     headers = {

--- a/conda_forge_webservices/tests/linting/test_compute_lint_message.py
+++ b/conda_forge_webservices/tests/linting/test_compute_lint_message.py
@@ -42,7 +42,7 @@ class Test_compute_lint_message(unittest.TestCase):
         """  # noqa
 
         lint = compute_lint_message('conda-forge', 'conda-forge-webservices', 16)
-        self.assert_(lint)
+        self.assertTrue(lint)
         self.assertTrue(
             "found it was in an excellent condition." in lint['message'])
 
@@ -101,7 +101,7 @@ class Test_compute_lint_message(unittest.TestCase):
         """)  # noqa
 
         lint = compute_lint_message('conda-forge', 'conda-forge-webservices', 56)
-        self.assert_(lint)
+        self.assertTrue(lint)
         self.assertMultiLineEqual(expected_message, lint['message'])
 
     def test_conflict_2_ok_recipe(self):
@@ -115,7 +115,7 @@ class Test_compute_lint_message(unittest.TestCase):
         """)  # noqa
 
         lint = compute_lint_message('conda-forge', 'conda-forge-webservices', 57)
-        self.assert_(lint)
+        self.assertTrue(lint)
         self.assertMultiLineEqual(expected_message, lint['message'])
 
     def test_bad_recipe(self):
@@ -141,7 +141,7 @@ class Test_compute_lint_message(unittest.TestCase):
         """  # noqa
 
         lint = compute_lint_message('conda-forge', 'conda-forge-webservices', 17)
-        self.assert_(lint)
+        self.assertTrue(lint)
         self.assertTrue("found some lint" in lint['message'])
         self.assertTrue(
             "The home item is expected in the about section." in lint['message'])
@@ -164,7 +164,7 @@ class Test_compute_lint_message(unittest.TestCase):
         """  # noqa
 
         lint = compute_lint_message('conda-forge', 'conda-forge-webservices', 217)
-        self.assert_(lint)
+        self.assertTrue(lint)
         self.assertTrue(
             "I do have some suggestions for making it better though" in lint['message'])
 
@@ -177,7 +177,7 @@ class Test_compute_lint_message(unittest.TestCase):
         """)  # noqa
 
         lint = compute_lint_message('conda-forge', 'conda-forge-webservices', 18)
-        self.assert_(lint)
+        self.assertTrue(lint)
         self.assertMultiLineEqual(expected_message, lint['message'])
 
     def test_closed_pr(self):

--- a/conda_forge_webservices/tests/test_tokens.py
+++ b/conda_forge_webservices/tests/test_tokens.py
@@ -1,0 +1,53 @@
+import os
+import tempfile
+import subprocess
+
+import pytest
+
+from ..tokens import generate_app_token
+
+
+@pytest.mark.parametrize("token_repo", [
+    "staged-recipes",
+    ""
+])
+def test_github_app_tokens(token_repo):
+    app_id = os.environ["CF_WEBSERVICES_APP_ID"]
+    raw_pem = os.environ["CF_WEBSERVICES_PRIVATE_KEY"].encode()
+    token = generate_app_token(
+        app_id, raw_pem,
+        token_repo,
+    )
+    assert token is not None
+    repo = "cf-autotick-bot-test-package-feedstock"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        subprocess.run(
+            f"cd {tmpdir} && git clone https://github.com/conda-forge/{repo}.git",
+            shell=True,
+            check=True,
+        )
+
+        subprocess.run(
+            f"cd {tmpdir}/{repo} && "
+            "git remote set-url --push origin "
+            f"https://x-access-token:{token}@github.com/conda-forge/{repo}.git",
+            shell=True,
+            check=True,
+        )
+
+        subprocess.run(
+            f"cd {tmpdir}/{repo} && git commit -m '[ci skip] test' --allow-empty",
+            shell=True,
+            check=True,
+        )
+
+        out = subprocess.run(
+            f"cd {tmpdir}/{repo} && git push",
+            shell=True,
+        )
+
+    if token_repo == repo:
+        assert out.returncode == 0
+    else:
+        assert out.returncode != 0

--- a/conda_forge_webservices/tokens.py
+++ b/conda_forge_webservices/tokens.py
@@ -1,0 +1,98 @@
+import time
+import base64
+import os
+import io
+import sys
+from contextlib import redirect_stdout, redirect_stderr
+
+import jwt
+import requests
+from cryptography.hazmat.backends import default_backend
+
+
+def generate_app_token(app_id, raw_pem, repo):
+    """Get an app token.
+
+    Parameters
+    ----------
+    app_id : str
+        The github app ID.
+    raw_pem : bytes
+        An app private key as bytes.
+    repo : str
+        The name of the repo for which the token is scoped.
+        This should be like `ngmix-feedstock` without the org `conda-forge`
+        in front.
+
+    Returns
+    -------
+    gh_token : str
+        The github token. May return None if there is an error.
+    """
+    try:
+        if raw_pem[0:1] != b'-':
+            raw_pem = base64.b64decode(raw_pem)
+
+        f = io.StringIO()
+        with redirect_stdout(f), redirect_stderr(f):
+            private_key = default_backend().load_pem_private_key(raw_pem, None)
+
+            ti = int(time.time())
+            token = jwt.encode(
+                {
+                    'iat': ti,
+                    'exp': ti + 60*10,
+                    'iss': app_id,
+                },
+                private_key,
+                algorithm='RS256',
+            )
+
+        if (
+            "GITHUB_ACTIONS" in os.environ
+            and os.environ["GITHUB_ACTIONS"] == "true"
+        ):
+            sys.stdout.flush()
+            print("masking JWT token for github actions", flush=True)
+            print("::add-mask::%s" % token, flush=True)
+
+        with redirect_stdout(f), redirect_stderr(f):
+            r = requests.get(
+                "https://api.github.com/app/installations",
+                headers={
+                    'Authorization': 'Bearer %s' % token,
+                    'Accept': 'application/vnd.github.machine-man-preview+json',
+                },
+            )
+            r.raise_for_status()
+
+            r = requests.post(
+                "https://api.github.com/app/installations/"
+                "%s/access_tokens" % r.json()[0]["id"],
+                headers={
+                    'Authorization': 'Bearer %s' % token,
+                    'Accept': 'application/vnd.github.machine-man-preview+json',
+                },
+                json={"repositories": [repo]},
+            )
+            r.raise_for_status()
+
+            gh_token = r.json()["token"]
+
+        if (
+            "GITHUB_ACTIONS" in os.environ
+            and os.environ["GITHUB_ACTIONS"] == "true"
+        ):
+            sys.stdout.flush()
+            print("masking GITHUB token for github actions", flush=True)
+            print("::add-mask::%s" % gh_token, flush=True)
+
+        assert r.json()["permissions"] == {
+            "contents": "write", "metadata": "read", "workflows": "write"
+        }
+        assert set(r["name"] for r in r.json()["repositories"]) == {repo}
+
+    except Exception:
+        gh_token = None
+
+    return gh_token


### PR DESCRIPTION
<!--
Thank you for the pull request. This repo's testing mechanism requires that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

If you have push access to this repo, please push directly to a branch in this repo and create
a PR from that branch

If you do not have push access to this repo, create a PR from your fork's branch and ask the
conda-forge/core team to push your commits to a branch on this repo. 

Note that the tests will not pass until the branch is on the main repo and not your fork!
-->

Checklist
* [x] Pushed the branch to main repo
* [x] CI passed on the branch

