### PR TITLE
dep: remove update hook since we do not need it

### DIFF
--- a/conda_forge_webservices/update_me.py
+++ b/conda_forge_webservices/update_me.py
@@ -140,4 +140,5 @@ def main():
     )
     args = parser.parse_args()
     update("conda-forge-webservices", WEBSERVICE_PKGS, force=args.force)
-    update("webservices-dispatch-action", DOCKER_IMAGE_PKGS, force=args.force)
+    # no longer needed but keeping this around just in case
+    # update("webservices-dispatch-action", DOCKER_IMAGE_PKGS, force=args.force)


### PR DESCRIPTION
<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the 
merge queue.
-->

Checklist
* [ ] CI is passing
