### PR TITLE
fix: relock does not play nice with more than one env

### DIFF
--- a/.github/workflows/clean-and-update.yml
+++ b/.github/workflows/clean-and-update.yml
@@ -6,22 +6,11 @@ on:
   workflow_dispatch: null
 
 jobs:
-  clean-and-update:
-    name: clean-and-update
+  relock:
+    name: relock
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-
-      - name: setup conda
-        uses: mamba-org/setup-micromamba@f8b8a1e23a26f60a44c853292711bacfd3eac822 # v1
-        with:
-          environment-file: conda-lock.yml
-          environment-name: webservices
-          condarc: |
-            show_channel_urls: true
-            channel_priority: strict
-            channels:
-              - conda-forge
 
       - name: generate token
         id: generate_token
@@ -44,26 +33,51 @@ jobs:
             conda-libmamba-solver
             mamba
 
+  clean-and-cache:
+    name: clean-and-cache
+    runs-on: "ubuntu-latest"
+    defaults:
+      run:
+        shell: bash -leo pipefail {0}
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+
+      - name: setup conda
+        uses: mamba-org/setup-micromamba@f8b8a1e23a26f60a44c853292711bacfd3eac822 # v1
+        with:
+          environment-file: conda-lock.yml
+          environment-name: webservices
+          condarc: |
+            show_channel_urls: true
+            channel_priority: strict
+            channels:
+              - conda-forge
+
+      - name: generate token
+        id: generate_token
+        uses: actions/create-github-app-token@31c86eb3b33c9b601a1f60f98dcbfd1d70f379b4 # v1
+        with:
+          app-id: ${{ secrets.CF_CURATOR_APP_ID }}
+          private-key: ${{ secrets.CF_CURATOR_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: install code
-        shell: bash -l {0}
         run: |
           git config --global user.email "79913779+conda-forge-curator[bot]@users.noreply.github.com"
           git config --global user.name "conda-forge-curator[bot]"
           git config --global pull.rebase false
           mkdir -p ~/.conda-smithy/ && echo $GH_TOKEN > ~/.conda-smithy/github.token
-          pip install --no-deps -e .
+          pip install --no-deps --no-build-isolation -e .
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
 
       - name: clean cf-staging
-        shell: bash -l {0}
         run: |
           python scripts/clean_cf_staging.py
         env:
           STAGING_BINSTAR_TOKEN: ${{ secrets.HEROKU_ONLY_STAGING_BINSTAR_TOKEN }}
 
       - name: cache status data
-        shell: bash -l {0}
         run: |
           cache-status-data
         env:


### PR DESCRIPTION
### Description

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

This PR fixes the clean and update script to use two jobs so we can relock and clean.

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
