### PR TITLE
fix: relock for more things

### DIFF
--- a/.github/workflows/clean-and-update.yml
+++ b/.github/workflows/clean-and-update.yml
@@ -28,11 +28,14 @@ jobs:
           automerge: true
           skip-if-pr-exists: true
           include-only-packages:
+            anaconda-client
             conda-smithy
             conda
             conda-build
             conda-libmamba-solver
             mamba
+            conda-forge-tick
+            conda-forge-feedstock-ops
 
   clean-and-cache:
     name: clean-and-cache


### PR DESCRIPTION
### Description

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

We need to relock on more packages.

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
