### PR TITLE
feat: squash the docker image

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -114,25 +114,48 @@ jobs:
           version=$(python -c "import conda_forge_webservices; print(conda_forge_webservices.__version__.replace('+', '.'))")
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
-      - name: set up docker buildx
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'conda-forge/conda-forge-webservices'
-        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3
+      - name: enable experimental docker features (needed for squash)
+        run: |
+          sudo cp docker_daemon_config.json /etc/docker/daemon.json
+          sudo service docker restart
 
-      - name: login to docker hub
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'conda-forge/conda-forge-webservices'
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
-        with:
-          username: condaforgebot
-          password: ${{ secrets.CF_BOT_DH_PASSWORD }}
+      - name: docker info
+        run: |
+          docker info
 
-      - name: build and push docker image
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'conda-forge/conda-forge-webservices'
-        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v5
-        with:
-          context: .
-          file: Dockerfile_wda
-          push: true
-          tags: condaforge/webservices-dispatch-action:${{ steps.install-code.outputs.version }}
+      - name: build and push
+        run: |
+          image_tag=condaforge/webservices-dispatch-action:${{ steps.install-code.outputs.version }}
+
+          docker build \
+            -t ${image_tag} \
+            -f Dockerfile_wda \
+            --no-cache --squash .
+
+          docker login -u condaforgebot -p $DH_PASSWORD
+          docker push ${image_tag}
+        env:
+          DH_PASSWORD: ${{ secrets.CF_BOT_DH_PASSWORD }}
+
+      # - name: set up docker buildx
+      #   if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'conda-forge/conda-forge-webservices'
+      #   uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3
+
+      # - name: login to docker hub
+      #   if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'conda-forge/conda-forge-webservices'
+      #   uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
+      #   with:
+      #     username: condaforgebot
+      #     password: ${{ secrets.CF_BOT_DH_PASSWORD }}
+
+      # - name: build and push docker image
+      #   if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'conda-forge/conda-forge-webservices'
+      #   uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v5
+      #   with:
+      #     context: .
+      #     file: Dockerfile_wda
+      #     push: true
+      #     tags: condaforge/webservices-dispatch-action:${{ steps.install-code.outputs.version }}
 
   live-tests-upload:
     name: live-tests-upload

--- a/docker_daemon_config.json
+++ b/docker_daemon_config.json
@@ -1,0 +1,3 @@
+{
+    "experimental": true
+}


### PR DESCRIPTION
### Description

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

This PR enables docker image squashing. 

fixes #707 

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
