### PR TITLE
Replace flake 8 with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,8 @@
 repos:
-- repo: https://github.com/pycqa/flake8
-  rev: 7.0.0
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.4.4
   hooks:
-    - id: flake8
+    - id: ruff
 
 ci:
     autofix_commit_msg: |

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -862,7 +862,7 @@ def make_noarch(repo):
         for line in lines:
             if build_line:
                 spaces = len(line) - len(line.lstrip())
-                line = "{}noarch: python\n{}".format(" "*spaces, line)
+                line = "{}noarch: python\n{}".format(" " * spaces, line)
             build_line = False
             if line.rstrip() == 'build:':
                 build_line = True

--- a/conda_forge_webservices/status_monitor.py
+++ b/conda_forge_webservices/status_monitor.py
@@ -53,7 +53,7 @@ WEBS_STATUS_DATA = {
     'updated_at': None,
 }
 START_TIME = datetime.datetime.fromisoformat("2020-01-01T00:00:00+00:00")
-TIME_INTERVAL = 60*5  # five minutes
+TIME_INTERVAL = 60 * 5  # five minutes
 
 
 def _make_time_key(uptime):
@@ -141,7 +141,7 @@ def _make_report_data(iso=False):
     report = {}
     for key in APP_DATA:
         rates = {}
-        for k in range(know, know-96, -1):
+        for k in range(know, know - 96, -1):
             tstr = _make_est_from_time_key(k, iso=iso)
             rates[tstr] = APP_DATA[key]['rates'].get(k, 0)
 

--- a/conda_forge_webservices/tokens.py
+++ b/conda_forge_webservices/tokens.py
@@ -72,7 +72,7 @@ def get_app_token_for_webservices_only(full_name=None, fallback_env_token=None):
         LOGGER.info("===================================================")
         LOGGER.info(
             "app token exists - timeout %sm",
-            (APP_TOKEN_RESET_TIME - now)/60,
+            (APP_TOKEN_RESET_TIME - now) / 60,
         )
         LOGGER.info("===================================================")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[tool.ruff.lint]
+ignore = [
+    "E203", # allow spaces before colons
+]
+select = [
+    "E", "F", "W"
+]
+preview = true
+
+[tool.ruff.lint.pycodestyle]
+max-line-length = 88

--- a/scripts/test_cfep13_copy.py
+++ b/scripts/test_cfep13_copy.py
@@ -198,8 +198,6 @@ def _compute_local_info(dist, croot, hash_type):
 
     md5 = h.hexdigest()
 
-    _, name, version, _ = _split_pkg(dist)
-
     return {dist: md5}
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,0 @@
-[flake8]
-max-line-length = 88
-extend-ignore = E203


### PR DESCRIPTION
Hello 👋!

As part of the STF work for Conda, this PR switches source linting from `flake8` to `ruff`, similar to other projects in the Conda ecosystem.

### Changes
- Replaces the pre-commit hook for `flake8` with `ruff`
- Adds a `pyproject.toml` file to configure `ruff`
- Removes `setup.cfg` as its only content was `flake8` config
- Brings the repo into a state where it conforms to the linter

Tested locally via:
 
```bash
$ conda install -c conda-forge pre-commit
$ pre-commit run --all-files
```

### Why is `ruff` used in preview mode?

It seems as if Ruff (as of `0.4.4`) is only truly a drop-in replacement for `flake8` in preview mode, because otherwise, a bunch of the `E` [rules](https://docs.astral.sh/ruff/rules/#error-e) (which `flake8` currently _does_ flag in this repo, despite not being `F` rules 🤔), are missed, such as:

``` bash
E302 [*] Expected 2 blank lines, found 1
E271 [*] Multiple spaces after keyword
E211 [*] Whitespace before '('
```

Hence the `preview = true` setting for `ruff` in this PR. In comparison to some other Conda projects:
- `conda-smithy` [has a PR](https://github.com/conda-forge/conda-smithy/pull/1919#issuecomment-2095912831) that uses `ruff`’s `E` ruleset _without_ preview mode, so maybe these unstable rules are not relevant there, or they are covered by the black formatting in that repo, not sure.
- `conda` itself [also does _not_ use preview mode](https://github.com/conda/conda/blob/main/pyproject.toml#L160-L188).
- However, the Autotick Bot [_does_ use preview mode](https://github.com/regro/cf-scripts/blob/master/pyproject.toml#L49-L51)

So this might need tweaking depending on your preferences. 

Checklist
* [ ] Pushed the branch to main repo
* [ ] CI passed on the branch