### PR TITLE
Pin `pytest` to pre-`8.2.0`

### DIFF
--- a/conda-test-requirements.txt
+++ b/conda-test-requirements.txt
@@ -1,1 +1,1 @@
-pytest
+pytest<8.2.0


### PR DESCRIPTION
Workaround issues with `pytest` + `tornado` that cropped up with `pytest` version `8.2.0`.

xref: https://github.com/conda-forge/conda-forge-webservices/issues/614#issuecomment-2109408460

Checklist
* [x] Pushed the branch to main repo
* [x] CI passed on the branch

