### PR TITLE
ENH use app tokens for teams

### DIFF
--- a/conda_forge_webservices/update_teams.py
+++ b/conda_forge_webservices/update_teams.py
@@ -7,6 +7,7 @@ import textwrap
 from functools import lru_cache
 
 from ruamel.yaml import YAML
+from conda_forge_webservices.tokens import get_app_token_for_webservices_only
 
 LOGGER = logging.getLogger("conda_forge_webservices.update_teams")
 
@@ -53,7 +54,12 @@ def update_team(org_name, repo_name, commit=None):
     ):
         return
 
-    gh = github.Github(os.environ['GH_TOKEN'])
+    gh = github.Github(
+        get_app_token_for_webservices_only(
+            full_name=os.path.join(org_name, repo_name),
+            fallback_env_token="GH_TOKEN",
+        )
+    )
     org = gh.get_organization(org_name)
     gh_repo = org.get_repo(repo_name)
 
@@ -103,7 +109,7 @@ def update_team(org_name, repo_name, commit=None):
         if addm or newm:
             message += textwrap.dedent("""
                 You should get push access to this feedstock and CI services.
-                
+
                 Your package won't be available for installation locally until it is built
                 and synced to the anaconda.org CDN (takes 1-2 hours after the build finishes).
 


### PR DESCRIPTION
<!--
Thank you for the pull request. This repo's testing mechanism requires that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

If you have push access to this repo, please push directly to a branch in this repo and create
a PR from that branch

If you do not have push access to this repo, create a PR from your fork's branch and ask the
conda-forge/core team to push your commits to a branch on this repo. 

Note that the tests will not pass until the branch is on the main repo and not your fork!
-->

Checklist
* [ ] Pushed the branch to main repo
* [ ] CI passed on the branch

