### PR TITLE
fix: only lint recipes

### DIFF
--- a/conda_forge_webservices/github_actions_integration/linting.py
+++ b/conda_forge_webservices/github_actions_integration/linting.py
@@ -1,3 +1,4 @@
+import os
 import time
 
 from .utils import dedent_with_escaped_continue
@@ -12,8 +13,10 @@ def get_recipes_for_linting(gh, repo, pr_id, lints, hints):
         recipes_to_lint = set(
             fname
             for fname in recipes_to_lint
-            if fname
-            not in ["recipes/example/meta.yaml", "recipes/example-v1/recipe.yaml"]
+            if (
+                fname
+                not in ["recipes/example/meta.yaml", "recipes/example-v1/recipe.yaml"]
+            ) and os.path.basename(fname) in ["meta.yaml", "recipe.yaml"]
         )
     else:
         recipes_to_lint = set(fnames)


### PR DESCRIPTION
### Description

This one fixes yet another linting bug.

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
