### PR TITLE
feat: update the docker image for conda-forge-tick

### DIFF
--- a/conda_forge_webservices/update_me.py
+++ b/conda_forge_webservices/update_me.py
@@ -28,6 +28,7 @@ DOCKER_IMAGE_PKGS = [
     "conda-build",
     "conda-libmamba-solver",
     "mamba",
+    "conda-forge-tick",
 ]
 
 


### PR DESCRIPTION
<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the 
merge queue.
-->

Checklist
* [x] CI is passing

xref: https://github.com/regro/cf-scripts/issues/2894
