### PR TITLE
Stop using conda_build.conda_interface

### DIFF
--- a/conda_forge_webservices/update_me.py
+++ b/conda_forge_webservices/update_me.py
@@ -40,8 +40,10 @@ def main():
     """
     # keep these imports here to protect the webservice from memory errors
     # due to conda
-    from conda_build.conda_interface import (
-        VersionOrder, MatchSpec, get_index, Resolve)
+    from conda.core.index import get_index
+    from conda.models.match_spec import MatchSpec
+    from conda.models.version import VersionOrder
+    from conda.resolve import Resolve
 
     r = requests.get(
         "https://conda-forge.herokuapp.com/conda-webservice-update/versions")


### PR DESCRIPTION
`conda_build.conda_interface` is being deprecated.

`conda_build.conda_interface.get_index` (which is `conda.exports.get_index`) is using the `conda.models.Dist` -> `conda.models.records.PackageRecord` mapping. `Dist` class is legacy code that's being phased out, so avoid it.

refs:
- https://github.com/conda/conda-build/pull/5152
- https://github.com/conda/conda-build/pull/5222

<!--
Thank you for the pull request. This repo's testing mechanism requires that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

If you have push access to this repo, please push directly to a branch in this repo and create
a PR from that branch

If you do not have push access to this repo, create a PR from your fork's branch and ask the
conda-forge/core team to push your commits to a branch on this repo. 

Note that the tests will not pass until the branch is on the main repo and not your fork!
-->

Checklist
* [ ] Pushed the branch to main repo
* [ ] CI passed on the branch

