### PR TITLE
feat: deploy directly to heroku

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,19 +8,20 @@ on:
 
 env:
   PY_COLORS: "1"
-  IMAGE_NAME: condaforge/conda-forge-webservices
 
 concurrency:
   group: release
   cancel-in-progress: false
 
 jobs:
-  release:
-    name: release
+  tag-and-release:
+    name: tag-and-release
     runs-on: "ubuntu-latest"
     defaults:
       run:
         shell: bash -leo pipefail {0}
+    outputs:
+      new_version: ${{ steps.version.outputs.NEXT }}
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
@@ -45,48 +46,90 @@ jobs:
           echo "next version: ${NEXT}"
           echo "NEXT=${NEXT}" >> "$GITHUB_OUTPUT"
 
-      # TODO: move webservices-dispatch-action to this repo and push via the following
-      # - name: set up docker buildx
-      #   uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3
-
-      # - name: login to docker hub
-      #   uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
-      #   with:
-      #     username: condaforgebot
-      #     password: ${{ secrets.CF_BOT_DH_PASSWORD }}
-
-      # - name: build docker metadata
-      #   id: meta
-      #   uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5
-      #   with:
-      #     images: ${{ env.IMAGE_NAME }}
-      #     flavor: |
-      #       latest=false
-      #     tags: |
-      #       type=raw,value=${{ steps.version.outputs.NEXT }}
-      #       type=raw,value=latest
-
-      # - name: build and push image
-      #   uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85 # v6
-      #   with:
-      #     context: .
-      #     push: true
-      #     tags: ${{ steps.meta.outputs.tags }}
-      #     labels: ${{ steps.meta.outputs.labels }}
-
-      # - name: push README to docker hub
-      #   uses: christian-korneck/update-container-description-action@d36005551adeaba9698d8d67a296bd16fa91f8e8 # v1
-      #   env:
-      #     DOCKER_USER: condaforgebot
-      #     DOCKER_PASS: ${{ secrets.CF_BOT_DH_PASSWORD }}
-      #   with:
-      #     destination_container_repo: ${{ env.IMAGE_NAME }}:latest
-      #     provider: dockerhub
-      #     short_description: "conda-forge-webservices image used to power the admin webservices GitHub Actions integrations"
-      #     readme_file: "Dockerfile_README.md"
-
       - name: tag and release
         run: |
           python scripts/release.py "${{ steps.version.outputs.NEXT }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # FIXME: uncomment this when dispatch work is here
+  # build-and-push-dispatch-container:
+  #   name: build and push dispatch container
+  #   runs-on: "ubuntu-latest"
+  #   needs: tag-and-release
+  #   defaults:
+  #     run:
+  #       shell: bash -leo pipefail {0}
+  #   env:
+  #     IMAGE_NAME: condaforge/conda-forge-webservices-gha-dispatch
+
+  #   steps:
+  #     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+  #       with:
+  #         fetch-depth: 0
+
+  #     - uses: mamba-org/setup-micromamba@f8b8a1e23a26f60a44c853292711bacfd3eac822 # v1
+  #       with:
+  #         environment-file: conda-lock.yml
+  #         environment-name: webservices
+  #         condarc: |
+  #           show_channel_urls: true
+  #           channel_priority: strict
+  #           channels:
+  #             - conda-forge
+
+  #     - name: set up docker buildx
+  #       uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3
+
+  #     - name: login to docker hub
+  #       uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
+  #       with:
+  #         username: condaforgebot
+  #         password: ${{ secrets.CF_BOT_DH_PASSWORD }}
+
+  #     - name: build docker metadata
+  #       id: meta
+  #       uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5
+  #       with:
+  #         images: ${{ env.IMAGE_NAME }}
+  #         flavor: |
+  #           latest=false
+  #         tags: |
+  #           type=raw,value=${{ needs.tag-and-release.outputs.new_version }}
+  #           type=raw,value=latest
+
+  #     - name: build and push image
+  #       uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85 # v6
+  #       with:
+  #         context: .
+  #         push: true
+  #         tags: ${{ steps.meta.outputs.tags }}
+  #         labels: ${{ steps.meta.outputs.labels }}
+
+  #     - name: push README to docker hub
+  #       uses: christian-korneck/update-container-description-action@d36005551adeaba9698d8d67a296bd16fa91f8e8 # v1
+  #       env:
+  #         DOCKER_USER: condaforgebot
+  #         DOCKER_PASS: ${{ secrets.CF_BOT_DH_PASSWORD }}
+  #       with:
+  #         destination_container_repo: ${{ env.IMAGE_NAME }}:${{ needs.tag-and-release.outputs.new_version }}
+  #         provider: dockerhub
+  #         short_description: "conda-forge-webservices image used to power the admin webservices GitHub Actions integrations"
+  #         readme_file: "Dockerfile_README.md"
+
+  build-and-push-to-heroku:
+    name: build and push to heroku
+    runs-on: "ubuntu-latest"
+    needs: tag-and-release  # FIXME: change to build-and-push-dispatch-container when we do that
+
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        with:
+          ref: ${{ needs.tag-and-release.outputs.new_version }}
+
+      - name: build and push to heroku
+        uses: gonuit/heroku-docker-deploy@9ab97585f979857642d66612a2ae4062b3347d53
+        with:
+          email: ${{ secrets.HEROKU_EMAIL }}
+          heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
+          heroku_app_name: conda-forge

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -5,7 +5,7 @@ import github
 
 tag = sys.argv[1]
 gh = github.Github(auth=github.Auth.Token(os.environ["GITHUB_TOKEN"]))
-repo = gh.get_repo("regro/cf-scripts")
+repo = gh.get_repo("conda-forge/conda-forge-webservices")
 
 repo.create_git_release(
     tag=tag,


### PR DESCRIPTION
### Description

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

This PR moves the code to use a direct deploy to heroku.

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
