### PR TITLE
feat: enable new linting and rerendering for testing

### DIFF
--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -987,10 +987,8 @@ def rerender(full_name, pr_num):
     _, repo_name = full_name.split("/")
     if repo_name == "cf-autotick-bot-test-package-feedstock":
         ref = conda_forge_webservices.__version__.replace("+", ".")
-        workflow = (
-            gh
-            .get_repo("conda-forge/conda-forge-webservices")
-            .get_workflow("webservices-workflow-dispatch.yml")
+        workflow = gh.get_repo("conda-forge/conda-forge-webservices").get_workflow(
+            "webservices-workflow-dispatch.yml"
         )
         running = workflow.create_dispatch(
             ref=ref,

--- a/conda_forge_webservices/linting.py
+++ b/conda_forge_webservices/linting.py
@@ -43,10 +43,8 @@ def lint_via_github_actions(full_name: str, pr_num: int) -> bool:
 
     if repo_name == "cf-autotick-bot-test-package-feedstock":
         ref = conda_forge_webservices.__version__.replace("+", ".")
-        workflow = (
-            gh
-            .get_repo("conda-forge/conda-forge-webservices")
-            .get_workflow("webservices-workflow-dispatch.yml")
+        workflow = gh.get_repo("conda-forge/conda-forge-webservices").get_workflow(
+            "webservices-workflow-dispatch.yml"
         )
         running = workflow.create_dispatch(
             ref=ref,


### PR DESCRIPTION
### Description

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

This PR turns on the new workflows in order to test them out on the test feedstock.

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
