### PR TITLE
feat: move outputs allow list

### DIFF
--- a/conda_forge_webservices/feedstock_outputs.py
+++ b/conda_forge_webservices/feedstock_outputs.py
@@ -34,8 +34,8 @@ PROD = "conda-forge"
 @lru_cache(maxsize=1)
 def _load_allowed_autoreg_feedstock_globs(time_int):
     r = requests.get(
-        "https://raw.githubusercontent.com/conda-forge/admin-requests/"
-        "main/.feedstock_outputs_autoreg_allowlist.yml"
+        "https://raw.githubusercontent.com/conda-forge/feedstock-outputs/"
+        "main/feedstock_outputs_autoreg_allowlist.yml"
     )
     r.raise_for_status()
     yaml = YAML(typ="safe")
@@ -451,7 +451,7 @@ Common ways to fix this problem include:
   via our [admin-requests repo](https://github.com/conda-forge/admin-requests?tab=readme-ov-file#add-a-package-output-to-a-feedstock).
 - In rare cases, the package name may change regularly in a well defined way (e.g., `libllvm18`, `libllvm19`, etc.).
   In this case, please submit a PR updating our
-  [list of feedstocks with allowed glob patterns](https://github.com/conda-forge/admin-requests/blob/main/.feedstock_outputs_autoreg_allowlist.yml).
+  [list of feedstocks with allowed glob patterns](https://github.com/conda-forge/feedstock-outputs/blob/main/feedstock_outputs_autoreg_allowlist.yml).
   Output packages that match these patterns will be automatically registered for your feedstock.
 
 If you have any issues or questions, you can find us on Element in the

--- a/conda_forge_webservices/tests/test_feedstock_outputs.py
+++ b/conda_forge_webservices/tests/test_feedstock_outputs.py
@@ -209,7 +209,7 @@ def test_is_valid_feedstock_output(
             assert "g/o/o/goo.json" in name
             data = {"feedstocks": ["blarg"]}
             status = 200
-        elif ".feedstock_outputs_autoreg_allowlist.yml" in name:
+        elif "feedstock_outputs_autoreg_allowlist.yml" in name:
             status = 200
             text = "{}"
         else:


### PR DESCRIPTION
<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the 
merge queue.
-->

Checklist
* [ ] CI is passing
