### PR TITLE
Refactor out linting into pre-commit

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,13 +43,6 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
 
-      - name: lint
-        shell: bash -l {0}
-        run: |
-          # maybe later...
-          # black --check conda_forge_webservices
-          flake8 conda_forge_webservices
-
       - name: run test suite
         shell: bash -l {0}
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+- repo: https://github.com/pycqa/flake8
+  rev: 7.0.0
+  hooks:
+    - id: flake8
+
+ci:
+    autofix_commit_msg: |
+        [pre-commit.ci] auto fixes from pre-commit.com hooks
+
+        for more information, see https://pre-commit.ci
+    autofix_prs: false
+    autoupdate_commit_msg: '[ci skip] [pre-commit.ci] pre-commit autoupdate'
+    autoupdate_schedule: monthly
+    skip: []
+    submodules: false

--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -1,5 +1,4 @@
 anaconda-client>=1.8.0
-black
 cachetools
 conda
 conda-build
@@ -8,7 +7,6 @@ conda-forge-pinning
 conda-smithy>=3.7.6  # this pin is for bot automerge and maint. team bug fixes
 cryptography>=39
 python-dateutil
-flake8
 git
 lxml
 mock


### PR DESCRIPTION
Configure pre-commit to run on conda-forge-webservices. This breaks out the linting portions from GitHub Actions and the Docker image used by Heroku. It also matches more closely to how other repos linting works.

As `black` is not tested now, dropped it. Though we could explore using `black` in a follow-up with pre-commit.ci (as `flake8` is done here)

Checklist
* [x] Pushed the branch to main repo
* [x] CI passed on the branch

Edit: Have configured pre-commit.ci to run on this repo, which is tested in this PR (note 3 checks below) and it passes