### PR TITLE
fix: force add to bypass gitignore

### DIFF
--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -3,7 +3,7 @@ metadata:
     - url: conda-forge
       used_env_vars: []
   content_hash:
-    linux-64: 73fd1c3685ce88f9cc1b13e8a84e3af980d3dd9f63089380cdb94a209ac61bc0
+    linux-64: b1d797b93113a3b14aae9d6333f597f6f4fdd141713e35b4087b819441c60d34
   platforms:
     - linux-64
   sources:
@@ -223,15 +223,15 @@ package:
       python-dateutil: '>=2.1,<3.0.0'
       urllib3: '>=1.25.4,!=2.2.0,<3'
     hash:
-      md5: e6a1cbe67d52fe1d90fa8bb624d42954
-      sha256: a7b7bee71e07c7a06a86d85fcdaec47503cce48107506f529acf707b17ca091d
+      md5: e7c23cf1a9dca81e650ea828a3c19d6f
+      sha256: 3f6ae2d83e7ab62bc7c27e5dc53e6c377ba15f0e5454da44bcea22f2f1784b95
     manager: conda
     name: botocore
     optional: false
     platform: linux-64
     url:
-      https://conda.anaconda.org/conda-forge/noarch/botocore-1.35.49-pyge310_1234567_0.conda
-    version: 1.35.49
+      https://conda.anaconda.org/conda-forge/noarch/botocore-1.35.50-pyge310_1234567_0.conda
+    version: 1.35.50
   - category: main
     dependencies:
       __glibc: '>=2.17,<3.0.a0'
@@ -609,15 +609,15 @@ package:
       pyyaml: ''
       rattler-build-conda-compat: '>=0.0.2,<2.0.0a0'
     hash:
-      md5: b8ee0bb4e2b91216e2eb0e24a8649e8b
-      sha256: 205f69bc11700cd5ca3640a4dff2ad2f3f8a080cefb42efba66c8add19eff1e1
+      md5: b7d04c26b896f2f1de9c5877bd817954
+      sha256: e8e1100648d75d3dd2445106c8cf02280f0cd940d3dc3b4a5947045c9075a9bb
     manager: conda
     name: conda-forge-feedstock-ops
     optional: false
     platform: linux-64
     url:
-      https://conda.anaconda.org/conda-forge/noarch/conda-forge-feedstock-ops-0.10.0-pyhd8ed1ab_0.conda
-    version: 0.10.0
+      https://conda.anaconda.org/conda-forge/noarch/conda-forge-feedstock-ops-0.10.1-pyhd8ed1ab_0.conda
+    version: 0.10.1
   - category: main
     dependencies:
       beautifulsoup4: ''
@@ -629,27 +629,27 @@ package:
       ruamel.yaml: ''
       typing-extensions: ''
     hash:
-      md5: 3ebe8ada26ac6a082abc08e9305c509c
-      sha256: 31637889fcb139f7a86b079e6e9bcedaf17c67b6abe78d7313741a5563eb8ced
+      md5: 93f4ef42763aa9a23f19a816fcda5f85
+      sha256: d039411f4f9e4bf135826ead16955f039abf931219a62c6b22ad13fb830274b9
     manager: conda
     name: conda-forge-metadata
     optional: false
     platform: linux-64
     url:
-      https://conda.anaconda.org/conda-forge/noarch/conda-forge-metadata-0.10.0-pyhd8ed1ab_0.conda
-    version: 0.10.0
+      https://conda.anaconda.org/conda-forge/noarch/conda-forge-metadata-0.11.0-pyhd8ed1ab_0.conda
+    version: 0.11.0
   - category: main
     dependencies: {}
     hash:
-      md5: 8da1420437a8fb5722142b39fdd603c3
-      sha256: e4934f58c69b3115609e2d83be4c46202ab359b85cacfe8bf230780b9b22aaa9
+      md5: 77a9627ac95396d369ef57c09ed3bf4c
+      sha256: 705461aad2d98fc0f711d2497bce5e3fa90e7c474557f0db5beca4ebfe854d48
     manager: conda
     name: conda-forge-pinning
     optional: false
     platform: linux-64
     url:
-      https://conda.anaconda.org/conda-forge/noarch/conda-forge-pinning-2024.10.25.18.47.03-hd8ed1ab_0.conda
-    version: 2024.10.25.18.47.03
+      https://conda.anaconda.org/conda-forge/noarch/conda-forge-pinning-2024.10.29.12.41.35-hd8ed1ab_0.conda
+    version: 2024.10.29.12.41.35
   - category: main
     dependencies:
       attrs: ''
@@ -2574,14 +2574,14 @@ package:
       libgcc: '>=13'
       libzlib: '>=1.3.1,<2.0a0'
     hash:
-      md5: 540296f0ce9d3352188c15a89b30b9ac
-      sha256: 76ffc7a5823b51735c11d535f3666b3c9c7d1519f9fbb6fa9cdff79db01960b9
+      md5: b6f02b52a174e612e89548f4663ce56a
+      sha256: 8a9aadf996a2399f65b679c6e7f29139d5059f699c63e6d7b50e20db10c00508
     manager: conda
     name: libsqlite
     optional: false
     platform: linux-64
     url:
-      https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.47.0-hadc24fc_0.conda
+      https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.47.0-hadc24fc_1.conda
     version: 3.47.0
   - category: main
     dependencies:
@@ -2802,13 +2802,13 @@ package:
       python: '>=3.11,<3.12.0a0'
       python_abi: 3.11.*
     hash:
-      md5: b76d6a1a47942ad2021a9d3d7fe527bd
-      sha256: 6f162a5102aa56eba2152abc5242016d8be4e192c378adc2c1482474e436c339
+      md5: e8782d6eed47d773c2bd8cb36230f841
+      sha256: a688a22eeb432b87d7d118bfb4a536ced4b332cfccc5fcd4bff3f3ceb5921cec
     manager: conda
     name: lxml
     optional: false
     platform: linux-64
-    url: https://conda.anaconda.org/conda-forge/linux-64/lxml-5.3.0-py311hcfaa980_1.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/lxml-5.3.0-py311hcfaa980_2.conda
     version: 5.3.0
   - category: main
     dependencies:
@@ -3216,14 +3216,14 @@ package:
       setuptools: ''
       wheel: ''
     hash:
-      md5: 6c78fbb8ddfd64bcb55b5cbafd2d2c43
-      sha256: d820e5358bcb117fa6286e55d4550c60b0332443df62121df839eab2d11c890b
+      md5: 5dd546fe99b44fda83963d15f84263b7
+      sha256: 499313e72e20225f84c2e9690bbaf5b952c8d7e0bf34b728278538f766b81628
     manager: conda
     name: pip
     optional: false
     platform: linux-64
-    url: https://conda.anaconda.org/conda-forge/noarch/pip-24.2-pyh8b19718_1.conda
-    version: '24.2'
+    url: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+    version: 24.3.1
   - category: main
     dependencies:
       libgcc-ng: '>=12'
@@ -3896,15 +3896,15 @@ package:
       __glibc: '>=2.17,<3.0.a0'
       openssl: '>=3.3.2,<4.0a0'
     hash:
-      md5: 178d902a1d285c0c9b617549f125c8c8
-      sha256: 5601bded1695d6e6069c4bb7a38126c8aa765004bb1b4bf4c3d282bd2b36c1c0
+      md5: ee3a108031a028cc612ef89773313e5f
+      sha256: d48a1da4855d4b2de8af2dd7af3b9a86e59788d2771df25b1964d45e9114e36d
     manager: conda
     name: rattler-build
     optional: false
     platform: linux-64
     url:
-      https://conda.anaconda.org/conda-forge/linux-64/rattler-build-0.28.0-h51b9b6e_0.conda
-    version: 0.28.0
+      https://conda.anaconda.org/conda-forge/linux-64/rattler-build-0.28.1-h51b9b6e_0.conda
+    version: 0.28.1
   - category: main
     dependencies:
       conda-build: ''
@@ -4503,14 +4503,14 @@ package:
       colorama: ''
       python: '>=3.7'
     hash:
-      md5: c6e94fc2b2ec71ea33fe7c7da259acb4
-      sha256: f2384902cef72048b0e9bad5c03d7a843de02ba6bc8618a9ecab6ff81a131312
+      md5: 92718e1f892e1e4623dcc59b9f9c4e55
+      sha256: 32c39424090a8cafe7994891a816580b3bd253eb4d4f5473bdefcf6a81ebc061
     manager: conda
     name: tqdm
     optional: false
     platform: linux-64
-    url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.5-pyhd8ed1ab_0.conda
-    version: 4.66.5
+    url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.6-pyhd8ed1ab_0.conda
+    version: 4.66.6
   - category: main
     dependencies:
       python: '>=3.8'
@@ -4692,15 +4692,15 @@ package:
       platformdirs: <5,>=3.9.1
       python: '>=3.8'
     hash:
-      md5: a6ed1227ba6ec37cfc2b25e6512f729f
-      sha256: 18bae5ff9f02793ca56d295f0a5f1d4443623ee3be09a6805eb7d4b18245968c
+      md5: dae21509d62aa7bf676279ced3edcb3f
+      sha256: 189b935224732267df10dc116bce0835bd76fcdb20c30f560591c92028d513b0
     manager: conda
     name: virtualenv
     optional: false
     platform: linux-64
     url:
-      https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.27.0-pyhd8ed1ab_0.conda
-    version: 20.27.0
+      https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.27.1-pyhd8ed1ab_0.conda
+    version: 20.27.1
   - category: main
     dependencies:
       msrest: '>=0.6.0,<0.7.0'

--- a/conda_forge_webservices/github_actions_integration/__main__.py
+++ b/conda_forge_webservices/github_actions_integration/__main__.py
@@ -316,7 +316,7 @@ def main_finalize_task(task_data_dir):
                     cwd=feedstock_dir,
                 )
                 subprocess.run(
-                    ["git", "add", "."],
+                    ["git", "add", "-f", "."],
                     cwd=feedstock_dir,
                     check=True,
                 )

--- a/conda_forge_webservices/github_actions_integration/rerendering.py
+++ b/conda_forge_webservices/github_actions_integration/rerendering.py
@@ -32,7 +32,7 @@ def rerender(git_repo):
         ret = 0
         if msg is not None:
             subprocess.call(
-                ["git", "add", "."],
+                ["git", "add", "-f", "."],
                 cwd=git_repo.working_dir,
             )
             subprocess.call(

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - conda-forge-metadata >=0.9.2
   - conda-forge-pinning
   - conda-forge-tick >=2024.9.26
-  - conda-forge-feedstock-ops >=0.10.0  # pin to fix bug in rerender patches
+  - conda-forge-feedstock-ops >=0.10.1  # pin to fix bug in rerenders
   - conda-smithy >=3.34.1  # this pin is for jinja2 sandboxes
   - cryptography >=39
   - python-dateutil


### PR DESCRIPTION
### Description

I am trying to fix a rerendering bug where files are missing.

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
