### PR TITLE
Require Python 3.10 everywhere

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@v3
         with:
-          python-version: 3.8
+          python-version: '3.10'
           channels: conda-forge,defaults
           channel-priority: strict
           show-channel-urls: true


### PR DESCRIPTION
One GHA test was still using Python 3.8 whereas the rest use Python 3.10, upgrade it to Python 3.10 as well to match.

xref: https://github.com/conda-forge/conda-forge-webservices/pull/567

<hr>

Checklist
* [x] Pushed the branch to main repo
* [x] CI passed on the branch

