### PR TITLE
feat: inject app tokens for feedstocks

### DIFF
--- a/conda_forge_webservices/tests/test_tokens.py
+++ b/conda_forge_webservices/tests/test_tokens.py
@@ -1,9 +1,12 @@
+import os
 import tempfile
 import subprocess
 
 import pytest
 
 from ..tokens import (
+    generate_app_token_for_feedstock,
+    inject_app_token_into_feedstock,
     get_app_token_for_webservices_only,
 )
 from ..utils import with_action_url
@@ -52,11 +55,58 @@ def test_github_app_tokens_for_webservices_cache():
     assert token_again == token
 
 
-def test_github_app_tokens_for_webservices_feedstock():
-    token = get_app_token_for_webservices_only()
-    assert token is not None
-    token_again = get_app_token_for_webservices_only(
-        full_name="conda-forge/cf-autotick-bot-test-package-feedstock",
-        fallback_env_token="GH_TOKEN",
+@pytest.mark.parametrize(
+    "token_repo", ["staged-recipes", "cf-autotick-bot-test-package-feedstock"]
+)
+def test_github_app_tokens_for_feedstocks(token_repo):
+    app_id = os.environ["CF_WEBSERVICES_APP_ID"]
+    raw_pem = os.environ["CF_WEBSERVICES_PRIVATE_KEY"].encode()
+    token = generate_app_token_for_feedstock(
+        app_id,
+        raw_pem,
+        token_repo,
     )
-    assert token_again == token
+    assert token is not None
+    repo = "cf-autotick-bot-test-package-feedstock"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        subprocess.run(
+            f"cd {tmpdir} && git clone https://github.com/conda-forge/{repo}.git",
+            shell=True,
+            check=True,
+        )
+
+        subprocess.run(
+            f"cd {tmpdir}/{repo} && "
+            "git remote set-url --push origin "
+            f"https://x-access-token:{token}@github.com/conda-forge/{repo}.git",
+            shell=True,
+            check=True,
+        )
+
+        subprocess.run(
+            f"cd {tmpdir}/{repo} && git commit -m '[ci skip] test' --allow-empty",
+            shell=True,
+            check=True,
+        )
+
+        out = subprocess.run(
+            f"cd {tmpdir}/{repo} && git push",
+            shell=True,
+        )
+
+    if token_repo == repo:
+        assert out.returncode == 0
+    else:
+        assert out.returncode != 0
+
+
+@pytest.mark.parametrize(
+    "token_repo", ["staged-recipes", "cf-autotick-bot-test-package-feedstock"]
+)
+def test_inject_app_token_into_feedstock(token_repo):
+    res = inject_app_token_into_feedstock("conda-forge/" + token_repo)
+    if token_repo == "cf-autotick-bot-test-package-feedstock":
+        assert res
+    else:
+        assert not res

--- a/conda_forge_webservices/tokens.py
+++ b/conda_forge_webservices/tokens.py
@@ -6,27 +6,21 @@ import sys
 import logging
 from contextlib import redirect_stdout, redirect_stderr
 
+from typing import Any
+
 from github import Auth, Github, GithubIntegration
 
 LOGGER = logging.getLogger("conda_forge_webservices.tokens")
 
+FEEDSTOCK_TOKEN_RESET_TIMES: dict[str, Any] = {}
 APP_TOKEN_RESET_TIME = None
 
 
-def get_app_token_for_webservices_only(full_name=None, fallback_env_token=None):
+def get_app_token_for_webservices_only():
     """Get's an app token that should only be used in the webservices bot.
 
     This function caches the token and only returns a new one when the current
     one is expired or about to expire in the next minute.
-
-    Parameters
-    ----------
-    full_name : str, optional
-        The full name of the repo (e.g., "conda-forge/blah"). If given,
-        app tokens are only made for the test feedstock.
-    fallback_env_token : str, optional
-        If not None, then this token from the environment variables
-        is used for every feedstock except for the testing feedstock.
 
     Returns
     -------
@@ -35,12 +29,6 @@ def get_app_token_for_webservices_only(full_name=None, fallback_env_token=None):
     """
     global APP_TOKEN_RESET_TIME
     global APP_TOKEN
-
-    # this is for testing - will turn it on for all repos later
-    if full_name is not None and fallback_env_token is not None:
-        repo_name = full_name.split("/")[1]
-        if repo_name != "cf-autotick-bot-test-package-feedstock":
-            return os.environ[fallback_env_token]
 
     # add a minute to make sure token doesn't expire
     # while we are using it
@@ -148,6 +136,194 @@ def generate_app_token_for_webservices_only(app_id, raw_pem):
 
         with redirect_stdout(f), redirect_stderr(f):
             gh_token = integration.get_access_token(installation.id).token
+        if "GITHUB_ACTIONS" in os.environ and os.environ["GITHUB_ACTIONS"] == "true":
+            sys.stdout.flush()
+            print("made GITHUB token and masking it for github actions", flush=True)
+            print(f"::add-mask::{gh_token}", flush=True)
+
+    except Exception:
+        gh_token = None
+
+    return gh_token
+
+
+def inject_app_token_into_feedstock(full_name, repo=None):
+    """Inject the cf-webservices-tokens app token into the repo secrets.
+
+    Parameters
+    ----------
+    full_name : str
+        The full name of the repo (e.g., "conda-forge/blah").
+    repo : pygithub Repository
+        Optional repo object to use. If not passed, a new one will be made.
+
+    Returns
+    -------
+    injected : bool
+        True if the token was injected, False otherwise.
+    """
+    repo_name = full_name.split("/")[1]
+
+    # this is for testing - will turn it on for all repos later
+    if repo_name not in [
+        "cf-autotick-bot-test-package-feedstock",
+        "conda-forge-pinning-feedstock",
+    ]:
+        return False
+
+    if not repo_name.endswith("-feedstock"):
+        return False
+
+    global FEEDSTOCK_TOKEN_RESET_TIMES
+
+    now = time.time()
+    now_plus_30min = now + 30 * 60
+    if FEEDSTOCK_TOKEN_RESET_TIMES.get(repo_name, now_plus_30min) <= now_plus_30min:
+        token = generate_app_token_for_feedstock(
+            os.environ["CF_WEBSERVICES_APP_ID"],
+            os.environ["CF_WEBSERVICES_PRIVATE_KEY"].encode(),
+            repo_name,
+        )
+        if token is not None:
+            if repo is None:
+                gh = Github(get_app_token_for_webservices_only())
+                repo = gh.get_repo(full_name)
+            try:
+                repo.create_secret("RERENDERING_GITHUB_TOKEN", token)
+                FEEDSTOCK_TOKEN_RESET_TIMES[repo_name] = Github(
+                    token
+                ).rate_limiting_resettime
+                LOGGER.info("")
+                LOGGER.info("===================================================")
+                LOGGER.info(
+                    "injected app token for repo %s - timeout %sm",
+                    repo_name,
+                    (FEEDSTOCK_TOKEN_RESET_TIMES[repo_name] - now) / 60,
+                )
+                LOGGER.info("===================================================")
+                worked = True
+            except Exception:
+                LOGGER.info("")
+                LOGGER.info("===================================================")
+                LOGGER.info(
+                    "app token could not be pushed to secrets for %s", repo_name
+                )
+                LOGGER.info("===================================================")
+                worked = False
+
+            return worked
+        else:
+            LOGGER.info("")
+            LOGGER.info("===================================================")
+            LOGGER.info("app token could not be made for %s", repo_name)
+            LOGGER.info("===================================================")
+            return False
+    else:
+        LOGGER.info("")
+        LOGGER.info("===================================================")
+        LOGGER.info(
+            "app token exists for repo %s - timeout %sm",
+            repo_name,
+            (FEEDSTOCK_TOKEN_RESET_TIMES[repo_name] - now) / 60,
+        )
+        LOGGER.info("===================================================")
+        return True
+
+
+def generate_app_token_for_feedstock(app_id, raw_pem, repo):
+    """Get an app token.
+
+    Parameters
+    ----------
+    app_id : str
+        The github app ID.
+    raw_pem : bytes
+        An app private key as bytes.
+    repo : str
+        The name of the repo for which the token is scoped.
+        This should be like `ngmix-feedstock` without the org `conda-forge`
+        in front.
+
+    Returns
+    -------
+    gh_token : str
+        The github token. May return None if there is an error.
+    """
+    if "GITHUB_ACTIONS" in os.environ and os.environ["GITHUB_ACTIONS"] == "true":
+        sys.stdout.flush()
+        print(
+            "running in github actions",
+            flush=True,
+        )
+        print(f"::add-mask::{raw_pem}", flush=True)
+
+    try:
+        f = io.StringIO()
+        if raw_pem[0:1] != b"-":
+            with redirect_stdout(f), redirect_stderr(f):
+                raw_pem = base64.b64decode(raw_pem)
+            if (
+                "GITHUB_ACTIONS" in os.environ
+                and os.environ["GITHUB_ACTIONS"] == "true"
+            ):
+                sys.stdout.flush()
+                print("base64 decoded PEM", flush=True)
+                print(f"::add-mask::{raw_pem}", flush=True)
+
+        if isinstance(raw_pem, bytes):
+            with redirect_stdout(f), redirect_stderr(f):
+                raw_pem = raw_pem.decode()
+            if (
+                "GITHUB_ACTIONS" in os.environ
+                and os.environ["GITHUB_ACTIONS"] == "true"
+            ):
+                sys.stdout.flush()
+                print("utf-8 decoded PEM", flush=True)
+                print(f"::add-mask::{raw_pem}", flush=True)
+
+        with redirect_stdout(f), redirect_stderr(f):
+            gh_auth = Auth.AppAuth(app_id=app_id, private_key=raw_pem)
+        if "GITHUB_ACTIONS" in os.environ and os.environ["GITHUB_ACTIONS"] == "true":
+            sys.stdout.flush()
+            print("loaded Github Auth", flush=True)
+
+        with redirect_stdout(f), redirect_stderr(f):
+            integration = GithubIntegration(auth=gh_auth)
+        if "GITHUB_ACTIONS" in os.environ and os.environ["GITHUB_ACTIONS"] == "true":
+            sys.stdout.flush()
+            print("loaded Github Integration", flush=True)
+
+        with redirect_stdout(f), redirect_stderr(f):
+            installation = integration.get_repo_installation("conda-forge", repo)
+        if "GITHUB_ACTIONS" in os.environ and os.environ["GITHUB_ACTIONS"] == "true":
+            sys.stdout.flush()
+            print("found Github installation", flush=True)
+
+        with redirect_stdout(f), redirect_stderr(f):
+            gh_token_data = integration.get_access_token(
+                installation.id,
+                permissions={
+                    "contents": "write",
+                    "metadata": "read",
+                    "workflows": "write",
+                    "checks": "read",
+                    "pull_requests": "write",
+                    "statuses": "read",
+                },
+            )
+
+            assert gh_token_data.permissions == {
+                "contents": "write",
+                "metadata": "read",
+                "workflows": "write",
+                "checks": "read",
+                "pull_requests": "write",
+                "statuses": "read",
+            }
+            assert gh_token_data.repository_selection == repo
+
+            gh_token = gh_token_data.token
+
         if "GITHUB_ACTIONS" in os.environ and os.environ["GITHUB_ACTIONS"] == "true":
             sys.stdout.flush()
             print("made GITHUB token and masking it for github actions", flush=True)


### PR DESCRIPTION
<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the 
merge queue.
-->

Checklist
* [ ] CI is passing

This PR adds back injecting app tokens for feedstocks. It will enable us to move to GHA if we want.
