### PR TITLE
Fix sneaky comma and retry to avoid race conditions

### DIFF
--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -70,7 +70,7 @@ def _find_reactable_comment(
                 if hasattr(comment, "create_reaction"):
                     return comment
             except Exception as inner_exc:
-                LOGGER.debug(
+                LOGGER.info(
                     "Cannot find PR/issue comment with %s. Trying again...",
                     comment_type,
                     exc_info=inner_exc,

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -105,7 +105,19 @@ def add_reaction(
     )
 
     try:
-        comment = _find_reactable_comment(repo, issue_number, comment_id, review_id)
+        for i in range(NUM_GH_API_TRIES):
+            try:
+                comment = _find_reactable_comment(
+                    repo, issue_number, comment_id, review_id
+                )
+                break
+            except RuntimeError as exc:
+                # There seems to be a race condition where we get the payload before the
+                # API can return the actual comment, so let's retry for a tiny bit
+                if i < 4:
+                    time.sleep(0.050 * 2**i)
+                    continue
+                raise exc
         comment.create_reaction(reaction)
     except Exception as exc:
         if errors_ok:

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -220,7 +220,7 @@ def pr_detailed_comment(
         return
 
     if comment_id is not None or review_id is not None:
-        repo = github.Github(GH_TOKEN).get_repo("{}/{}".format(org_name, repo_name)),
+        repo = github.Github(GH_TOKEN).get_repo("{}/{}".format(org_name, repo_name))
         add_reaction("rocket", repo, pr_num, comment_id, review_id)
 
     tmp_dir = None

--- a/conda_forge_webservices/tests/test_commands.py
+++ b/conda_forge_webservices/tests/test_commands.py
@@ -385,6 +385,8 @@ class TestCommands(unittest.TestCase):
           The summary of a submitted review (e.g. "Approved").
         - https://github.com/conda-forge/conda-pypi-feedstock/pull/5#discussion_r1646160070
           A comment that is part of a submitted review.
+        - https://github.com/conda-forge/conda-pypi-feedstock/pull/5#discussion_r1646411494
+          A reply to one of those comments.
         - https://github.com/conda-forge/conda-pypi-feedstock/pull/5#discussion_r1646163741
           A single-comment review (comment on a diff line).
 
@@ -403,6 +405,7 @@ class TestCommands(unittest.TestCase):
             (5, 2178557279, None),  # Normal PR comment
             (5, None, 2128210901),  # Submitted review
             (5, None, 1646160070),  # Comment in a submitted review
+            (5, None, 1646411494),  # Reply in a review comment
             (5, None, 1646163741),  # Single comment review
             (4, -1, None),  # Issue description
             (4, 2178549014, None),  # Issue comment


### PR DESCRIPTION
<!--
Thank you for the pull request. This repo's testing mechanism requires that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

If you have push access to this repo, please push directly to a branch in this repo and create
a PR from that branch

If you do not have push access to this repo, create a PR from your fork's branch and ask the
conda-forge/core team to push your commits to a branch on this repo. 

Note that the tests will not pass until the branch is on the main repo and not your fork!
-->

Checklist
* [X] Pushed the branch to main repo
* [ ] CI passed on the branch

This is becoming a little joke. That comma was causing:

```
2024-06-19T15:11:32.052717+00:00 app[web.1]: add_reaction failed
2024-06-19T15:11:32.052758+00:00 app[web.1]:     Traceback (most recent call last):
2024-06-19T15:11:32.052759+00:00 app[web.1]:       File "/conda_forge_webservices/conda_forge_webservices/commands.py", line 108, in add_reaction
2024-06-19T15:11:32.052760+00:00 app[web.1]:         comment = _find_reactable_comment(repo, issue_number, comment_id, review_id)
2024-06-19T15:11:32.052760+00:00 app[web.1]:       File "/conda_forge_webservices/conda_forge_webservices/commands.py", line 58, in _find_reactable_comment
2024-06-19T15:11:32.052760+00:00 app[web.1]:         return repo.get_issue(issue_number).get_comment(comment_id)
2024-06-19T15:11:32.052761+00:00 app[web.1]:     AttributeError: 'tuple' object has no attribute 'get_issue'
```