### PR TITLE
doc: update docs for merge queue

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,16 @@
 <!--
-Thank you for the pull request. This repo's testing mechanism requires that the commit be pushed to
+Thank you for the pull request! This repo's tests require that the commit be pushed to
 a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
 to test the commenting of the linter and command bot.
 
-If you have push access to this repo, please push directly to a branch in this repo and create
-a PR from that branch
+To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
+due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
+will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
+will get kicked out of the queue for fixes.
 
-If you do not have push access to this repo, create a PR from your fork's branch and ask the
-conda-forge/core team to push your commits to a branch on this repo. 
-
-Note that the tests will not pass until the branch is on the main repo and not your fork!
+If you have push access to this repo, you can use a branch for your PR, but this will not bypass the 
+merge queue.
 -->
 
 Checklist
-* [ ] Pushed the branch to main repo
-* [ ] CI passed on the branch
-
+* [ ] CI is passing

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,6 @@
 name: tests
 
 on:
-  push: null
   workflow_dispatch: null
   merge_group: null
   pull_request: null
@@ -75,7 +74,7 @@ jobs:
     runs-on: "ubuntu-latest"
     needs: tests
     concurrency:
-      group: live-tests
+      group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests' || format('{0}-{1}', github.workflow, github.ref) }}
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         if: ${{ !github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,13 +115,9 @@ jobs:
         shell: bash -l {0}
         run: |
           export CF_WEBSERVICES_TEST=1
-          if [[ '${{ github.event.pull_request.head.repo.fork }}' == "true" ]]; then
-            unset CF_WEBSERVICES_TOKEN
-            unset CF_WEBSERVICES_APP_ID
-            unset CF_WEBSERVICES_PRIVATE_KEY
-            unset GH_TOKEN
+          if [[ '${{ github.event.pull_request.head.repo.fork }}' != "true" ]]; then
+            ./scripts/run_cfep13_tests.sh
           fi
-          ./scripts/run_cfep13_tests.sh
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
           PROD_BINSTAR_TOKEN: ${{ secrets.PROD_BINSTAR_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,7 +76,7 @@ jobs:
     runs-on: "ubuntu-latest"
     needs: tests
     concurrency:
-      group: live-tests
+      group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests' || format('{0}-{1}', github.workflow, github.ref) }}
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,13 +18,6 @@ jobs:
     name: tests
     runs-on: "ubuntu-latest"
     steps:
-      - name: run test suite
-        shell: bash -l {0}
-        run: |
-          echo "owner: ${GITHUB_REPOSITORY_OWNER}"
-          echo 'fork: ${{ github.event.pull_request.head.repo.fork }}'
-          exit 1
-
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
 
       - uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca # v3
@@ -62,7 +55,7 @@ jobs:
         run: |
           echo "owner: ${GITHUB_REPOSITORY_OWNER}"
           export CF_WEBSERVICES_TEST=1
-          if [[ ${GITHUB_REPOSITORY_OWNER} != "conda-forge" ]]; then
+          if [[ '${{ github.event.pull_request.head.repo.fork }}' == "true" ]]; then
             unset CF_WEBSERVICES_TOKEN
             unset CF_WEBSERVICES_APP_ID
             unset CF_WEBSERVICES_PRIVATE_KEY
@@ -122,7 +115,7 @@ jobs:
         shell: bash -l {0}
         run: |
           export CF_WEBSERVICES_TEST=1
-          if [[ ${GITHUB_REPOSITORY_OWNER} != "conda-forge" ]]; then
+          if [[ '${{ github.event.pull_request.head.repo.fork }}' == "true" ]]; then
             unset CF_WEBSERVICES_TOKEN
             unset CF_WEBSERVICES_APP_ID
             unset CF_WEBSERVICES_PRIVATE_KEY

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,10 +6,6 @@ on:
   merge_group: null
   pull_request: null
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 env:
   PY_COLORS: 1
 
@@ -17,6 +13,9 @@ jobs:
   tests:
     name: tests
     runs-on: "ubuntu-latest"
+    concurrency:
+      group: ${{ github.workflow }}-tests-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
 
@@ -76,7 +75,7 @@ jobs:
     runs-on: "ubuntu-latest"
     needs: tests
     concurrency:
-      group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests' || format('{0}-{1}', github.workflow, github.ref) }}
+      group: live-tests
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         if: ${{ !github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
         shell: bash -l {0}
         run: |
           echo "owner: ${GITHUB_REPOSITORY_OWNER}"
-          ecoo 'fork: ${{ github.event.pull_request.head.repo.fork }}'
+          echo 'fork: ${{ github.event.pull_request.head.repo.fork }}'
           exit 1
 
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,7 @@ jobs:
         shell: bash -l {0}
         run: |
           echo "owner: ${GITHUB_REPOSITORY_OWNER}"
+          ecoo 'fork: ${{ github.event.pull_request.head.repo.fork }}'
           exit 1
 
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,8 +79,10 @@ jobs:
       group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests' || format('{0}-{1}', github.workflow, github.ref) }}
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        if: ${{ !github.event.pull_request.head.repo.fork }}
 
       - uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca # v3
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         with:
           python-version: '3.10'
           channels: conda-forge
@@ -99,6 +101,7 @@ jobs:
 
       - name: configure conda
         shell: bash -l {0}
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         run: |
           conda config --set show_channel_urls True
           conda config --add channels conda-forge

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,12 @@ jobs:
     name: tests
     runs-on: "ubuntu-latest"
     steps:
+      - name: run test suite
+        shell: bash -l {0}
+        run: |
+          echo "owner: ${GITHUB_REPOSITORY_OWNER}"
+          exit 1
+
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
 
       - uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca # v3
@@ -53,6 +59,7 @@ jobs:
       - name: run test suite
         shell: bash -l {0}
         run: |
+          echo "owner: ${GITHUB_REPOSITORY_OWNER}"
           export CF_WEBSERVICES_TEST=1
           if [[ ${GITHUB_REPOSITORY_OWNER} != "conda-forge" ]]; then
             unset CF_WEBSERVICES_TOKEN

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ uses a single machine user with no special permissions in order to make forks fo
 
 ## Testing
 
-The tests for this repo require a GitHub API key which is not available on forks. Thus the tests only pass
-for PRs made from a branch in this repo. If your PR is in a fork, please ask a member of `@conda-forge/core`
-to push your PR branch to the main repo to enable the tests.
+The tests for this repo require a GitHub API key which is not available on forks. We use a merge queue to handle this. 
+The tests in your PR will run, but some of them will be skipped. Once the PR is merged, it will be put into a queue on the 
+upstream repo for complete testing. If it passes, it will be merged. If it does not pass, the PR will be kicked out of the 
+queue and we will have to try again. Only maintainers on the upstream repo can add tests to the merge queue. You can 
+bump `@conda-forge/core` for a review and merge into the queue.


### PR DESCRIPTION
<!--
Thank you for the pull request. This repo's testing mechanism requires that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

If you have push access to this repo, please push directly to a branch in this repo and create
a PR from that branch

If you do not have push access to this repo, create a PR from your fork's branch and ask the
conda-forge/core team to push your commits to a branch on this repo. 

Note that the tests will not pass until the branch is on the main repo and not your fork!
-->

Checklist
* [ ] Pushed the branch to main repo
* [ ] CI passed on the branch

This PR updates the docs for the merge queue and tests it out.
