### PR TITLE
fix: bug in processing version requests / inputs

### DIFF
--- a/conda_forge_webservices/github_actions_integration/__main__.py
+++ b/conda_forge_webservices/github_actions_integration/__main__.py
@@ -98,11 +98,15 @@ def main_run_task(task, repo, pr_number, task_data_dir, requested_version):
         task_data["task_results"]["info_message"] = info_message
         task_data["task_results"]["commit_message"] = commit_message
     elif task == "version_update":
-        if requested_version == "null" or not requested_version:
+        if (
+            requested_version.lower() == "null"
+            or requested_version.lower() == "none"
+            or not requested_version
+        ):
             requested_version = None
 
         LOGGER.info(
-            "version update requested version: %s",
+            "version update requested version: '%s'",
             requested_version,
         )
         _pull_docker_image()


### PR DESCRIPTION
### Description

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

This PR fixes a bug in processing version requests. It was missed in the tests due to how things get called in production versus testing.

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
