### PR TITLE
feat: move rerender and linting to new gha integration

### DIFF
--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -985,25 +985,19 @@ def rerender(full_name, pr_num):
     inject_app_token_into_feedstock_readonly(full_name, repo=repo)
 
     _, repo_name = full_name.split("/")
-    if repo_name == "cf-autotick-bot-test-package-feedstock":
-        ref = __version__.replace("+", ".")
-        workflow = gh.get_repo("conda-forge/conda-forge-webservices").get_workflow(
-            "webservices-workflow-dispatch.yml"
-        )
-        running = workflow.create_dispatch(
-            ref=ref,
-            inputs={
-                "task": "rerender",
-                "repo": repo_name,
-                "pr_number": str(pr_num),
-                "container_tag": ref,
-            },
-        )
-    else:
-        running = repo.create_repository_dispatch(
-            "rerender",
-            client_payload={"pr": pr_num},
-        )
+    ref = __version__.replace("+", ".")
+    workflow = gh.get_repo("conda-forge/conda-forge-webservices").get_workflow(
+        "webservices-workflow-dispatch.yml"
+    )
+    running = workflow.create_dispatch(
+        ref=ref,
+        inputs={
+            "task": "rerender",
+            "repo": repo_name,
+            "pr_number": str(pr_num),
+            "container_tag": ref,
+        },
+    )
 
     return not running
 

--- a/conda_forge_webservices/linting.py
+++ b/conda_forge_webservices/linting.py
@@ -41,25 +41,19 @@ def lint_via_github_actions(full_name: str, pr_num: int) -> bool:
     if should_skip:
         return False
 
-    if repo_name == "cf-autotick-bot-test-package-feedstock":
-        ref = __version__.replace("+", ".")
-        workflow = gh.get_repo("conda-forge/conda-forge-webservices").get_workflow(
-            "webservices-workflow-dispatch.yml"
-        )
-        running = workflow.create_dispatch(
-            ref=ref,
-            inputs={
-                "task": "lint",
-                "repo": repo_name,
-                "pr_number": str(pr_num),
-                "container_tag": ref,
-            },
-        )
-    else:
-        running = repo.create_repository_dispatch(
-            "lint",
-            client_payload={"pr": pr_num},
-        )
+    ref = __version__.replace("+", ".")
+    workflow = gh.get_repo("conda-forge/conda-forge-webservices").get_workflow(
+        "webservices-workflow-dispatch.yml"
+    )
+    running = workflow.create_dispatch(
+        ref=ref,
+        inputs={
+            "task": "lint",
+            "repo": repo_name,
+            "pr_number": str(pr_num),
+            "container_tag": ref,
+        },
+    )
 
     if running:
         _set_pr_status(repo_owner, repo_name, sha, "pending")


### PR DESCRIPTION
### Description

This PR moves linting and rerendering to the new GHA integration for everything.

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
