### PR TITLE
Enumerate each package on a separate line

### DIFF
--- a/conda_forge_webservices/update_me.py
+++ b/conda_forge_webservices/update_me.py
@@ -98,10 +98,15 @@ def main():
             # keep a record around
             pth = os.path.join(clone_dir, "pkg_versions.json")
             with open(pth, "w") as fp:
-                json.dump(final_install, fp)
+                json.dump(final_install, fp, indent=2)
+                fp.write("\n")
             repo.index.add(pth)
 
-            msg_vers = ", ".join(["{}={}".format(k, v) for k, v in to_install.items()])
+            msg_vers = (
+                "Redeploy for package updates:\n\n" +
+                "\n".join(["* `{}={}`".format(k, v) for k, v in to_install.items()])
+            )
+
             repo.index.commit("redeploy for '%s'" % msg_vers)
             repo.git.push("origin", "main")
 

--- a/pkg_versions.json
+++ b/pkg_versions.json
@@ -1,1 +1,8 @@
-{"anaconda-client": "1.12.3", "conda-smithy": "3.34.0", "conda": "24.3.0", "conda-build": "24.3.0", "conda-libmamba-solver": "24.1.0", "mamba": "1.5.8"}
+{
+  "anaconda-client": "1.12.3",
+  "conda-smithy": "3.34.0",
+  "conda": "24.3.0",
+  "conda-build": "24.3.0",
+  "conda-libmamba-solver": "24.1.0",
+  "mamba": "1.5.8"
+}


### PR DESCRIPTION
When writing out `pkg_versions.json`, write each one to a separate line. This should keep the diffs cleaner and easier to read.

Also write the commit message so that package versions are in a bullet point list in the body of the message. This will make it easier to follow what was changed and keep the commit messages more readable.

<hr>

Checklist
* [x] Pushed the branch to main repo
* [ ] CI passed on the branch

