### PR TITLE
fix: do not commit if there is an error

### DIFF
--- a/conda_forge_webservices/github_actions_integration/__main__.py
+++ b/conda_forge_webservices/github_actions_integration/__main__.py
@@ -230,28 +230,31 @@ def main_finalize_task(task_data_dir):
                 repo,
             )
 
-            sync_dirs(
-                source_feedstock_dir,
-                feedstock_dir,
-                ignore_dot_git=True,
-                update_git=True,
-            )
-            subprocess.run(
-                ["git", "add", "."],
-                cwd=feedstock_dir,
-                check=True,
-            )
-            subprocess.run(
-                [
-                    "git",
-                    "commit",
-                    "-m",
-                    task_results["commit_message"],
-                    "--allow-empty",
-                ],
-                cwd=feedstock_dir,
-                check=True,
-            )
+            if not task_results["rerender_error"]:
+                sync_dirs(
+                    source_feedstock_dir,
+                    feedstock_dir,
+                    ignore_dot_git=True,
+                    update_git=True,
+                )
+                subprocess.run(
+                    ["git", "add", "."],
+                    cwd=feedstock_dir,
+                    check=True,
+                )
+
+                if task_results["commit_message"]:
+                    subprocess.run(
+                        [
+                            "git",
+                            "commit",
+                            "-m",
+                            task_results["commit_message"],
+                            "--allow-empty",
+                        ],
+                        cwd=feedstock_dir,
+                        check=True,
+                    )
 
         # now do any comments and/or pushes
         if task == "rerender":


### PR DESCRIPTION
### Description

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

This PR fixes an issue where we attempt to commit rerenders that have error.

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
