### PR TITLE
REF make test commits more explicit

### DIFF
--- a/conda_forge_webservices/tests/test_tokens.py
+++ b/conda_forge_webservices/tests/test_tokens.py
@@ -32,7 +32,9 @@ def test_github_app_tokens_for_webservices(token_repo):
         )
 
         subprocess.run(
-            f"cd {tmpdir}/{repo} && git commit -m '[ci skip] test' --allow-empty",
+            f"cd {tmpdir}/{repo} && "
+            "git commit -m '[ci skip] test webservices app token can commit' "
+            "--allow-empty",
             shell=True,
             check=True,
         )


### PR DESCRIPTION
<!--
Thank you for the pull request. This repo's testing mechanism requires that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

If you have push access to this repo, please push directly to a branch in this repo and create
a PR from that branch

If you do not have push access to this repo, create a PR from your fork's branch and ask the
conda-forge/core team to push your commits to a branch on this repo. 

Note that the tests will not pass until the branch is on the main repo and not your fork!
-->

Checklist
* [x] Pushed the branch to main repo
* [x] CI passed on the branch

