### PR TITLE
feat: enable relocking in PRs

### DIFF
--- a/.github/workflows/clean-and-update.yml
+++ b/.github/workflows/clean-and-update.yml
@@ -22,7 +22,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: relock
-        uses: beckermr/relock-conda@37dda99dfc45d796d0b2526761856b10ff257d32
+        uses: beckermr/relock-conda@2fef2c0c536910c687bf0ae5a5691ab5da5fe579
         with:
           github-token: ${{ steps.generate_token.outputs.token }}
           automerge: true

--- a/.github/workflows/clean-and-update.yml
+++ b/.github/workflows/clean-and-update.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: "0 * * * *"
   workflow_dispatch: null
+  issue_comment:
 
 jobs:
   relock:
@@ -36,6 +37,7 @@ jobs:
   clean-and-cache:
     name: clean-and-cache
     runs-on: "ubuntu-latest"
+    if: github.event_name != 'issue_comment'
     defaults:
       run:
         shell: bash -leo pipefail {0}


### PR DESCRIPTION
### Description

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
