### PR TITLE
chore: ensure we are always using latest fsops

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - conda-forge-metadata >=0.9.2
   - conda-forge-pinning
   - conda-forge-tick >=2024.9.26
-  - conda-forge-feedstock-ops >=0.7.0
+  - conda-forge-feedstock-ops >=0.9.0
   - conda-smithy >=3.34.1  # this pin is for jinja2 sandboxes
   - cryptography >=39
   - python-dateutil


### PR DESCRIPTION
### Description

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

This PR ensures we are always using the latest fsops packages.

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
