### PR TITLE
ENH make sure tokens always have the correct permissions

### DIFF
--- a/conda_forge_webservices/tokens.py
+++ b/conda_forge_webservices/tokens.py
@@ -156,7 +156,17 @@ def generate_app_token(app_id, raw_pem, repo):
                     'Authorization': 'Bearer %s' % token,
                     'Accept': 'application/vnd.github.machine-man-preview+json',
                 },
-                json={"repositories": [repo]},
+                json={
+                    "repositories": [repo],
+                    "permissions": {
+                        "contents": "write",
+                        "metadata": "read",
+                        "workflows": "write",
+                        "checks": "read",
+                        "pull_requests": "write",
+                        "statuses": "read",
+                    }
+                },
             )
             r.raise_for_status()
 


### PR DESCRIPTION
<!--
Thank you for the pull request. This repo's testing mechanism requires that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

If you have push access to this repo, please push directly to a branch in this repo and create
a PR from that branch

If you do not have push access to this repo, create a PR from your fork's branch and ask the
conda-forge/core team to push your commits to a branch on this repo. 

Note that the tests will not pass until the branch is on the main repo and not your fork!
-->

Checklist
* [x] Pushed the branch to main repo
* [x] CI passed on the branch

