### PR TITLE
fix: ensure logging prints

### DIFF
--- a/conda_forge_webservices/update_me.py
+++ b/conda_forge_webservices/update_me.py
@@ -44,6 +44,8 @@ def update(repo_name, pkgs, force=False):
     from conda.models.version import VersionOrder
     from conda.resolve import Resolve
 
+    LOGGER.info(f"updating {repo_name}")
+
     if repo_name == "conda-forge-webservices":
         url = "https://conda-forge.herokuapp.com/conda-webservice-update/versions"
     else:
@@ -129,6 +131,8 @@ def main():
     Note this script runs on GHA, not on the heroku app.
     """
 
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+    
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--force", action="store_true", help="Force the service to update."

--- a/conda_forge_webservices/update_me.py
+++ b/conda_forge_webservices/update_me.py
@@ -2,6 +2,7 @@ import argparse
 import datetime
 import os
 import subprocess
+import sys
 import json
 import tempfile
 import shutil

--- a/conda_forge_webservices/update_me.py
+++ b/conda_forge_webservices/update_me.py
@@ -132,7 +132,7 @@ def main():
     """
 
     logging.basicConfig(stream=sys.stdout, level=logging.INFO)
-    
+
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--force", action="store_true", help="Force the service to update."


### PR DESCRIPTION
<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the 
merge queue.
-->

Checklist
* [ ] CI is passing
