### PR TITLE
Drop `nose` from requirements

### DIFF
--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -12,7 +12,6 @@ flake8
 git
 lxml
 mock
-nose
 parameterized
 pygithub>=2.2.0  # for GH App endpoints
 pyjwt


### PR DESCRIPTION
In PR ( https://github.com/conda-forge/conda-forge-webservices/pull/304 ), we moved from `nose` to `pytest`, which closed out issue ( https://github.com/conda-forge/conda-forge-webservices/issues/199 ). However the `nose` requirement persisted in this list. AFAICT it is no longer used in the code anywhere; so, go ahead and drop `nose` from the requirements

Checklist
* [x] Pushed the branch to main repo
* [x] CI passed on the branch

