### PR TITLE
feat: change command recipe path

### DIFF
--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -966,7 +966,7 @@ def update_version(full_name, pr_num, input_ver):
 def make_noarch(repo):
     meta_yaml = _determine_recipe_path(repo)
     if meta_yaml is None:
-        return None
+        return False
     with open(meta_yaml, 'r') as fh:
         lines = [line for line in fh]
     with open(meta_yaml, 'w') as fh:

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -728,6 +728,15 @@ def restart_pull_request_ci(repo, pr_num):
     time.sleep(1)  # wait a bit to be sure things are ok
     pull.edit(state='open')
 
+def _determine_recipe_path(repo):
+    """Determine rattler-build or conda-build recipe path."""
+    recipe_path = os.path.join(repo.working_dir, "recipe", "meta.yaml")
+    if os.path.exists(recipe_path):
+        return recipe_path
+    rattler_build_recipe_path = os.path.join(repo.working_dir, "recipe", "recipe.yaml")
+    if os.path.exists(rattler_build_recipe_path):
+        return rattler_build_recipe_path
+    return None
 
 def add_user(repo, user):
     # a feedstock has user names in three spots as of 2021/06/19
@@ -740,7 +749,9 @@ def add_user(repo, user):
     # adjust those easily enough.
     # Those happen to also be the only locations where adding a user really matters.
 
-    recipe_path = os.path.join(repo.working_dir, "recipe", "meta.yaml")
+    recipe_path = _determine_recipe_path(repo)
+    if not recipe_path:
+        return None
     co_path = os.path.join(repo.working_dir, ".github", "CODEOWNERS")
     yaml = YAML(typ="safe")
     if os.path.exists(recipe_path):
@@ -953,7 +964,9 @@ def update_version(full_name, pr_num, input_ver):
 
 
 def make_noarch(repo):
-    meta_yaml = os.path.join(repo.working_dir, "recipe", "meta.yaml")
+    meta_yaml = _determine_recipe_path(repo)
+    if meta_yaml is None:
+        return None
     with open(meta_yaml, 'r') as fh:
         lines = [line for line in fh]
     with open(meta_yaml, 'w') as fh:

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -728,6 +728,7 @@ def restart_pull_request_ci(repo, pr_num):
     time.sleep(1)  # wait a bit to be sure things are ok
     pull.edit(state='open')
 
+
 def _determine_recipe_path(repo):
     """Determine rattler-build or conda-build recipe path."""
     recipe_path = os.path.join(repo.working_dir, "recipe", "meta.yaml")
@@ -737,6 +738,7 @@ def _determine_recipe_path(repo):
     if os.path.exists(rattler_build_recipe_path):
         return rattler_build_recipe_path
     return None
+
 
 def add_user(repo, user):
     # a feedstock has user names in three spots as of 2021/06/19


### PR DESCRIPTION
This supersedes #644 and #643.

Only modifies the recipe path, so that the commands are also applied to rattler-build recipe.yaml.

cc @isuruf @beckermr 

Checklist
* [x] CI is passing
