### PR TITLE
fix: handle linting errors properly

### DIFF
--- a/conda_forge_webservices/github_actions_integration/__main__.py
+++ b/conda_forge_webservices/github_actions_integration/__main__.py
@@ -152,7 +152,11 @@ def main_run_task(task, repo, pr_number, task_data_dir, requested_version):
             res = lint_feedstock(feedstock_dir, use_container=True)
             if len(res) == 2:
                 lints, hints = res
-                errors = {}
+                all_keys = set(lints.keys()) | set(hints.keys())
+                errors = {
+                    key: False
+                    for key in all_keys
+                }
             else:
                 lints, hints, errors = res
             lint_error = False
@@ -162,6 +166,7 @@ def main_run_task(task, repo, pr_number, task_data_dir, requested_version):
             lint_error = True
             lints = None
             hints = None
+            errors = {}
 
         task_data["task_results"]["lint_error"] = lint_error
         task_data["task_results"]["lints"] = lints
@@ -406,12 +411,12 @@ def main_finalize_task(task_data_dir):
                 )
                 sys.exit(1)
         elif task == "lint":
-            if task_results.get("errors"):
+            if "errors" in task_results:
                 recipes_to_lint, _ = get_recipes_for_linting(
                     gh, gh_repo, pr.number, task_results["lints"], task_results["hints"]
                 )
                 if any(
-                    task_results["errors"].get(rec, False) for rec in recipes_to_lint
+                    task_results["errors"].get(rec, True) for rec in recipes_to_lint
                 ):
                     task_results["lint_error"] = True
 

--- a/conda_forge_webservices/github_actions_integration/__main__.py
+++ b/conda_forge_webservices/github_actions_integration/__main__.py
@@ -153,10 +153,7 @@ def main_run_task(task, repo, pr_number, task_data_dir, requested_version):
             if len(res) == 2:
                 lints, hints = res
                 all_keys = set(lints.keys()) | set(hints.keys())
-                errors = {
-                    key: False
-                    for key in all_keys
-                }
+                errors = {key: False for key in all_keys}
             else:
                 lints, hints, errors = res
             lint_error = False


### PR DESCRIPTION
### Description

This PR fixes up some edge cases in handling linter errors.

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
