### PR TITLE
feat: use pending status for linting

### DIFF
--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -754,13 +754,13 @@ def restart_pull_request_ci(repo, pr_num):
 
 
 def _determine_recipe_path(repo):
-    """Determine rattler-build or conda-build recipe path."""
+    """Determine v1 or v0 path."""
     recipe_path = os.path.join(repo.working_dir, "recipe", "meta.yaml")
     if os.path.exists(recipe_path):
         return recipe_path
-    rattler_build_recipe_path = os.path.join(repo.working_dir, "recipe", "recipe.yaml")
-    if os.path.exists(rattler_build_recipe_path):
-        return rattler_build_recipe_path
+    v1_recipe_path = os.path.join(repo.working_dir, "recipe", "recipe.yaml")
+    if os.path.exists(v1_recipe_path):
+        return v1_recipe_path
     return None
 
 

--- a/conda_forge_webservices/feedstock_outputs.py
+++ b/conda_forge_webservices/feedstock_outputs.py
@@ -491,7 +491,7 @@ community [channel](https://app.element.io/#/room/#conda-forge:matrix.org) or yo
         message += (
             "\n\n"
             "To fix package package output validation errors, follow the "
-            "instructions above to add"
+            "instructions above to add "
             "new package outputs to your feedstock or to add your "
             "feedstock+packages to the allow list for automatic "
             "registration."

--- a/conda_forge_webservices/linting.py
+++ b/conda_forge_webservices/linting.py
@@ -169,7 +169,11 @@ def _set_pr_status(
 
 
 def compute_lint_message(
-    repo_owner: str, repo_name: str, pr_id: int, ignore_base: bool = False
+    repo_owner: str,
+    repo_name: str,
+    pr_id: int,
+    ignore_base: bool = False,
+    set_pending_status: bool = True,
 ) -> LintInfo | None:
     gh = github.Github(get_app_token_for_webservices_only())
 
@@ -222,7 +226,8 @@ def compute_lint_message(
         if should_skip:
             return None
 
-        _set_pr_status(repo_owner, repo_name, sha, "pending")
+        if set_pending_status:
+            _set_pr_status(repo_owner, repo_name, sha, "pending")
 
         # Raise an error if the PR is not mergeable.
         if not mergeable:
@@ -267,8 +272,9 @@ def compute_lint_message(
     if pull_request.state == "open":
         return {"message": message, "status": status, "sha": sha}
     else:
-        # won't happen later with a comment and we should npt leave things pending
-        _set_pr_status(repo_owner, repo_name, sha, status)
+        if set_pending_status:
+            # won't happen later with a comment and we should not leave things pending
+            _set_pr_status(repo_owner, repo_name, sha, status)
         return None
 
 

--- a/conda_forge_webservices/linting.py
+++ b/conda_forge_webservices/linting.py
@@ -151,8 +151,12 @@ def lint_all_recipes(all_recipe_dir: Path, base_recipes: list[Path]) -> tuple[st
 def _set_pr_status(
     owner: str, repo_name: str, sha: str, status: str, target_url: str | None = None
 ):
-    gh = github.Github(get_app_token_for_webservices_only())
+    if target_url is not None:
+        kwargs = {"target_url": target_url}
+    else:
+        kwargs = {}
 
+    gh = github.Github(get_app_token_for_webservices_only())
     user = gh.get_user(owner)
     repo = user.get_repo(repo_name)
     commit = repo.get_commit(sha)
@@ -160,7 +164,7 @@ def _set_pr_status(
         status,
         description="Linting in progress...",
         context="conda-forge-linter",
-        target_url=target_url,
+        **kwargs,
     )
 
 

--- a/conda_forge_webservices/linting.py
+++ b/conda_forge_webservices/linting.py
@@ -52,11 +52,10 @@ def lint_all_recipes(all_recipe_dir: Path, base_recipes: list[Path]) -> tuple[st
         rel_pr_recipes.append(rel_path)
 
         if recipe.name == "recipe.yaml":
-            # this is a rattler-build recipe and not yet handled
+            # this is a v1 recipe and not yet handled
             hint = "\nFor **{}**:\n\n{}".format(
                 rel_path,
-                "This is a rattler-build recipe and not yet lintable. "
-                "We are working on it!",
+                "This is a v1 recipe and not yet lintable. " "We are working on it!",
             )
             messages.append(hint)
             # also add it to hints so that the PR is marked as mixed

--- a/conda_forge_webservices/tests/linting/test_compute_lint_message.py
+++ b/conda_forge_webservices/tests/linting/test_compute_lint_message.py
@@ -145,7 +145,7 @@ def test_conflict_2_ok_recipe():
     assert expected_message == lint["message"]
 
 
-def test_rattler_build_recipe():
+def test_v1_recipe():
     expected_message = textwrap.dedent("""
     Hi! This is the friendly automated conda-forge-linting service.
 
@@ -157,7 +157,7 @@ def test_rattler_build_recipe():
 
     For **recipe/recipe.yaml**:
 
-    This is a rattler-build recipe and not yet lintable. We are working on it!
+    This is a v1 recipe and not yet lintable. We are working on it!
     """)  # noqa
 
     lint = compute_lint_message(
@@ -267,7 +267,7 @@ I do have some suggestions for making it better though...
 
 For **recipe/recipe.yaml**:
 
-This is a rattler-build recipe and not yet lintable. We are working on it!
+This is a v1 recipe and not yet lintable. We are working on it!
 """,  # noqa
             "mixed",
         )

--- a/conda_forge_webservices/tests/linting/test_compute_lint_message.py
+++ b/conda_forge_webservices/tests/linting/test_compute_lint_message.py
@@ -12,22 +12,30 @@ def data_folder():
 
 
 def test_skip_ci_recipe():
-    lint = compute_lint_message("conda-forge", "conda-forge-webservices", 58)
+    lint = compute_lint_message(
+        "conda-forge", "conda-forge-webservices", 58, set_pending_status=False
+    )
     assert lint is None
 
 
 def test_skip_lint_recipe():
-    lint = compute_lint_message("conda-forge", "conda-forge-webservices", 59)
+    lint = compute_lint_message(
+        "conda-forge", "conda-forge-webservices", 59, set_pending_status=False
+    )
     assert lint is None
 
 
 def test_ci_skip_recipe():
-    lint = compute_lint_message("conda-forge", "conda-forge-webservices", 65)
+    lint = compute_lint_message(
+        "conda-forge", "conda-forge-webservices", 65, set_pending_status=False
+    )
     assert lint is None
 
 
 def test_lint_skip_recipe():
-    lint = compute_lint_message("conda-forge", "conda-forge-webservices", 66)
+    lint = compute_lint_message(
+        "conda-forge", "conda-forge-webservices", 66, set_pending_status=False
+    )
     assert lint is None
 
 
@@ -40,7 +48,9 @@ def test_good_recipe():
 
     """  # noqa
 
-    lint = compute_lint_message("conda-forge", "conda-forge-webservices", 16)
+    lint = compute_lint_message(
+        "conda-forge", "conda-forge-webservices", 16, set_pending_status=False
+    )
     assert lint is not None, lint["message"]
     assert "found it was in an excellent condition." in lint["message"], lint["message"]
 
@@ -53,7 +63,9 @@ def test_ok_recipe_above_good_recipe():
 
     """)  # noqa
 
-    lint = compute_lint_message("conda-forge", "conda-forge-webservices", 54)
+    lint = compute_lint_message(
+        "conda-forge", "conda-forge-webservices", 54, set_pending_status=False
+    )
     assert expected_message == lint["message"]
 
 
@@ -65,7 +77,9 @@ def test_ok_recipe_beside_good_recipe():
 
     """)  # noqa
 
-    lint = compute_lint_message("conda-forge", "conda-forge-webservices", 62)
+    lint = compute_lint_message(
+        "conda-forge", "conda-forge-webservices", 62, set_pending_status=False
+    )
     assert expected_message == lint["message"]
 
 
@@ -77,7 +91,9 @@ def test_ok_recipe_above_ignored_good_recipe():
 
     """)  # noqa
 
-    lint = compute_lint_message("conda-forge", "conda-forge-webservices", 54, True)
+    lint = compute_lint_message(
+        "conda-forge", "conda-forge-webservices", 54, True, set_pending_status=False
+    )
     assert expected_message == lint["message"]
 
 
@@ -89,7 +105,9 @@ def test_ok_recipe_beside_ignored_good_recipe():
 
     """)  # noqa
 
-    lint = compute_lint_message("conda-forge", "conda-forge-webservices", 62, True)
+    lint = compute_lint_message(
+        "conda-forge", "conda-forge-webservices", 62, True, set_pending_status=False
+    )
     assert expected_message == lint["message"]
 
 
@@ -103,7 +121,9 @@ def test_conflict_ok_recipe():
     Please ping the 'conda-forge/core' team (using the @ notation in a comment) if you believe this is a bug.
     """)  # noqa
 
-    lint = compute_lint_message("conda-forge", "conda-forge-webservices", 56)
+    lint = compute_lint_message(
+        "conda-forge", "conda-forge-webservices", 56, set_pending_status=False
+    )
     assert lint is not None, lint["message"]
     assert expected_message == lint["message"]
 
@@ -118,7 +138,9 @@ def test_conflict_2_ok_recipe():
     Please ping the 'conda-forge/core' team (using the @ notation in a comment) if you believe this is a bug.
     """)  # noqa
 
-    lint = compute_lint_message("conda-forge", "conda-forge-webservices", 57)
+    lint = compute_lint_message(
+        "conda-forge", "conda-forge-webservices", 57, set_pending_status=False
+    )
     assert lint is not None, lint["message"]
     assert expected_message == lint["message"]
 
@@ -134,11 +156,13 @@ def test_rattler_build_recipe():
 
 
     For **recipe/recipe.yaml**:
-    
+
     This is a rattler-build recipe and not yet lintable. We are working on it!
     """)  # noqa
 
-    lint = compute_lint_message("conda-forge", "conda-forge-webservices", 632)
+    lint = compute_lint_message(
+        "conda-forge", "conda-forge-webservices", 632, set_pending_status=False
+    )
     assert lint is not None, lint["message"]
     assert expected_message == lint["message"]
 
@@ -165,7 +189,9 @@ def test_bad_recipe():
         * Recipe maintainer "support" does not exist
     """  # noqa
 
-    lint = compute_lint_message("conda-forge", "conda-forge-webservices", 17)
+    lint = compute_lint_message(
+        "conda-forge", "conda-forge-webservices", 17, set_pending_status=False
+    )
     assert lint is not None, lint["message"]
     assert "found some lint" in lint["message"], lint["message"]
     assert "The home item is expected in the about section." in lint["message"], lint[
@@ -190,7 +216,9 @@ def test_mixed_recipe():
         * Whenever possible python packages should use pip. See https://conda-forge.org/docs/maintainer/adding_pkgs.html#use-pip
     """  # noqa
 
-    lint = compute_lint_message("conda-forge", "conda-forge-webservices", 217)
+    lint = compute_lint_message(
+        "conda-forge", "conda-forge-webservices", 217, set_pending_status=False
+    )
     assert lint is not None, lint["message"]
     assert (
         "I do have some suggestions for making it better though" in lint["message"]
@@ -205,13 +233,17 @@ def test_no_recipe():
     Please ping the 'conda-forge/core' team (using the @ notation in a comment) if you believe this is a bug.
     """)  # noqa
 
-    lint = compute_lint_message("conda-forge", "conda-forge-webservices", 523)
+    lint = compute_lint_message(
+        "conda-forge", "conda-forge-webservices", 523, set_pending_status=False
+    )
     assert lint is not None, lint["message"]
     assert expected_message == lint["message"]
 
 
 def test_closed_pr():
-    lint = compute_lint_message("conda-forge", "conda-forge-webservices", 52)
+    lint = compute_lint_message(
+        "conda-forge", "conda-forge-webservices", 52, set_pending_status=False
+    )
     assert lint is None
 
 

--- a/conda_forge_webservices/tests/linting/test_main.py
+++ b/conda_forge_webservices/tests/linting/test_main.py
@@ -131,3 +131,19 @@ def test_cli_success_no_recipe(skip_if_no_tokens):
     )
     out, _ = child.communicate()
     assert child.returncode == 0, out
+
+
+def test_cli_success_v1_recipe(skip_if_no_tokens):
+    child = subprocess.Popen(
+        [
+            sys.executable,
+            "-m" "conda_forge_webservices.linting",
+            "conda-forge/conda-forge-webservices",
+            "632",
+            "--enable-commenting",
+        ],
+        stdout=subprocess.PIPE,
+        env=os.environ,
+    )
+    out, _ = child.communicate()
+    assert child.returncode == 0, out

--- a/conda_forge_webservices/tests/linting/test_main.py
+++ b/conda_forge_webservices/tests/linting/test_main.py
@@ -115,3 +115,19 @@ def test_cli_success_good(skip_if_no_tokens):
     )
     out, _ = child.communicate()
     assert child.returncode == 0, out
+
+
+def test_cli_success_no_recipe(skip_if_no_tokens):
+    child = subprocess.Popen(
+        [
+            sys.executable,
+            "-m" "conda_forge_webservices.linting",
+            "conda-forge/conda-forge-webservices",
+            "523",
+            "--enable-commenting",
+        ],
+        stdout=subprocess.PIPE,
+        env=os.environ,
+    )
+    out, _ = child.communicate()
+    assert child.returncode == 0, out


### PR DESCRIPTION
<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the 
merge queue.
-->

Checklist
* [ ] CI is passing
