### PR TITLE
feat: handle per-recipe errors in linting

### DIFF
--- a/conda_forge_webservices/github_actions_integration/__main__.py
+++ b/conda_forge_webservices/github_actions_integration/__main__.py
@@ -152,7 +152,7 @@ def main_run_task(task, repo, pr_number, task_data_dir, requested_version):
             res = lint_feedstock(feedstock_dir, use_container=True)
             if len(res) == 2:
                 lints, hints = res
-                errors = None
+                errors = {}
             else:
                 lints, hints, errors = res
             lint_error = False


### PR DESCRIPTION
### Description

This PR sets up the code to handle per recipe linting runtime failures. We'll need a PR in conda-forge-feedstock-ops after this to generate those errors.

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
