### PR TITLE
Remove bot automerge

### DIFF
--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -35,7 +35,9 @@ UPDATE_CB3_MSG = re.compile(
     pre + "(please )?update (for )?(cb|conda[- ]build)[- ]?3", re.I)
 PING_TEAM = re.compile(pre + r"(please )?ping (?P<team>\S+)", re.I)
 RERUN_BOT = re.compile(pre + "(please )?rerun (the )?bot", re.I)
-ADD_BOT_AUTOMERGE = re.compile(pre + "(please )?add bot automerge", re.I)
+ADD_BOT_AUTOMERGE = re.compile(pre + "(please )?(add|enable) bot auto-?merge", re.I)
+REMOVE_BOT_AUTOMERGE = re.compile(
+    pre + "(please )?(remove|delete|stop|disable) bot auto-?merge", re.I)
 ADD_PY = re.compile(
     pre
     + r"(please )?add (python (?P<verfloat>[0-9]{1}\.[0-9]{1})|py(?P<verint>[0-9]{2}))",
@@ -258,10 +260,10 @@ def issue_comment(org_name, repo_name, issue_num, title, comment):
 
     issue_commands = [UPDATE_TEAM_MSG, ADD_NOARCH_MSG, UPDATE_CIRCLECI_KEY_MSG,
                       RERENDER_MSG, UPDATE_CB3_MSG, ADD_BOT_AUTOMERGE, ADD_PY,
-                      ADD_USER]
+                      ADD_USER, REMOVE_BOT_AUTOMERGE]
     send_pr_commands = [
         ADD_NOARCH_MSG, RERENDER_MSG, UPDATE_CB3_MSG, ADD_BOT_AUTOMERGE, ADD_PY,
-        ADD_USER]
+        ADD_USER, REMOVE_BOT_AUTOMERGE]
 
     if not any(command.search(text) for command in issue_commands):
         return
@@ -400,6 +402,16 @@ def issue_comment(org_name, repo_name, issue_num, title, comment):
                 extra_msg = "\n\nMerge this PR to enable bot automerging.\n"
 
                 changed_anything |= add_bot_automerge(git_repo)
+            elif REMOVE_BOT_AUTOMERGE.search(text):
+                pr_title = (
+                    "[ci skip] [cf admin skip] ***NO_CI*** removing bot automerge"
+                )
+                comment_msg = "removing bot automerge"
+                to_close = REMOVE_BOT_AUTOMERGE.search(title)
+                check_bump_build = False
+                extra_msg = "\n\nMerge this PR to disable bot automerging.\n"
+
+                changed_anything |= remove_bot_automerge(git_repo)
             elif ADD_PY.search(text):
                 m = ADD_PY.search(text)
                 if m.group('verfloat'):
@@ -781,7 +793,8 @@ def add_bot_automerge(repo):
     else:
         cfg = {}
 
-    if cfg.get('bot', {}).get('automerge', False):
+    current_automerge_value = cfg.get('bot', {}).get('automerge', False)
+    if current_automerge_value:
         # already have it
         return False
 
@@ -798,7 +811,37 @@ def add_bot_automerge(repo):
     repo.index.add([cf_yml])
     author = Actor("conda-forge-admin", "pelson.pub+conda-forge@gmail.com")
     repo.index.commit(
-        "[ci skip] ***NO_CI*** added bot automerge", author=author)
+        "[ci skip] [cf admin skip] ***NO_CI*** added bot automerge", author=author)
+    return True
+
+
+def remove_bot_automerge(repo):
+    yaml = YAML()
+
+    cf_yml = os.path.join(repo.working_dir, "conda-forge.yml")
+    if os.path.exists(cf_yml):
+        with open(cf_yml, 'r') as fp:
+            cfg = yaml.load(fp)
+    else:
+        cfg = {}
+
+    current_automerge_value = cfg.get('bot', {}).get('automerge', False)
+    if not current_automerge_value:
+        # already disabled
+        return False
+
+    # remove it from conda-forge.yml
+    del cfg['bot']['automerge']
+    if len(cfg['bot']) == 0:
+        del cfg['bot']
+    with open(cf_yml, 'w') as fp:
+        yaml.dump(cfg, fp)
+
+    # now commit
+    repo.index.add([cf_yml])
+    author = Actor("conda-forge-admin", "pelson.pub+conda-forge@gmail.com")
+    repo.index.commit(
+        "[ci skip] [cf admin skip] ***NO_CI*** removed bot automerge", author=author)
     return True
 
 

--- a/conda_forge_webservices/tests/test_automerge.py
+++ b/conda_forge_webservices/tests/test_automerge.py
@@ -85,8 +85,8 @@ class TestRemoveAutomerge(unittest.TestCase):
                 assert not remove_bot_automerge(repo)
 
     @parameterized.expand([
-        ("on-and-other-bot-key", dict(travis="blah", bot=dict(automerge=False, x=5))),
-        ("on-and-only-bot-key", dict(travis="blah", bot=dict(automerge=False)))])
+        ("on-and-other-bot-key", dict(travis="blah", bot=dict(automerge=True, x=5))),
+        ("on-and-only-bot-key", dict(travis="blah", bot=dict(automerge=True)))])
     def test_automerge_remove(self, _, cfg):
         yaml = YAML()
 

--- a/conda_forge_webservices/tests/test_automerge.py
+++ b/conda_forge_webservices/tests/test_automerge.py
@@ -7,11 +7,11 @@ from ruamel.yaml import YAML
 
 from git import Repo
 
-from ..commands import add_bot_automerge
+from ..commands import add_bot_automerge, remove_bot_automerge
 from ..utils import pushd
 
 
-class TestAutomerge(unittest.TestCase):
+class TestAddAutomerge(unittest.TestCase):
     def test_automerge_already_on(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             with pushd(tmpdir):
@@ -58,7 +58,69 @@ class TestAutomerge(unittest.TestCase):
 
                     # make sure the commit is correct
                     cmt_msg = repo.head.ref.commit.message
-                    assert '[ci skip] ***NO_CI*** added bot automerge' in cmt_msg
+                    assert (
+                        "[ci skip] [cf admin skip] ***NO_CI*** added bot automerge"
+                        in cmt_msg
+                    )
+                    # make sure both the conda-forge.yml and the main.yml are
+                    # tracked
+                    assert not repo.is_dirty()
+
+
+class TestRemoveAutomerge(unittest.TestCase):
+    @parameterized.expand([
+        ("empty", {},),
+        ("off", {'travis': 'blah', 'bot': {'automerge': False}},)])
+    def test_automerge_already_off(self, _, cfg):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with pushd(tmpdir):
+                repo_pth = os.path.join(tmpdir, "myrepo-feedstock")
+                repo = Repo.init(repo_pth)
+
+                cfg_pth = os.path.join(repo_pth, 'conda-forge.yml')
+                with open(cfg_pth, "w") as fp:
+                    yaml = YAML()
+                    yaml.dump(cfg, fp)
+
+                assert not remove_bot_automerge(repo)
+
+    @parameterized.expand([
+        ("on-and-other-bot-key", dict(travis="blah", bot=dict(automerge=False, x=5))),
+        ("on-and-only-bot-key", dict(travis="blah", bot=dict(automerge=False)))])
+    def test_automerge_remove(self, _, cfg):
+        yaml = YAML()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with pushd(tmpdir):
+                repo_pth = os.path.join(tmpdir, "myrepo-feedstock")
+                repo = Repo.init(repo_pth)
+                with pushd(repo_pth):
+                    cfg_pth = os.path.join(repo_pth, 'conda-forge.yml')
+
+                    if cfg:
+                        with open(cfg_pth, "w") as fp:
+                            yaml.dump(cfg, fp)
+
+                    # ensure it says to commit
+                    assert remove_bot_automerge(repo)
+
+                    with open(cfg_pth, 'r') as fp:
+                        _cfg = yaml.load(fp)
+
+                    # make sure automerge is off
+                    current_automerge_value = _cfg.get('bot', {}).get(
+                        'automerge', False)
+                    assert not current_automerge_value
+
+                    # make other keys are still there
+                    assert cfg['travis'] == 'blah'
+
+                    # make sure the commit is correct
+                    cmt_msg = repo.head.ref.commit.message
+                    assert (
+                        '[ci skip] [cf admin skip] ***NO_CI*** removed bot automerge'
+                        in cmt_msg
+                    )
 
                     # make sure both the conda-forge.yml and the main.yml are
                     # tracked


### PR DESCRIPTION
<!--
Thank you for the pull request. This repo's testing mechanism requires that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

If you have push access to this repo, please push directly to a branch in this repo and create
a PR from that branch

If you do not have push access to this repo, create a PR from your fork's branch and ask the
conda-forge/core team to push your commits to a branch on this repo. 

Note that the tests will not pass until the branch is on the main repo and not your fork!
-->

Checklist
* [ ] Pushed the branch to main repo
* [ ] CI passed on the branch

