### PR TITLE
React to comments upon receiving webhook

### DIFF
--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -44,7 +44,7 @@ UPDATE_VERSION = re.compile(
 
 
 def add_reaction(
-    comment_id, reaction, gh_repo=None, org_name=None, repo_name=None, errors_ok=False
+    comment_id, reaction, gh_repo=None, org_name=None, repo_name=None, errors_ok=True
 ):
     if comment_id is None:
         return

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -44,7 +44,7 @@ UPDATE_VERSION = re.compile(
 
 
 def add_reaction(
-    comment_id, reaction, gh_repo=None, org_name=None, repo_name=None, errors_ok=True
+    comment_id, reaction, gh_repo=None, org_name=None, repo_name=None, errors_ok=False
 ):
     if comment_id is None:
         return

--- a/conda_forge_webservices/tests/test_webapp.py
+++ b/conda_forge_webservices/tests/test_webapp.py
@@ -94,10 +94,9 @@ class TestBucketHandler(TestHandlerBase):
                 return_value=None)
     @mock.patch('conda_forge_webservices.commands.pr_comment', return_value=None)
     @mock.patch('conda_forge_webservices.commands.issue_comment', return_value=None)
+    @mock.patch('conda_forge_webservices.commands.add_reaction', return_value=None)
     @mock.patch('conda_forge_webservices.update_teams.update_team', return_value=None)
     @mock.patch('conda_forge_webservices.webapp.print_rate_limiting_info',
-                return_value=None)
-    @mock.patch('conda_forge_webservices.webapp.add_reaction',
                 return_value=None)
     def test_accept_repos(self, *methods):
         for hook, accepted_repos, accepted_events in [
@@ -139,11 +138,13 @@ class TestBucketHandler(TestHandlerBase):
                                 'ref': 'ref',
                             },
                             'body': 'body',
+                            'id': 56767,
                         },
                         'issue': {
                             'number': 16,
                             'body': 'body',
                             'title': 'title',
+                            'id': 56767,
                         },
                         'action': 'opened',
                         'ref': 'refs/heads/' + __branch,

--- a/conda_forge_webservices/tests/test_webapp.py
+++ b/conda_forge_webservices/tests/test_webapp.py
@@ -97,6 +97,8 @@ class TestBucketHandler(TestHandlerBase):
     @mock.patch('conda_forge_webservices.update_teams.update_team', return_value=None)
     @mock.patch('conda_forge_webservices.webapp.print_rate_limiting_info',
                 return_value=None)
+    @mock.patch('conda_forge_webservices.webapp.add_reaction',
+                return_value=None)
     def test_accept_repos(self, *methods):
         for hook, accepted_repos, accepted_events in [
             ("/conda-linting/org-hook",


### PR DESCRIPTION
<!--
Thank you for the pull request. This repo's testing mechanism requires that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

If you have push access to this repo, please push directly to a branch in this repo and create
a PR from that branch

If you do not have push access to this repo, create a PR from your fork's branch and ask the
conda-forge/core team to push your commits to a branch on this repo. 

Note that the tests will not pass until the branch is on the main repo and not your fork!
-->

Checklist
* [X] Pushed the branch to main repo
* [x] CI passed on the branch



This makes the webservices react to the command comments with a 🚀  (like what pre-commit.ci does) so the user has early feedback that the command was received (e.g. with rerenders and so on, it might take a while). I added it within a try/except that swallows (but logs) the exceptions so this is not critical in case of errors.