### PR TITLE
Enable Dependabot GHA workflow updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Following [this GH doc]( https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot#example-dependabotyml-file-for-github-actions ), this enables Dependabot updates on this repo to help keep GHA workflows updated

Checklist
* [x] Pushed the branch to main repo
* [ ] CI passed on the branch

