### PR TITLE
fix: make sure to add output file when autoregistering with globs

### DIFF
--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -2,7 +2,7 @@ anaconda-client>=1.8.0
 cachetools
 conda
 conda-build
-conda-forge-metadata>=0.4.1
+conda-forge-metadata>=0.9.1
 conda-forge-pinning
 conda-smithy>=3.34.1  # this pin is for jinja2 sandboxes
 cryptography>=39

--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -12,7 +12,7 @@ lxml
 mock
 parameterized
 pygithub>=2.2.0  # for GH App endpoints
-python=3.10.*
+python=3.11.*
 pytz
 requests
 ruamel.yaml>=0.16

--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -2,7 +2,7 @@ anaconda-client>=1.8.0
 cachetools
 conda
 conda-build
-conda-forge-metadata>=0.9.1
+conda-forge-metadata>=0.9.2
 conda-forge-pinning
 conda-smithy>=3.34.1  # this pin is for jinja2 sandboxes
 cryptography>=39

--- a/conda_forge_webservices/feedstock_outputs.py
+++ b/conda_forge_webservices/feedstock_outputs.py
@@ -16,7 +16,10 @@ import github
 
 from binstar_client.utils import get_server_api
 from binstar_client import BinstarError
-from conda_forge_metadata.feedstock_outputs import package_to_feedstock
+from conda_forge_metadata.feedstock_outputs import (
+    package_to_feedstock,
+    feedstock_outputs_config,
+)
 from conda_forge_metadata.feedstock_outputs import sharded_path as _get_sharded_path
 import binstar_client.errors
 
@@ -386,7 +389,9 @@ def validate_feedstock_outputs(
     valid_outputs = _is_valid_feedstock_output(
         project,
         outputs_to_test,
-        register=True,  # ** DO NOT TURN TO TRUE UNLESS YOU KNOW WHAT YOU ARE DOING. **
+        # to turn this off, set the value in the config.json blob in
+        # conda-forge/feedstock-outputs
+        register=feedstock_outputs_config().get("auto_register_all", False),
     )
 
     valid_hashes = _is_valid_output_hash(outputs_to_test, hash_type)

--- a/conda_forge_webservices/feedstock_outputs.py
+++ b/conda_forge_webservices/feedstock_outputs.py
@@ -304,7 +304,7 @@ def _is_valid_feedstock_output(
     for un in unique_names:
         try:
             registered_feedstocks = package_to_feedstock(un)
-        except requests.HTTPError:
+        except requests.exceptions.HTTPError:
             registered_feedstocks = []
 
         if registered_feedstocks:

--- a/conda_forge_webservices/tests/test_feedstock_outputs.py
+++ b/conda_forge_webservices/tests/test_feedstock_outputs.py
@@ -243,6 +243,7 @@ def test_is_valid_feedstock_output(
         return return_value
 
     p2f_mock.__call__ = _get_p2f_fun
+    print(p2f_mock("g/o/o/goo.json"), p2f_mock("b/a/r/bar.json"), p2f_mock("blah.json"))
 
     outputs = [
         "noarch/bar-0.1-py_0.tar.bz2",

--- a/conda_forge_webservices/tests/test_feedstock_outputs.py
+++ b/conda_forge_webservices/tests/test_feedstock_outputs.py
@@ -284,13 +284,7 @@ def test_is_valid_feedstock_output(
             "noarch/glob-0.2-py_12.tar.bz2": register,
         }
 
-    if register and project in [
-        "foo",
-        "foo-feedstock",
-        "blah",
-        "blarg-feedstock",
-        "boo-feedstock",
-    ]:
+    if register:
         assert afs_mock.called_once_with(project.replace("-feedstock", ""), "glob")
     else:
         afs_mock.assert_not_called()

--- a/conda_forge_webservices/tests/test_feedstock_outputs.py
+++ b/conda_forge_webservices/tests/test_feedstock_outputs.py
@@ -187,7 +187,9 @@ def test_is_valid_output_hash():
     "project", ["foo-feedstock", "blah", "foo", "blarg-feedstock", "boo-feedstock"]
 )
 @mock.patch("conda_forge_webservices.feedstock_outputs.requests")
+@mock.patch("conda_forge_webservices.feedstock_outputs.package_to_feedstock")
 def test_is_valid_feedstock_output(
+    p2f_mock,
     req_mock,
     monkeypatch,
     project,
@@ -227,6 +229,20 @@ def test_is_valid_feedstock_output(
         return resp
 
     req_mock.get = _get_function
+
+    def _get_p2f_fun(name):
+        if "bar.json" in name:
+            assert "b/a/r/bar.json" in name
+            return_value = ["foo", "blah"]
+        elif "goo.json" in name:
+            assert "g/o/o/goo.json" in name
+            return_value = ["blarg"]
+        else:
+            return_value = []
+
+        return return_value
+
+    p2f_mock.__call__ = _get_p2f_fun
 
     outputs = [
         "noarch/bar-0.1-py_0.tar.bz2",

--- a/conda_forge_webservices/tests/test_feedstock_outputs.py
+++ b/conda_forge_webservices/tests/test_feedstock_outputs.py
@@ -242,8 +242,7 @@ def test_is_valid_feedstock_output(
 
         return return_value
 
-    p2f_mock.__call__ = _get_p2f_fun
-    print(p2f_mock("g/o/o/goo.json"), p2f_mock("b/a/r/bar.json"), p2f_mock("blah.json"))
+    p2f_mock.side_effect = _get_p2f_fun
 
     outputs = [
         "noarch/bar-0.1-py_0.tar.bz2",

--- a/conda_forge_webservices/tests/test_feedstock_outputs.py
+++ b/conda_forge_webservices/tests/test_feedstock_outputs.py
@@ -13,8 +13,6 @@ from conda_forge_webservices.feedstock_outputs import (
     _is_valid_output_hash,
     copy_feedstock_outputs,
     validate_feedstock_outputs,
-    check_allowed_autoreg_feedstock_globs,
-    _load_allowed_autoreg_feedstock_globs,
 )
 
 
@@ -271,10 +269,3 @@ def test_is_valid_feedstock_output(
         assert len(req_mock.put.call_args_list) == 1
     else:
         req_mock.put.assert_not_called()
-
-
-def test_check_allowed_autoreg_feedstock_globs():
-    _load_allowed_autoreg_feedstock_globs.cache_clear()
-    assert check_allowed_autoreg_feedstock_globs("llvmdev", "libllvm3456")
-    assert not check_allowed_autoreg_feedstock_globs("llvmdev", "python")
-    assert not check_allowed_autoreg_feedstock_globs("blah", "python")


### PR DESCRIPTION
<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the 
merge queue.
-->

Checklist
* [x] CI is passing

closes #668 
