### PR TITLE
Replace Gitter chat with Element channel

### DIFF
--- a/conda_forge_webservices/feedstock_outputs.py
+++ b/conda_forge_webservices/feedstock_outputs.py
@@ -419,8 +419,8 @@ token. Below we have put some information about the failure to help you debug it
 
 **Rerendering the feedstock will usually fix these problems.**
 
-If you have any issues or questions, you can find us on gitter in the
-community [chat room](https://gitter.im/conda-forge/conda-forge.github.io) or you can bump us right here.
+If you have any issues or questions, you can find us on Element in the
+community [channel](https://app.element.io/#/room/#conda-forge:matrix.org) or you can bump us right here.
 """ % team_name  # noqa
 
     is_all_valid = True

--- a/conda_forge_webservices/update_teams.py
+++ b/conda_forge_webservices/update_teams.py
@@ -108,7 +108,7 @@ def update_team(org_name, repo_name, commit=None):
                 Your package won't be available for installation locally until it is built
                 and synced to the anaconda.org CDN (takes 1-2 hours after the build finishes).
 
-                Feel free to join the community [Element channel(https://app.element.io/#/room/#conda-forge:matrix.org).
+                Feel free to join the community [Element channel](https://app.element.io/#/room/#conda-forge:matrix.org).
 
                 NOTE: Please make sure to not push to the repository directly.
                       Use branches in your fork for any changes and send a PR.

--- a/conda_forge_webservices/update_teams.py
+++ b/conda_forge_webservices/update_teams.py
@@ -108,7 +108,7 @@ def update_team(org_name, repo_name, commit=None):
                 Your package won't be available for installation locally until it is built
                 and synced to the anaconda.org CDN (takes 1-2 hours after the build finishes).
 
-                Feel free to join the community [chat room](https://gitter.im/conda-forge/conda-forge.github.io).
+                Feel free to join the community [Element channel(https://app.element.io/#/room/#conda-forge:matrix.org).
 
                 NOTE: Please make sure to not push to the repository directly.
                       Use branches in your fork for any changes and send a PR.


### PR DESCRIPTION
Expanding the scope of - https://github.com/conda-forge/conda-forge.github.io/issues/1677

Replacing Gitter chatroom's  link with Element channel's  link.

cc: @jaimergp 

<!--
Thank you for the pull request. This repo's testing mechanism requires that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

If you have push access to this repo, please push directly to a branch in this repo and create
a PR from that branch

If you do not have push access to this repo, create a PR from your fork's branch and ask the
conda-forge/core team to push your commits to a branch on this repo. 

Note that the tests will not pass until the branch is on the main repo and not your fork!
-->

Checklist
* [ ] Pushed the branch to main repo
* [ ] CI passed on the branch



