### PR TITLE
fix: try only using patches

### DIFF
--- a/conda_forge_webservices/github_actions_integration/__main__.py
+++ b/conda_forge_webservices/github_actions_integration/__main__.py
@@ -10,7 +10,6 @@ import traceback
 import click
 from conda_forge_feedstock_ops import setup_logging
 from conda_forge_feedstock_ops.lint import lint as lint_feedstock
-from conda_forge_feedstock_ops.os_utils import sync_dirs
 from git import Repo
 
 from .utils import (
@@ -18,6 +17,7 @@ from .utils import (
     dedent_with_escaped_continue,
     flush_logger,
     get_gha_run_link,
+    get_git_patch_relative_to_commit,
     mark_pr_as_ready_for_review,
 )
 from .api_sessions import create_api_sessions
@@ -93,16 +93,19 @@ def main_run_task(task, repo, pr_number, task_data_dir, requested_version):
     )
     git_repo.remotes.origin.fetch([f"pull/{pr_number}/head:pull/{pr_number}/head"])
     git_repo.git.switch(f"pull/{pr_number}/head")
+    prev_head = git_repo.active_branch.commit
 
     task_data = {"task": task, "repo": repo, "pr_number": pr_number, "task_results": {}}
 
     if task == "rerender":
         _pull_docker_image()
         changed, rerender_error, info_message, commit_message = rerender(git_repo)
+        patch = get_git_patch_relative_to_commit(git_repo, prev_head)
         task_data["task_results"]["changed"] = changed
         task_data["task_results"]["rerender_error"] = rerender_error
         task_data["task_results"]["info_message"] = info_message
         task_data["task_results"]["commit_message"] = commit_message
+        task_data["task_results"]["patch"] = patch
     elif task == "version_update":
         if (
             requested_version.lower() == "null"
@@ -125,6 +128,7 @@ def main_run_task(task, repo, pr_number, task_data_dir, requested_version):
         task_data["task_results"]["version_changed"] = version_changed
         task_data["task_results"]["version_error"] = version_error
         task_data["task_results"]["new_version"] = new_version
+        task_data["task_results"]["patch"] = None
 
         if version_changed:
             task_data["task_results"]["commit_message"] = (
@@ -141,6 +145,8 @@ def main_run_task(task, repo, pr_number, task_data_dir, requested_version):
                 task_data["task_results"]["commit_message"] += (
                     " & " + commit_message[len("MNT: ") :]
                 )
+            patch = get_git_patch_relative_to_commit(git_repo, prev_head)
+            task_data["task_results"]["patch"] = patch
         else:
             task_data["task_results"]["rerender_changed"] = False
             task_data["task_results"]["rerender_error"] = False
@@ -181,12 +187,11 @@ def main_run_task(task, repo, pr_number, task_data_dir, requested_version):
         check=True,
         capture_output=True,
     )
-    if task == "lint":
-        subprocess.run(
-            ["rm", "-rf", feedstock_dir],
-            check=True,
-            capture_output=True,
-        )
+    subprocess.run(
+        ["rm", "-rf", feedstock_dir],
+        check=True,
+        capture_output=True,
+    )
 
 
 def _push_changes(
@@ -283,34 +288,38 @@ def main_finalize_task(task_data_dir):
             pr_branch = pr.head.ref
             pr_owner = pr.head.repo.owner.login
             pr_repo = pr.head.repo.name
-            repo_url = f"https://github.com/{pr_owner}/{pr_repo}.git"
-            feedstock_dir = os.path.join(
-                tmpdir,
-                pr_repo,
-            )
-            git_repo = Repo.clone_from(
-                repo_url,
-                feedstock_dir,
-                branch=pr_branch,
-            )
-
-            source_feedstock_dir = os.path.join(
-                task_data_dir,
-                repo,
-            )
-
-            sync_dirs(
-                source_feedstock_dir,
-                feedstock_dir,
-                ignore_dot_git=True,
-                update_git=True,
-                sync_stat_metadata=True,
-            )
-            subprocess.run(
-                ["git", "add", "."],
-                cwd=feedstock_dir,
-                check=True,
-            )
+            if task_results["patch"] is not None:
+                if task_results["commit_message"] is None:
+                    LOGGER.warning(
+                        "The webservices tasks did not provide a commit message "
+                        "but did provide a patch. This is likely an error. "
+                        "Proceeding with a default commit message."
+                    )
+                    task_results["commit_message"] = (
+                        "chore: conda-forge-webservices update"
+                    )
+                feedstock_dir = os.path.join(
+                    tmpdir,
+                    pr_repo,
+                )
+                git_repo = Repo.clone_from(
+                    f"https://github.com/{pr_owner}/{pr_repo}.git",
+                    feedstock_dir,
+                    branch=pr_branch,
+                )
+                patch_file = os.path.join(tmpdir, "rerender-diff.patch")
+                with open(patch_file, "w") as fp:
+                    fp.write(task_results["patch"])
+                subprocess.run(
+                    ["git", "apply", "--allow-empty", patch_file],
+                    check=True,
+                    cwd=feedstock_dir,
+                )
+                subprocess.run(
+                    ["git", "add", "."],
+                    cwd=feedstock_dir,
+                    check=True,
+                )
             if task_results["commit_message"] is not None:
                 subprocess.run(
                     [

--- a/conda_forge_webservices/github_actions_integration/__main__.py
+++ b/conda_forge_webservices/github_actions_integration/__main__.py
@@ -93,7 +93,7 @@ def main_run_task(task, repo, pr_number, task_data_dir, requested_version):
     )
     git_repo.remotes.origin.fetch([f"pull/{pr_number}/head:pull/{pr_number}/head"])
     git_repo.git.switch(f"pull/{pr_number}/head")
-    prev_head = git_repo.active_branch.commit
+    prev_head = git_repo.active_branch.commit.hexsha
 
     task_data = {"task": task, "repo": repo, "pr_number": pr_number, "task_results": {}}
 

--- a/conda_forge_webservices/github_actions_integration/utils.py
+++ b/conda_forge_webservices/github_actions_integration/utils.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import subprocess
 import sys
 import textwrap
 
@@ -182,3 +183,16 @@ def flush_logger(logger):
     sys.stderr.flush()
     sys.__stderr__.flush()
     sys.__stdout__.flush()
+
+
+def get_git_patch_relative_to_commit(git_repo, prev_head):
+    """Get the git patch between the input commit and the latest commit."""
+    curr_head = git_repo.active_branch.commit
+    ret = subprocess.run(
+        ["git", "diff", prev_head + ".." + curr_head],
+        cwd=git_repo.working_dir,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return ret.stdout

--- a/conda_forge_webservices/github_actions_integration/utils.py
+++ b/conda_forge_webservices/github_actions_integration/utils.py
@@ -187,7 +187,7 @@ def flush_logger(logger):
 
 def get_git_patch_relative_to_commit(git_repo, prev_head):
     """Get the git patch between the input commit and the latest commit."""
-    curr_head = git_repo.active_branch.commit
+    curr_head = git_repo.active_branch.commit.hexsha
     git_sha_diff = prev_head + ".." + curr_head
     ret = subprocess.run(
         ["git", "diff", git_sha_diff],

--- a/conda_forge_webservices/github_actions_integration/utils.py
+++ b/conda_forge_webservices/github_actions_integration/utils.py
@@ -188,11 +188,13 @@ def flush_logger(logger):
 def get_git_patch_relative_to_commit(git_repo, prev_head):
     """Get the git patch between the input commit and the latest commit."""
     curr_head = git_repo.active_branch.commit
+    git_sha_diff = prev_head + ".." + curr_head
     ret = subprocess.run(
-        ["git", "diff", prev_head + ".." + curr_head],
+        ["git", "diff", git_sha_diff],
         cwd=git_repo.working_dir,
         capture_output=True,
         text=True,
         check=True,
     )
+    LOGGER.info("git patch for diff %s: %s", git_sha_diff, ret.stdout)
     return ret.stdout


### PR DESCRIPTION
### Description

This PR tries to address #743 by only using patches and never copying the repo contents directly.

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
