### PR TITLE
Add "remove bot automerge" command

### DIFF
--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -395,7 +395,7 @@ def issue_comment(org_name, repo_name, issue_num, title, comment):
                 changed_anything |= make_rerender_dummy_commit(git_repo)
 
             elif ADD_BOT_AUTOMERGE.search(text):
-                pr_title = "[ci skip] adding bot automerge"
+                pr_title = "[ci skip] [cf admin skip] ***NO_CI*** adding bot automerge"
                 comment_msg = "added bot automerge"
                 to_close = ADD_BOT_AUTOMERGE.search(title)
                 check_bump_build = False
@@ -403,7 +403,9 @@ def issue_comment(org_name, repo_name, issue_num, title, comment):
 
                 changed_anything |= add_bot_automerge(git_repo)
             elif REMOVE_BOT_AUTOMERGE.search(text):
-                pr_title = "[ci skip] removing bot automerge"
+                pr_title = (
+                    "[ci skip] [cf admin skip] ***NO_CI*** removing bot automerge"
+                )
                 comment_msg = "removing bot automerge"
                 to_close = REMOVE_BOT_AUTOMERGE.search(title)
                 check_bump_build = False
@@ -809,7 +811,7 @@ def add_bot_automerge(repo):
     repo.index.add([cf_yml])
     author = Actor("conda-forge-admin", "pelson.pub+conda-forge@gmail.com")
     repo.index.commit(
-        "[ci skip] ***NO_CI*** added bot automerge", author=author)
+        "[ci skip] [cf admin skip] ***NO_CI*** added bot automerge", author=author)
     return True
 
 
@@ -839,7 +841,7 @@ def remove_bot_automerge(repo):
     repo.index.add([cf_yml])
     author = Actor("conda-forge-admin", "pelson.pub+conda-forge@gmail.com")
     repo.index.commit(
-        "[ci skip] ***NO_CI*** removed bot automerge", author=author)
+        "[ci skip] [cf admin skip] ***NO_CI*** removed bot automerge", author=author)
     return True
 
 

--- a/conda_forge_webservices/tests/test_automerge.py
+++ b/conda_forge_webservices/tests/test_automerge.py
@@ -7,11 +7,11 @@ from ruamel.yaml import YAML
 
 from git import Repo
 
-from ..commands import add_bot_automerge
+from ..commands import add_bot_automerge, remove_bot_automerge
 from ..utils import pushd
 
 
-class TestAutomerge(unittest.TestCase):
+class TestAddAutomerge(unittest.TestCase):
     def test_automerge_already_on(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             with pushd(tmpdir):
@@ -59,6 +59,63 @@ class TestAutomerge(unittest.TestCase):
                     # make sure the commit is correct
                     cmt_msg = repo.head.ref.commit.message
                     assert '[ci skip] ***NO_CI*** added bot automerge' in cmt_msg
+
+                    # make sure both the conda-forge.yml and the main.yml are
+                    # tracked
+                    assert not repo.is_dirty()
+
+
+class TestRemoveAutomerge(unittest.TestCase):
+    @parameterized.expand([
+        ("empty", {},),
+        ("off", {'travis': 'blah', 'bot': {'automerge': False}},)])
+    def test_automerge_already_off(self, _, cfg):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with pushd(tmpdir):
+                repo_pth = os.path.join(tmpdir, "myrepo-feedstock")
+                repo = Repo.init(repo_pth)
+
+                cfg_pth = os.path.join(repo_pth, 'conda-forge.yml')
+                with open(cfg_pth, "w") as fp:
+                    yaml = YAML()
+                    yaml.dump(cfg, fp)
+
+                assert not remove_bot_automerge(repo)
+
+    @parameterized.expand([
+        ("on-and-other-bot-key", dict(travis="blah", bot=dict(automerge=False, x=5))),
+        ("on-and-only-bot-key", dict(travis="blah", bot=dict(automerge=False)))])
+    def test_automerge_remove(self, _, cfg):
+        yaml = YAML()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with pushd(tmpdir):
+                repo_pth = os.path.join(tmpdir, "myrepo-feedstock")
+                repo = Repo.init(repo_pth)
+                with pushd(repo_pth):
+                    cfg_pth = os.path.join(repo_pth, 'conda-forge.yml')
+
+                    if cfg:
+                        with open(cfg_pth, "w") as fp:
+                            yaml.dump(cfg, fp)
+
+                    # ensure it says to commit
+                    assert remove_bot_automerge(repo)
+
+                    with open(cfg_pth, 'r') as fp:
+                        _cfg = yaml.load(fp)
+
+                    # make sure automerge is off
+                    current_automerge_value = _cfg.get('bot', {}).get(
+                        'automerge', False)
+                    assert not current_automerge_value
+
+                    # make other keys are still there
+                    assert cfg['travis'] == 'blah'
+
+                    # make sure the commit is correct
+                    cmt_msg = repo.head.ref.commit.message
+                    assert '[ci skip] ***NO_CI*** removed bot automerge' in cmt_msg
 
                     # make sure both the conda-forge.yml and the main.yml are
                     # tracked

--- a/conda_forge_webservices/tests/test_automerge.py
+++ b/conda_forge_webservices/tests/test_automerge.py
@@ -58,8 +58,10 @@ class TestAddAutomerge(unittest.TestCase):
 
                     # make sure the commit is correct
                     cmt_msg = repo.head.ref.commit.message
-                    assert '[ci skip] ***NO_CI*** added bot automerge' in cmt_msg
-
+                    assert (
+                        "[ci skip] [cf admin skip] ***NO_CI*** added bot automerge"
+                        in cmt_msg
+                    )
                     # make sure both the conda-forge.yml and the main.yml are
                     # tracked
                     assert not repo.is_dirty()
@@ -115,7 +117,10 @@ class TestRemoveAutomerge(unittest.TestCase):
 
                     # make sure the commit is correct
                     cmt_msg = repo.head.ref.commit.message
-                    assert '[ci skip] ***NO_CI*** removed bot automerge' in cmt_msg
+                    assert (
+                        '[ci skip] [cf admin skip] ***NO_CI*** removed bot automerge'
+                        in cmt_msg
+                    )
 
                     # make sure both the conda-forge.yml and the main.yml are
                     # tracked


### PR DESCRIPTION
@conda-forge/core, could you please give me a branch for testing?

<!--
Thank you for the pull request. This repo's testing mechanism requires that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

If you have push access to this repo, please push directly to a branch in this repo and create
a PR from that branch

If you do not have push access to this repo, create a PR from your fork's branch and ask the
conda-forge/core team to push your commits to a branch on this repo. 

Note that the tests will not pass until the branch is on the main repo and not your fork!
-->

Checklist
* [ ] Pushed the branch to main repo
* [ ] CI passed on the branch

