### PR TITLE
Use timezone aware 'now()'

### DIFF
--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -15,7 +15,7 @@ import logging
 
 import requests
 import github
-from datetime import datetime
+from datetime import datetime, timezone
 
 import conda_forge_webservices.linting as linting
 import conda_forge_webservices.feedstocks_service as feedstocks_service
@@ -107,7 +107,7 @@ def print_rate_limiting_info_for_token(token):
 
     # Compute time until GitHub API Rate Limit reset
     gh_api_reset_time = gh.get_rate_limit().core.reset
-    gh_api_reset_time -= datetime.utcnow()
+    gh_api_reset_time -= datetime.now(timezone.utc)
     msg = "{user} - remaining {remaining} out of {total}.".format(
         remaining=gh_api_remaining,
         total=gh_api_total, user=user,


### PR DESCRIPTION
<!--
Thank you for the pull request. This repo's testing mechanism requires that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

If you have push access to this repo, please push directly to a branch in this repo and create
a PR from that branch

If you do not have push access to this repo, create a PR from your fork's branch and ask the
conda-forge/core team to push your commits to a branch on this repo. 

Note that the tests will not pass until the branch is on the main repo and not your fork!
-->

Checklist
* [X] Pushed the branch to main repo
* [x] CI passed on the branch

Same problem as in https://github.com/conda-forge/staged-recipes/pull/24488