### PR TITLE
Replace metadata on `copy`

### DIFF
--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -1,4 +1,4 @@
-anaconda-client
+anaconda-client>=1.8.0
 black
 cachetools
 conda

--- a/conda_forge_webservices/feedstock_outputs.py
+++ b/conda_forge_webservices/feedstock_outputs.py
@@ -140,7 +140,7 @@ def copy_feedstock_outputs(outputs, channel, delete=True):
                     to_owner=PROD,
                     from_label=channel,
                     to_label=channel,
-                    replace=True,
+                    update=True,
                 )
                 copied[dist] = True
                 LOGGER.info("    copied: %s", dist)

--- a/conda_forge_webservices/feedstock_outputs.py
+++ b/conda_forge_webservices/feedstock_outputs.py
@@ -141,7 +141,6 @@ def copy_feedstock_outputs(outputs, channel, delete=True):
                     from_label=channel,
                     to_label=channel,
                     replace=True,
-                    update=True,
                 )
                 copied[dist] = True
                 LOGGER.info("    copied: %s", dist)

--- a/conda_forge_webservices/feedstock_outputs.py
+++ b/conda_forge_webservices/feedstock_outputs.py
@@ -140,6 +140,8 @@ def copy_feedstock_outputs(outputs, channel, delete=True):
                     to_owner=PROD,
                     from_label=channel,
                     to_label=channel,
+                    replace=True,
+                    update=True,
                 )
                 copied[dist] = True
                 LOGGER.info("    copied: %s", dist)

--- a/conda_forge_webservices/tests/test_feedstock_outputs.py
+++ b/conda_forge_webservices/tests/test_feedstock_outputs.py
@@ -96,6 +96,7 @@ def test_copy_feedstock_outputs_does_no_exist(
         to_owner="conda-forge",
         from_label="blah",
         to_label="blah",
+        update=True,
     )
 
     if not error:


### PR DESCRIPTION
When copying over a package from [the staging channel, `cf-staging`]( https://anaconda.org/cf-staging ), to [the main channel, `conda-forge`]( https://anaconda.org/conda-forge ), make sure to refresh all associated metadata as part of the copy.

<hr>

Checklist
* [x] Pushed the branch to main repo
* [x] CI passed on the branch

<hr>

xref: https://github.com/conda-forge/conda-forge-ci-setup-feedstock/pull/241
xref: https://github.com/conda/infrastructure/discussions/649#discussioncomment-6167410