### PR TITLE
fix: turn off permissions changes for now

### DIFF
--- a/conda_forge_webservices/github_actions_integration/__main__.py
+++ b/conda_forge_webservices/github_actions_integration/__main__.py
@@ -304,7 +304,7 @@ def main_finalize_task(task_data_dir):
                 feedstock_dir,
                 ignore_dot_git=True,
                 update_git=True,
-                sync_stat_metadata=True,
+                sync_stat_metadata=False,  # turn this off for now
             )
             subprocess.run(
                 ["git", "add", "."],


### PR DESCRIPTION
### Description

This PR turns off the permissions sync to see if that helps for now. 

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
