### PR TITLE
fix: bug in lint spacing

### DIFF
--- a/conda_forge_webservices/github_actions_integration/__main__.py
+++ b/conda_forge_webservices/github_actions_integration/__main__.py
@@ -163,7 +163,7 @@ def main_run_task(task, repo, pr_number, task_data_dir, requested_version):
             lint_error = True
             lints = None
             hints = None
-            errors = {}
+            errors = None
 
         task_data["task_results"]["lint_error"] = lint_error
         task_data["task_results"]["lints"] = lints
@@ -408,7 +408,11 @@ def main_finalize_task(task_data_dir):
                 )
                 sys.exit(1)
         elif task == "lint":
-            if "errors" in task_results:
+            if (
+                task_results["lints"] is not None
+                and task_results["hints"] is not None
+                and task_results["errors"] is not None
+            ):
                 recipes_to_lint, _ = get_recipes_for_linting(
                     gh, gh_repo, pr.number, task_results["lints"], task_results["hints"]
                 )

--- a/conda_forge_webservices/github_actions_integration/linting.py
+++ b/conda_forge_webservices/github_actions_integration/linting.py
@@ -159,8 +159,8 @@ def build_and_make_lint_comment(gh, repo, pr_id, lints, hints):
             I do have some suggestions for making it better though...
 
             {}
-            """.format("\n".join(messages)),
-        )
+            """
+        ).format("\n".join(messages))
 
         bad = dedent_with_escaped_continue(
             f"""
@@ -172,8 +172,8 @@ def build_and_make_lint_comment(gh, repo, pr_id, lints, hints):
             Here's what I've got...
 
             {{}}
-            """.format("\n".join(messages)),
-        )
+            """
+        ).format("\n".join(messages))
 
         if not all_recipes:
             message = dedent_with_escaped_continue(


### PR DESCRIPTION
### Description

This PR fixes a bug in the linter spacing for messages. See https://github.com/conda-forge/zlib-feedstock/pull/83.

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
