### PR TITLE
Use Mamba install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ RUN echo "**** install dev packages ****" && \
     conda config --show-sources  && \
     conda config --set always_yes yes && \
     conda config --set solver libmamba && \
-    conda install --quiet --file conda-requirements.txt && \
+    mamba install --quiet --file conda-requirements.txt && \
     conda clean --all --force-pkgs-dirs --yes && \
     find "$CONDA_DIR" -follow -type f \( -iname '*.a' -o -iname '*.pyc' -o -iname '*.js.map' \) -delete && \
     \


### PR DESCRIPTION
Heroku is running out of memory during the build. Switch back to Mamba for the install to see if that helps.

Checklist
* [x] Pushed the branch to main repo
* [ ] CI passed on the branch

