### PR TITLE
fix: try and get logs to appear

### DIFF
--- a/conda_forge_webservices/github_actions_integration/__main__.py
+++ b/conda_forge_webservices/github_actions_integration/__main__.py
@@ -8,6 +8,7 @@ import tempfile
 import traceback
 
 import click
+from conda_forge_feedstock_ops import setup_logging
 from conda_forge_feedstock_ops.lint import lint as lint_feedstock
 from conda_forge_feedstock_ops.os_utils import sync_dirs
 from git import Repo
@@ -76,7 +77,7 @@ def main_init_task(task, repo, pr_number):
 @click.option("--task-data-dir", required=True, type=str)
 @click.option("--requested-version", required=False, type=str, default=None)
 def main_run_task(task, repo, pr_number, task_data_dir, requested_version):
-    logging.basicConfig(level=logging.INFO)
+    setup_logging()
 
     LOGGER.info("running task `%s` for conda-forge/%s#%s", task, repo, pr_number)
 

--- a/conda_forge_webservices/github_actions_integration/__main__.py
+++ b/conda_forge_webservices/github_actions_integration/__main__.py
@@ -77,7 +77,7 @@ def main_init_task(task, repo, pr_number):
 @click.option("--task-data-dir", required=True, type=str)
 @click.option("--requested-version", required=False, type=str, default=None)
 def main_run_task(task, repo, pr_number, task_data_dir, requested_version):
-    setup_logging()
+    setup_logging(level="DEBUG")
 
     LOGGER.info("running task `%s` for conda-forge/%s#%s", task, repo, pr_number)
 

--- a/conda_forge_webservices/github_actions_integration/__main__.py
+++ b/conda_forge_webservices/github_actions_integration/__main__.py
@@ -427,7 +427,7 @@ def main_finalize_task(task_data_dir):
                     """
                     Hi! This is the friendly automated conda-forge-linting service.
 
-                    I Failed to even lint the recipe, probably because of a conda-smithy
+                    I failed to even lint the recipe, probably because of a conda-smithy
                     bug :cry:. This likely indicates a problem in your `meta.yaml`, \\
                     though. To get a traceback to help figure out what's going on, \\
                     install conda-smithy and run \\

--- a/conda_forge_webservices/github_actions_integration/__main__.py
+++ b/conda_forge_webservices/github_actions_integration/__main__.py
@@ -77,7 +77,7 @@ def main_init_task(task, repo, pr_number):
 @click.option("--task-data-dir", required=True, type=str)
 @click.option("--requested-version", required=False, type=str, default=None)
 def main_run_task(task, repo, pr_number, task_data_dir, requested_version):
-    setup_logging(level="DEBUG")
+    setup_logging()
 
     LOGGER.info("running task `%s` for conda-forge/%s#%s", task, repo, pr_number)
 

--- a/tests/test_live_linter.py
+++ b/tests/test_live_linter.py
@@ -7,6 +7,13 @@ import conda_forge_webservices
 
 TEST_CASES = [
     (
+        733,
+        "failure",
+        [
+            "failed to even lint the recipe",
+        ],
+    ),
+    (
         632,
         "failure",
         [


### PR DESCRIPTION
### Description

This PR trys to get logs to appear for linting.

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
