### PR TITLE
Cleanup for each Docker install step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ ADD https://loripsum.net/api /opt/docker/etc/gibberish
 COPY conda-requirements.txt /
 RUN echo "**** install dev packages ****" && \
     apk add --no-cache bash ca-certificates wget && \
+    rm -rf /var/cache/apk/* && \
     \
     echo "**** get Miniforge3 ****" && \
     mkdir -p "$CONDA_DIR" && \
@@ -53,6 +54,7 @@ RUN echo "**** install dev packages ****" && \
     \
     echo "**** install Miniforge3 ****" && \
     bash miniforge3.sh -f -b -p "$CONDA_DIR" && \
+    rm -f miniforge3.sh && \
     \
     echo "**** install base env ****" && \
     source /opt/conda/etc/profile.d/conda.sh && \
@@ -63,9 +65,6 @@ RUN echo "**** install dev packages ****" && \
     conda config --set always_yes yes && \
     conda config --set solver libmamba && \
     conda install --quiet --file conda-requirements.txt && \
-    echo "**** cleanup ****" && \
-    rm -rf /var/cache/apk/* && \
-    rm -f miniforge3.sh && \
     conda clean --all --force-pkgs-dirs --yes && \
     find "$CONDA_DIR" -follow -type f \( -iname '*.a' -o -iname '*.pyc' -o -iname '*.js.map' \) -delete && \
     \


### PR DESCRIPTION
Heroku is running out of memory trying to build the Docker image. Please see [this log]( https://dashboard.heroku.com/apps/conda-forge/activity/builds/26c8fe67-af97-44a3-8615-e9a608c97feb ).

So this tries to cleanup right after each install step instead of after all of them run. This should help keep the memory footprint minimal.

Checklist
* [x] Pushed the branch to main repo
* [x] CI passed on the branch

