### PR TITLE
PERF bypass executor earlier for feedstocks updates

### DIFF
--- a/conda_forge_webservices/tests/test_webapp.py
+++ b/conda_forge_webservices/tests/test_webapp.py
@@ -188,8 +188,7 @@ class TestBucketHandler(TestHandlerBase):
         'conda_forge_webservices.webapp.print_rate_limiting_info',
         return_value=None,
     )
-    @mock.patch('conda_forge_webservices.webapp.get_commit_message')
-    def test_skip_commits(self, commit_mock, *args):
+    def test_skip_commits(self, *args):
         for hook, accepted_repos, accepted_events, skip_slugs in [
             ("/conda-forge-feedstocks/org-hook",
              ["repo-feedstock"],
@@ -203,7 +202,6 @@ class TestBucketHandler(TestHandlerBase):
              ),
         ]:
             for commit_msg in (["blah"] + skip_slugs):
-                commit_mock.return_value = commit_msg
 
                 test_slugs = [
                     "conda-forge/repo-feedstock",
@@ -243,7 +241,7 @@ class TestBucketHandler(TestHandlerBase):
                             },
                             'action': 'opened',
                             'ref': 'refs/heads/' + __branch,
-                            'head_commit': {'id': 'xyz'},
+                            'head_commit': {'id': 'xyz', 'message': commit_msg},
                         }
 
                         hash = hmac.new(

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -255,7 +255,8 @@ class UpdateFeedstockHookHandler(tornado.web.RequestHandler):
                 owner == 'conda-forge' and
                 (ref == "refs/heads/master" or ref == "refs/heads/main") and
                 "[cf admin skip feedstocks]" not in commit_msg and
-                "[cf admin skip]" not in commit_msg
+                "[cf admin skip]" not in commit_msg and
+                repo_name.endswith("-feedstock")
             ):
                 LOGGER.info("")
                 LOGGER.info("===================================================")

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -290,15 +290,7 @@ class UpdateTeamHookHandler(tornado.web.RequestHandler):
             repo_name = body['repository']['name']
             owner = body['repository']['owner']['login']
             ref = body['ref']
-            commit = (body.get('head_commit', None) or {}).get('id', None)
-
-            if commit:
-                commit_msg = get_commit_message(
-                    body['repository']['full_name'],
-                    commit,
-                )
-            else:
-                commit_msg = ""
+            commit_msg = (body.get('head_commit', None) or {}).get('message', '')
 
             # Only do anything if we are working with conda-forge,
             # and a push to main.

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -239,15 +239,7 @@ class UpdateFeedstockHookHandler(tornado.web.RequestHandler):
             repo_name = body['repository']['name']
             owner = body['repository']['owner']['login']
             ref = body['ref']
-            commit = (body.get('head_commit', None) or {}).get('id', None)
-
-            if commit:
-                commit_msg = get_commit_message(
-                    body['repository']['full_name'],
-                    commit,
-                )
-            else:
-                commit_msg = ""
+            commit_msg = (body.get('head_commit', None) or {}).get('message', '')
 
             # Only do anything if we are working with conda-forge, and a
             # push to main.

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -290,6 +290,7 @@ class UpdateTeamHookHandler(tornado.web.RequestHandler):
             repo_name = body['repository']['name']
             owner = body['repository']['owner']['login']
             ref = body['ref']
+            commit = (body.get('head_commit', None) or {}).get('id', None)
             commit_msg = (body.get('head_commit', None) or {}).get('message', '')
 
             # Only do anything if we are working with conda-forge,


### PR DESCRIPTION
<!--
Thank you for the pull request. This repo's testing mechanism requires that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

If you have push access to this repo, please push directly to a branch in this repo and create
a PR from that branch

If you do not have push access to this repo, create a PR from your fork's branch and ask the
conda-forge/core team to push your commits to a branch on this repo. 

Note that the tests will not pass until the branch is on the main repo and not your fork!
-->

Checklist
* [x] Pushed the branch to main repo
* [ ] CI passed on the branch

