### PR TITLE
fix: use rt parser and proper formatting

### DIFF
--- a/.github/workflows/clean-and-update.yml
+++ b/.github/workflows/clean-and-update.yml
@@ -22,7 +22,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: relock
-        uses: beckermr/relock-conda@2fef2c0c536910c687bf0ae5a5691ab5da5fe579
+        uses: beckermr/relock-conda@49530e32234db1af2014b31a9e7c484488ec5daa
         with:
           github-token: ${{ steps.generate_token.outputs.token }}
           automerge: true

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -57,6 +57,14 @@ UPDATE_VERSION = re.compile(
 )
 
 
+def _get_yaml_parser(typ="rt"):
+    parser = YAML(typ=typ)
+    parser.indent(mapping=2, sequence=4, offset=2)
+    parser.width = 320
+    parser.preserve_quotes = True
+    return parser
+
+
 def _get_conda_forge_yml(org_name: str, repo_name: str) -> dict:
     url = (
         f"https://raw.githubusercontent.com/{org_name}/{repo_name}/main/conda-forge.yml"
@@ -64,7 +72,7 @@ def _get_conda_forge_yml(org_name: str, repo_name: str) -> dict:
     try:
         r = requests.get(url)
         r.raise_for_status()
-        yaml = YAML(typ="safe")
+        yaml = _get_yaml_parser()
         return yaml.load(r.text)
     except requests.HTTPError:
         return {}
@@ -787,7 +795,7 @@ def add_user(repo, user):
     if not recipe_path:
         return None
     co_path = os.path.join(repo.working_dir, ".github", "CODEOWNERS")
-    yaml = YAML(typ="safe")
+    yaml = _get_yaml_parser(typ="rt")
     if os.path.exists(recipe_path):
         # get the current maintainers - if user is in them, return False
         with io.StringIO() as fp_out:
@@ -885,7 +893,7 @@ def add_user(repo, user):
 
 
 def add_bot_automerge(repo):
-    yaml = YAML(typ="safe")
+    yaml = _get_yaml_parser(typ="rt")
 
     cf_yml = os.path.join(repo.working_dir, "conda-forge.yml")
     if os.path.exists(cf_yml):
@@ -922,7 +930,7 @@ def add_bot_automerge(repo):
 
 
 def remove_bot_automerge(repo):
-    yaml = YAML(typ="safe")
+    yaml = _get_yaml_parser(typ="rt")
 
     cf_yml = os.path.join(repo.working_dir, "conda-forge.yml")
     if os.path.exists(cf_yml):

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -795,7 +795,7 @@ def add_user(repo, user):
     if not recipe_path:
         return None
     co_path = os.path.join(repo.working_dir, ".github", "CODEOWNERS")
-    yaml = _get_yaml_parser(typ="rt")
+    yaml = _get_yaml_parser()
     if os.path.exists(recipe_path):
         # get the current maintainers - if user is in them, return False
         with io.StringIO() as fp_out:
@@ -893,7 +893,7 @@ def add_user(repo, user):
 
 
 def add_bot_automerge(repo):
-    yaml = _get_yaml_parser(typ="rt")
+    yaml = _get_yaml_parser()
 
     cf_yml = os.path.join(repo.working_dir, "conda-forge.yml")
     if os.path.exists(cf_yml):
@@ -930,7 +930,7 @@ def add_bot_automerge(repo):
 
 
 def remove_bot_automerge(repo):
-    yaml = _get_yaml_parser(typ="rt")
+    yaml = _get_yaml_parser()
 
     cf_yml = os.path.join(repo.working_dir, "conda-forge.yml")
     if os.path.exists(cf_yml):


### PR DESCRIPTION
### Description

This PR switches the code to use the rt yaml parser. rt is a subclass of safe and so should be ok. 

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->

closes #688 
