### PR TITLE
feat: update output validation docs and add allow list

### DIFF
--- a/conda_forge_webservices/feedstock_outputs.py
+++ b/conda_forge_webservices/feedstock_outputs.py
@@ -310,7 +310,6 @@ def _is_valid_feedstock_output(
                         },
                     )
                     if r.status_code != 201:
-                        unique_names_valid[un] = False
                         LOGGER.info(
                             f"    output {un} not created for "
                             f"feedstock conda-forge/{feedstock}"

--- a/conda_forge_webservices/feedstock_outputs.py
+++ b/conda_forge_webservices/feedstock_outputs.py
@@ -39,7 +39,7 @@ def _load_allowed_autoreg_feedstock_globs(time_int):
     )
     r.raise_for_status()
     yaml = YAML(typ="safe")
-    return yaml.load(r.text)
+    return yaml.load(r.text.decode("utf-8"))
 
 
 def load_allowed_autoreg_feedstock_globs():

--- a/conda_forge_webservices/feedstock_outputs.py
+++ b/conda_forge_webservices/feedstock_outputs.py
@@ -460,10 +460,11 @@ community [channel](https://app.element.io/#/room/#conda-forge:matrix.org) or yo
     if not is_all_valid:
         message += (
             "\n\n"
-            "To fix package package output validation errors, you can submit "
-            "a PR to our "
-            "[admin requests repo](https://github.com/conda-forge/admin-requests"
-            "?tab=readme-ov-file#add-a-package-output-to-a-feedstock)."
+            "To fix package package output validation errors, follow the "
+            "instructions above to add"
+            "new package outputs to your feedstock or to add your "
+            "feedstock+packages to the allow list for automatic "
+            "registration."
         )
 
     repo = gh.get_repo(f"conda-forge/{feedstock}")

--- a/conda_forge_webservices/feedstock_outputs.py
+++ b/conda_forge_webservices/feedstock_outputs.py
@@ -39,7 +39,7 @@ def _load_allowed_autoreg_feedstock_globs(time_int):
     )
     r.raise_for_status()
     yaml = YAML(typ="safe")
-    return yaml.load(r.text.decode("utf-8"))
+    return yaml.load(r.text)
 
 
 def load_allowed_autoreg_feedstock_globs():

--- a/conda_forge_webservices/feedstock_outputs.py
+++ b/conda_forge_webservices/feedstock_outputs.py
@@ -405,13 +405,19 @@ def comment_on_outputs_copy(feedstock, git_sha, errors, valid, copied):
     message = f"""\
 Hi @conda-forge/{team_name}! This is the friendly automated conda-forge-webservice!
 
-It appears that one or more of your feedstock's outputs did not copy from the
+It appears that one or more of your feedstock's packages did not copy from the
 staging channel (cf-staging) to the production channel (conda-forge). :(
 
 This failure can happen for a lot of reasons, including an outdated feedstock
-token. Below we have put some information about the failure to help you debug it.
+token or your feedstock not having permissions to upload the given package.
+Below we have put some information about the failure to help you debug it.
 
-**Rerendering the feedstock will usually fix these problems.**
+Common ways to fix this problem include:
+
+- Retry the package build and upload by pushing an empty commit to the feedstock.
+- Rerender the feedstock in a PR from a fork of the feedstock and merge.
+- Request a feedstock token reset via our [admin-requests repo](https://github.com/conda-forge/admin-requests?tab=readme-ov-file#reset-your-feedstock-token).
+- Request that any new packages be added to the feedstock via our [admin-requests-repo](https://github.com/conda-forge/admin-requests?tab=readme-ov-file#add-a-package-output-to-a-feedstock).
 
 If you have any issues or questions, you can find us on Element in the
 community [channel](https://app.element.io/#/room/#conda-forge:matrix.org) or you can bump us right here.
@@ -419,7 +425,7 @@ community [channel](https://app.element.io/#/room/#conda-forge:matrix.org) or yo
 
     is_all_valid = True
     if len(valid) > 0:
-        valid_msg = "output validation (is this output allowed for your feedstock?):\n"
+        valid_msg = "output validation (is this package allowed for your feedstock?):\n"
         for o, v in valid.items():
             valid_msg += f" - **{o}**: {v}\n"
             is_all_valid &= v
@@ -428,7 +434,9 @@ community [channel](https://app.element.io/#/room/#conda-forge:matrix.org) or yo
         message += valid_msg
 
     if len(copied) > 0:
-        copied_msg = "copied (did this output get copied to the production channel?):\n"
+        copied_msg = (
+            "copied (did this package get copied to the production channel?):\n"
+        )
         for o, v in copied.items():
             copied_msg += f" - **{o}**: {v}\n"
 
@@ -447,10 +455,10 @@ community [channel](https://app.element.io/#/room/#conda-forge:matrix.org) or yo
     if not is_all_valid:
         message += (
             "\n\n"
-            "To fix invalid outputs, you may need to manually add this feedstock to the"
-            " feedstock-outputs map (did another feedstock already make this package?):"
-            "\n"
-            " - https://github.com/conda-forge/feedstock-outputs"
+            "To fix package package output validation errors, you can submit "
+            "a PR to our "
+            "[admin requests repo](https://github.com/conda-forge/admin-requests"
+            "?tab=readme-ov-file#add-a-package-output-to-a-feedstock)."
         )
 
     repo = gh.get_repo(f"conda-forge/{feedstock}")

--- a/conda_forge_webservices/feedstock_outputs.py
+++ b/conda_forge_webservices/feedstock_outputs.py
@@ -417,7 +417,12 @@ Common ways to fix this problem include:
 - Retry the package build and upload by pushing an empty commit to the feedstock.
 - Rerender the feedstock in a PR from a fork of the feedstock and merge.
 - Request a feedstock token reset via our [admin-requests repo](https://github.com/conda-forge/admin-requests?tab=readme-ov-file#reset-your-feedstock-token).
-- Request that any new packages be added to the feedstock via our [admin-requests-repo](https://github.com/conda-forge/admin-requests?tab=readme-ov-file#add-a-package-output-to-a-feedstock).
+- Request that any new packages be added to the allowed outputs for the feedstock
+  via our [admin-requests-repo](https://github.com/conda-forge/admin-requests?tab=readme-ov-file#add-a-package-output-to-a-feedstock).
+- In rare cases, the package name may change regularly in a well defined way (e.g., `libllvm18`, `libllvm19`, etc.).
+  In this case, please submit a PR updating our
+  [list of feedstocks with allowed glob patterns](https://github.com/conda-forge/admin-requests/blob/main/.feedstock_outputs_autoreg_allowlist.yml).
+  Output packages that match these patterns will be automatically registered for your feedstock.
 
 If you have any issues or questions, you can find us on Element in the
 community [channel](https://app.element.io/#/room/#conda-forge:matrix.org) or you can bump us right here.

--- a/conda_forge_webservices/tests/test_feedstock_outputs.py
+++ b/conda_forge_webservices/tests/test_feedstock_outputs.py
@@ -201,17 +201,21 @@ def test_is_valid_feedstock_output(
         if "bar.json" in name:
             assert "b/a/r/bar.json" in name
             data = {"feedstocks": ["foo", "blah"]}
+            test = None
             status = 200
         elif "goo.json" in name:
             assert "g/o/o/goo.json" in name
             data = {"feedstocks": ["blarg"]}
+            test = None
             status = 200
         elif ".feedstock_outputs_autoreg_allowlist.yml" in name:
             status = 200
             data = None
+            test = None
             text = "{}"
         else:
             status = 404
+            test = None
             data = None
 
         resp = mock.MagicMock()

--- a/conda_forge_webservices/tests/test_feedstock_outputs.py
+++ b/conda_forge_webservices/tests/test_feedstock_outputs.py
@@ -13,6 +13,7 @@ from conda_forge_webservices.feedstock_outputs import (
     _is_valid_output_hash,
     copy_feedstock_outputs,
     validate_feedstock_outputs,
+    check_allowed_autoreg_feedstock_globs,
 )
 
 
@@ -263,3 +264,9 @@ def test_is_valid_feedstock_output(
         assert len(req_mock.put.call_args_list) == 1
     else:
         req_mock.put.assert_not_called()
+
+
+def test_check_allowed_autoreg_feedstock_globs():
+    assert check_allowed_autoreg_feedstock_globs("llvmdev", "libllvm3456")
+    assert not check_allowed_autoreg_feedstock_globs("llvmdev", "python")
+    assert not check_allowed_autoreg_feedstock_globs("blah", "python")

--- a/conda_forge_webservices/tests/test_feedstock_outputs.py
+++ b/conda_forge_webservices/tests/test_feedstock_outputs.py
@@ -206,6 +206,10 @@ def test_is_valid_feedstock_output(
             assert "g/o/o/goo.json" in name
             data = {"feedstocks": ["blarg"]}
             status = 200
+        elif ".feedstock_outputs_autoreg_allowlist.yml" in name:
+            status = 200
+            data = None
+            text = "{}"
         else:
             status = 404
             data = None
@@ -219,6 +223,8 @@ def test_is_valid_feedstock_output(
                     json.dumps(data).encode("utf-8")
                 ).decode("ascii"),
             }
+        if text is not None:
+            resp.text = text
         return resp
 
     req_mock.get = _get_function

--- a/conda_forge_webservices/tests/test_feedstock_outputs.py
+++ b/conda_forge_webservices/tests/test_feedstock_outputs.py
@@ -198,25 +198,21 @@ def test_is_valid_feedstock_output(
     monkeypatch.setenv("FEEDSTOCK_OUTPUTS_REPO", "efg456")
 
     def _get_function(name, *args, **kwargs):
+        data = None
+        text = None
         if "bar.json" in name:
             assert "b/a/r/bar.json" in name
             data = {"feedstocks": ["foo", "blah"]}
-            test = None
             status = 200
         elif "goo.json" in name:
             assert "g/o/o/goo.json" in name
             data = {"feedstocks": ["blarg"]}
-            test = None
             status = 200
         elif ".feedstock_outputs_autoreg_allowlist.yml" in name:
             status = 200
-            data = None
-            test = None
             text = "{}"
         else:
             status = 404
-            test = None
-            data = None
 
         resp = mock.MagicMock()
         resp.status_code = status

--- a/conda_forge_webservices/tests/test_feedstock_outputs.py
+++ b/conda_forge_webservices/tests/test_feedstock_outputs.py
@@ -14,6 +14,7 @@ from conda_forge_webservices.feedstock_outputs import (
     copy_feedstock_outputs,
     validate_feedstock_outputs,
     check_allowed_autoreg_feedstock_globs,
+    _load_allowed_autoreg_feedstock_globs,
 )
 
 
@@ -245,13 +246,13 @@ def test_is_valid_feedstock_output(
         assert valid == {
             "noarch/bar-0.1-py_0.tar.bz2": True,
             "noarch/goo-0.3-py_10.tar.bz2": False,
-            "noarch/glob-0.2-py_12.tar.bz2": True,
+            "noarch/glob-0.2-py_12.tar.bz2": register,
         }
     elif project == "blah":
         assert valid == {
             "noarch/bar-0.1-py_0.tar.bz2": True,
             "noarch/goo-0.3-py_10.tar.bz2": False,
-            "noarch/glob-0.2-py_12.tar.bz2": True,
+            "noarch/glob-0.2-py_12.tar.bz2": register,
         }
     elif project == "blarg":
         assert valid == {
@@ -273,6 +274,7 @@ def test_is_valid_feedstock_output(
 
 
 def test_check_allowed_autoreg_feedstock_globs():
+    _load_allowed_autoreg_feedstock_globs.cache_clear()
     assert check_allowed_autoreg_feedstock_globs("llvmdev", "libllvm3456")
     assert not check_allowed_autoreg_feedstock_globs("llvmdev", "python")
     assert not check_allowed_autoreg_feedstock_globs("blah", "python")


### PR DESCRIPTION
<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the 
merge queue.
-->

Checklist
* [x] CI is passing
