### PR TITLE
feat: add automerge code + tests

### DIFF
--- a/conda_forge_webservices/github_actions_integration/__main__.py
+++ b/conda_forge_webservices/github_actions_integration/__main__.py
@@ -12,6 +12,7 @@ from conda_forge_feedstock_ops import setup_logging
 from conda_forge_feedstock_ops.lint import lint as lint_feedstock
 from git import Repo
 
+from .automerge import automerge_pr
 from .utils import (
     comment_and_push_if_changed,
     dedent_with_escaped_continue,
@@ -471,3 +472,19 @@ def main_finalize_task(task_data_dir):
                 sys.exit(1)
         else:
             raise ValueError(f"Task `{task}` is not valid!")
+
+
+@click.command(name="conda-forge-webservices-automerge")
+@click.option("--repo", required=True, type=str)
+@click.option("--sha", required=True, type=str)
+def main_automerge(repo, sha):
+    logging.basicConfig(level=logging.INFO)
+
+    LOGGER.info("Running automerge for conda-forge/%s@%s", repo, sha)
+
+    full_repo_name = f"conda-forge/{repo}"
+    _, gh = create_api_sessions()
+    gh_repo = gh.get_repo(full_repo_name)
+    for pr in gh_repo.get_pulls():
+        if pr.head.sha == sha:
+            automerge_pr(repo, pr)

--- a/conda_forge_webservices/github_actions_integration/automerge.py
+++ b/conda_forge_webservices/github_actions_integration/automerge.py
@@ -1,0 +1,535 @@
+from __future__ import annotations
+
+import contextlib
+import datetime
+import logging
+import os
+import random
+import subprocess
+import tempfile
+import time
+from typing import TYPE_CHECKING
+
+from github import GithubException
+from ruamel.yaml import YAML
+
+if TYPE_CHECKING:
+    from github.PullRequest import PullRequest
+    from github.Repository import Repository
+
+LOGGER = logging.getLogger(__name__)
+
+ALLOWED_USERS = ["regro-cf-autotick-bot"]
+
+IGNORED_CHECKS: list[str] = []
+
+# sets of states that indicate good / bad / neutral in the github API
+NEUTRAL_STATES = ["pending"]
+BAD_STATES = [
+    # for statuses
+    "failure",
+    "error",
+    # for checks
+    "action_required",
+    "canceled",
+    "timed_out",
+    "failed",
+    "neutral",
+]
+
+
+# https://stackoverflow.com/questions/6194499/pushd-through-os-system
+@contextlib.contextmanager
+def pushd(new_dir):
+    previous_dir = os.getcwd()
+    os.chdir(new_dir)
+    try:
+        yield
+    finally:
+        os.chdir(previous_dir)
+
+
+def _run_git_command(*args):
+    try:
+        c = subprocess.run(
+            ["git", *list(args)],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+    except subprocess.CalledProcessError as e:
+        print(c.stdout)
+        raise e
+
+
+def _get_conda_forge_config(pr):
+    """get the conda-forge.yml from upstream master
+
+    We always do this to make sure we use the maintainer settings and not
+    any from a fork.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _run_git_command("clone", pr.base.repo.clone_url, tmpdir)
+        with pushd(tmpdir):
+            _run_git_command("checkout", pr.base.ref)
+            with open("conda-forge.yml") as fp:
+                cfg = YAML().load(fp)
+    return cfg
+
+
+def _automerge_me(cfg):
+    """Compute if feedstock allows automerges from `conda-forge.yml`"""
+    return cfg.get("bot", {}).get("automerge", False)
+
+
+def _get_checks(repo, pr):
+    checks = []
+    commit = repo.get_commit(pr.head.sha)
+    for check in commit.get_check_suites():
+        _check = {}
+        _check["app"] = {"slug": check.app.slug}
+        _check["status"] = check.status
+        _check["conclusion"] = check.conclusion
+        # for gha we check the runs to ensure we have the right check
+        if check.status == "completed" and check.app.slug == "github-actions":
+            _check["runs"] = [run.name for run in check.get_check_runs()]
+        else:
+            _check["runs"] = None
+        checks.append(_check)
+    return checks
+
+
+def _get_github_checks(repo, pr):
+    """Get all of the github checks associated with a PR.
+
+    Parameters
+    ----------
+    repo : github.Repository.Repository
+        A `Repository` object for the given repo from the PyGithub package.
+    pr : github.PullRequest.PullRequest
+        A `PullRequest` object for the given PR from the PyGithub package.
+
+    Returns
+    -------
+    check_states : dict of bool or None
+        A dictionary mapping each check to its state.
+    """
+
+    check_states = {}
+    checks = _get_checks(repo, pr)
+    for check in checks:
+        name = check["app"]["slug"]
+        if name not in IGNORED_CHECKS:
+            if check["status"] != "completed":
+                check_states[name] = None
+            else:
+                if name == "github-actions":
+                    if (
+                        check["conclusion"] == "success"
+                        and check["runs"]
+                        and (not any(run == "automerge" for run in check["runs"]))
+                    ):
+                        check_states[name] = True
+                    else:
+                        check_states[name] = False
+                else:
+                    if check["conclusion"] == "success":
+                        check_states[name] = True
+                    else:
+                        check_states[name] = False
+
+    for name, good in check_states.items():
+        LOGGER.info("check: name|state = %s|%s", name, good)
+
+    return check_states
+
+
+def _get_github_statuses(repo, pr):
+    """Get all of the github statuses associated with a PR.
+
+    Parameters
+    ----------
+    repo : github.Repository.Repository
+        A `Repository` object for the given repo from the PyGithub package.
+    pr : github.PullRequest.PullRequest
+        A `PullRequest` object for the given PR from the PyGithub package.
+
+    Returns
+    -------
+    status_states : dict of bool or None
+        A dictionary mapping each status to its state.
+    """
+    # github emits all of the statuses with a time stamp as events
+    # you have to keep the latest one
+    # so this is why we compare the times below
+
+    commit = repo.get_commit(pr.head.sha)
+    statuses = commit.get_statuses()
+
+    oldest_time = None
+    status_states = {}
+    for status in statuses:
+        if oldest_time is None:
+            if status.updated_at.tzinfo is None:
+                oldest_time = datetime.datetime.now() - datetime.timedelta(weeks=10000)
+            else:
+                oldest_time = datetime.datetime.now(
+                    datetime.timezone.utc
+                ) - datetime.timedelta(weeks=10000)
+
+        if status.context not in status_states:
+            # init with really old time
+            status_states[status.context] = (None, oldest_time)
+
+        if status.state in NEUTRAL_STATES:
+            if status.updated_at > status_states[status.context][1]:
+                status_states[status.context] = (None, status.updated_at)
+        elif status.state in BAD_STATES:
+            if status.updated_at > status_states[status.context][1]:
+                status_states[status.context] = (False, status.updated_at)
+        else:
+            if status.updated_at > status_states[status.context][1]:
+                status_states[status.context] = (True, status.updated_at)
+
+    for context, val in status_states.items():
+        LOGGER.info("status: name|state = %s|%s", context, val[0])
+
+    return {k: v[0] for k, v in status_states.items()}
+
+
+def _circle_is_active():
+    """check if circle is active"""
+    if os.path.exists(".circleci/checkout_merge_commit.sh"):
+        return True
+
+    if os.path.exists(".circleci/fast_finish_ci_pr_build.sh"):
+        return True
+
+    # we now look for this sentinel text
+    #      filters:
+    #        branches:
+    #          ignore:
+    #            - /.*/
+    with open(".circleci/config.yml") as fp:
+        start = False
+        ind = 0
+        sentinels = ["filters:", "branches:", "ignore:", "- /.*/"]
+        found_sentinels = [False] * len(sentinels)
+        for line in fp.readlines():
+            if line.strip() == "filters:":
+                start = True
+            if start and ind < len(sentinels):
+                if line.strip() == sentinels[ind]:
+                    found_sentinels[ind] = True
+                ind += 1
+
+    if all(found_sentinels):
+        return False
+    else:
+        return True
+
+
+def _get_required_checks_and_statuses(pr, cfg):
+    """return a list of required statuses and checks"""
+    ignored_statuses = (
+        cfg.get("bot", {}).get("automerge_options", {}).get("ignored_statuses", [])
+    )
+    required = ["linter"]
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _run_git_command("clone", pr.head.repo.clone_url, tmpdir)
+        with pushd(tmpdir):
+            _run_git_command("checkout", pr.head.sha)
+
+            if os.path.exists("appveyor.yml") or os.path.exists(".appveyor.yml"):
+                required.append("appveyor")
+
+            if os.path.exists(".drone.yml"):
+                required.append("drone")
+
+            if os.path.exists(".travis.yml"):
+                required.append("travis")
+
+            if os.path.exists("azure-pipelines.yml"):
+                required.append("azure")
+
+            if os.path.exists(".github/workflows/conda-build.yml"):
+                required.append("github-actions")
+
+            # smithy writes this config even if circle is off, but we can check
+            # for other things
+            if os.path.exists(".circleci/config.yml") and _circle_is_active():
+                required.append("circle")
+
+    return [
+        r.lower()
+        for r in required
+        if not any(r.lower() in _i for _i in ignored_statuses)
+    ]
+
+
+def _all_statuses_and_checks_ok(status_states, check_states, req_checks_and_states):
+    """check all of the required statuses are OK and return their states"""
+    final_states = {r: None for r in req_checks_and_states}
+    for req in req_checks_and_states:
+        found_state = False
+        for k, s in status_states.items():
+            if req in k.lower():
+                if not found_state:
+                    found_state = True
+                    state = s
+                else:
+                    state = state and s
+
+        for k, s in check_states.items():
+            if req in k.lower():
+                if not found_state:
+                    found_state = True
+                    state = s
+                else:
+                    state = state and s
+
+        final_states[req] = None if not found_state else state
+        LOGGER.info("final status: name|state = %s|%s", req, final_states[req])
+
+    return all(v for v in final_states.values()), final_states
+
+
+def _comment_on_pr_with_race(pr, comment, check_slug, check_race=2):
+    # check for a PR comment with a given slug
+    # turn check_race > 1 to check more than once
+    last_comment = None
+    i = 0
+    while last_comment is None and i < check_race:
+        for cmnt in pr.get_issue_comments():
+            if check_slug in cmnt.body:
+                last_comment = cmnt
+        time.sleep(random.uniform(0.5, 1.5))
+        i += 1
+
+    if last_comment is None:
+        pr.create_issue_comment(comment)
+    else:
+        last_comment.edit(comment)
+
+
+def _no_extra_pr_commits(pr):
+    """check that no commits were made after a PR has the automerge label added"""
+    events = [e for e in pr.as_issue().get_timeline()]
+    dts = [e.created_at for e in events if e.created_at is not None]
+    if len(dts) > 1:
+        for i in range(1, len(dts)):
+            if dts[i] < dts[i - 1]:
+                LOGGER.warning("events are out of order!")
+                return None
+
+    label_ind = None
+    for i, e in enumerate(events):
+        if e.event == "labeled" and e.raw_data["label"]["name"] == "automerge":
+            label_ind = i
+
+    if label_ind is None:
+        LOGGER.warning("could not find 'automerge' label in events!")
+        return None
+
+    return all(e.event != "committed" for e in events[label_ind + 1 :])
+
+
+def _check_pr(pr: PullRequest, cfg) -> tuple[bool, str | None]:
+    """make sure a PR is ok to automerge"""
+
+    pr_has_automerge_label = any(label.name == "automerge" for label in pr.get_labels())
+
+    # If the automerge label is present, then we can proceed as long as no commits
+    # have since been added.
+    if pr_has_automerge_label:
+        _no_commits = _no_extra_pr_commits(pr)
+        if _no_commits is None:
+            return False, "could not determine if extra commits were made to PR"
+        else:
+            if _no_commits:
+                return True, None
+            else:
+                pr.remove_from_labels("automerge")
+                pr.create_issue_comment(
+                    """\
+Hi! This is the friendly conda-forge automerge bot!
+
+Commits were made to this PR after the `automerge` label was added. For \
+security reasons, I have disabled automerge by removing the `automerge` label. \
+Please add the `automerge` label again (or ask a maintainer to do so) if you'd \
+like to enable automerge again!
+"""
+                )
+                return False, "commits were made after the automerge label was added"
+    else:  # The PR has no automerge label, so proceed only if titled "[bot-automerge]"
+        # only allowed users
+        if pr.user.login not in ALLOWED_USERS:
+            return (
+                False,
+                f"user {pr.user.login} cannot automerge and no automerge label found",
+            )
+
+        # only if [bot-automerge] is in the pr title
+        if "[bot-automerge]" not in pr.title:
+            return False, "PR does not have the '[bot-automerge]' slug in the title"
+
+        # only if only ALLOWED_USERS have commits
+        committers = {getattr(c.author, "login", None) for c in pr.get_commits()}
+        if not all(c in ALLOWED_USERS for c in committers):
+            _comment_on_pr_with_race(
+                pr,
+                """\
+Hi! This is the friendly conda-forge automerge bot!
+
+It appears that not all commits to this PR were made by the bot. Thus this PR is \
+not being automatically merged. Please add the `automerge` label again (or ask a \
+maintainer to do so) if you'd like to enable automerge again!
+""",
+                "not all commits to this PR were made by the bot",
+            )
+            return False, "non-bot commits on a bot PR with the automerge slug"
+
+        # can we automerge in this feedstock?
+        if not _automerge_me(cfg):
+            return False, "automated bot merges are turned off for this feedstock"
+
+        return True, None
+
+
+def _comment_on_pr(pr, stats, msg):
+    # do not comment if pending
+    if any(v is None for v in stats.values()):
+        return
+
+    comment = """\
+Hi! This is the friendly conda-forge automerge bot!
+
+I considered the following status checks when analyzing this PR:
+"""
+    for k, v in stats.items():
+        if v:
+            _v = "passed"
+        elif v is None:
+            _v = "pending"
+        else:
+            _v = "failed"
+        comment = comment + f" - **{k}**: {_v}\n"
+
+    comment = comment + f"\n\nThus the PR was {msg}"
+
+    # the times at which PR statuses return are correlated and so this code
+    # can race when posting failures
+    # thus we can turn up check_race to say 10
+    # in that case to try and randomize to avoid double posting comments
+    # I considered using app slugs (e.g. require the failed check to be triggered
+    # by the same app as a failed one in the final statuses). However, some apps
+    # post more than one message (e.g., circle) so that would not work if they both
+    # fail.
+    # I also thought about using timestamps, but github check events don't come
+    # with one.
+    check_slug = "I considered the following status checks when analyzing this PR:"
+    _comment_on_pr_with_race(pr, comment, check_slug)
+
+
+def _automerge_pr(repo: Repository, pr: PullRequest) -> tuple[bool, str | None]:
+    cfg = _get_conda_forge_config(pr)
+    allowed, msg = _check_pr(pr, cfg)
+
+    if not allowed:
+        return False, msg
+
+    # get checks and statuses
+    status_states = _get_github_statuses(repo, pr)
+    check_states = _get_github_checks(repo, pr)
+
+    # get which ones are required
+    req_checks_and_states = _get_required_checks_and_statuses(pr, cfg)
+    if len(req_checks_and_states) == 0:
+        return False, "At least one status or check must be required"
+
+    ok, final_statuses = _all_statuses_and_checks_ok(
+        status_states, check_states, req_checks_and_states
+    )
+    if not ok:
+        _comment_on_pr(pr, final_statuses, "not passing and not merged.")
+        return False, "PR has failing or pending statuses/checks"
+
+    # make sure PR is mergeable and not already merged
+    # we have to get the PR again to ensure we have updated mergeable status
+    pr = repo.get_pull(pr.number)
+
+    if pr.is_merged():
+        return False, "PR has already been merged"
+
+    if pr.mergeable is None or not pr.mergeable:
+        _comment_on_pr(
+            pr,
+            final_statuses,
+            f"passing, but not in a mergeable state (mergeable={pr.mergeable}).",
+        )
+        return False, f"PR merge issue: mergeable={pr.mergeable}"
+
+    # we're good - now merge
+    try:
+        merge_status = pr.merge(
+            commit_message="automerged PR by conda-forge/automerge-action",
+            commit_title=f"{pr.title} (#{pr.number})",
+            merge_method="merge",
+            sha=pr.head.sha,
+        )
+        merge_status_merged = merge_status.merged
+        if not merge_status_merged:
+            merge_status_message = merge_status.message
+        else:
+            merge_status_message = None
+    except GithubException as e:
+        merge_status_merged = False
+        merge_status_message = "API error in PUT to merge"
+        LOGGER.exception(merge_status_message + ":")
+        if e.data is not None and "message" in e.data:
+            merge_status_message += f" -- '{e.data['message']}'"
+    except Exception:
+        merge_status_merged = False
+        merge_status_message = "Unexpected error while attempting to merge."
+        LOGGER.exception(merge_status_message)
+        merge_status_message += " Check Actions logs for stack trace."
+
+    if not merge_status_merged:
+        _comment_on_pr(
+            pr,
+            final_statuses,
+            f"passing, but could not be merged (error={merge_status_message}).",
+        )
+        return (False, f"PR could not be merged: {merge_status_message}")
+    else:
+        # use a smaller check_race here to make sure this one is prompt
+        _comment_on_pr(pr, final_statuses, "passing and merged! Have a great day!")
+        return True, "all is well :)"
+
+
+def automerge_pr(repo: Repository, pr: PullRequest) -> tuple[bool, str | None]:
+    """Possibly automerge a PR.
+
+    Parameters
+    ----------
+    repo : github.Repository.Repository
+        A `Repository` object for the given repo from the PyGithub package.
+    pr : github.PullRequest.PullRequest
+        A `PullRequest` object for the given PR from the PyGithub package.
+
+    Returns
+    -------
+    did_merge : bool
+        If `True`, the merge was done, `False` if not.
+    reason : str
+        The reason the merge worked or did not work.
+    """
+    did_merge, reason = _automerge_pr(repo, pr)
+
+    if did_merge:
+        LOGGER.info("MERGED PR %s on %s: %s", pr.number, repo.full_name, reason)
+    else:
+        LOGGER.info("DID NOT MERGE PR %s on %s: %s", pr.number, repo.full_name, reason)
+
+    return did_merge, reason

--- a/conda_forge_webservices/github_actions_integration/tests/test_automerge_pr.py
+++ b/conda_forge_webservices/github_actions_integration/tests/test_automerge_pr.py
@@ -1,0 +1,150 @@
+import unittest.mock
+from unittest.mock import MagicMock
+
+import pytest
+
+from ..automerge import automerge_pr
+
+
+@unittest.mock.patch(
+    "conda_forge_webservices.github_actions_integration.automerge._get_conda_forge_config"
+)
+def test_automerge_pr_bad_user(get_cfg_mock):
+    get_cfg_mock.return_value = {}
+    repo = MagicMock()
+    repo.full_name = "go"
+
+    pr = MagicMock()
+    pr.user.login = "blah"
+
+    did_merge, reason = automerge_pr(repo, pr)
+
+    assert not did_merge
+    assert "user blah" in reason
+    get_cfg_mock.assert_called_once_with(pr)
+
+
+@unittest.mock.patch(
+    "conda_forge_webservices.github_actions_integration.automerge._get_conda_forge_config"
+)
+def test_automerge_pr_no_title_slug(get_cfg_mock):
+    get_cfg_mock.return_value = {}
+    repo = MagicMock()
+    repo.full_name = "go"
+
+    pr = MagicMock()
+    pr.user.login = "regro-cf-autotick-bot"
+    pr.title = "blah"
+
+    did_merge, reason = automerge_pr(repo, pr)
+
+    assert not did_merge
+    assert "slug in the title" in reason
+    get_cfg_mock.assert_called_once_with(pr)
+
+
+@pytest.mark.parametrize(
+    "cfg",
+    [
+        {},
+        {"bot": {}},
+        {"bot": {"automerge": False}},
+    ],
+)
+@unittest.mock.patch(
+    "conda_forge_webservices.github_actions_integration.automerge._get_conda_forge_config"
+)
+def test_automerge_pr_feedstock_off(get_cfg_mock, cfg):
+    get_cfg_mock.return_value = cfg
+    repo = MagicMock()
+    repo.full_name = "go"
+
+    pr = MagicMock()
+    pr.user.login = "regro-cf-autotick-bot"
+    pr.title = "[bot-automerge] blah"
+
+    did_merge, reason = automerge_pr(repo, pr)
+
+    assert not did_merge
+    assert "off for this feedstock" in reason
+    get_cfg_mock.assert_called_once_with(pr)
+
+
+@pytest.mark.parametrize("fail", ["check", "status"])
+@unittest.mock.patch(
+    "conda_forge_webservices.github_actions_integration.automerge._get_conda_forge_config"
+)
+@unittest.mock.patch(
+    "conda_forge_webservices.github_actions_integration.automerge._get_required_checks_and_statuses"
+)
+@unittest.mock.patch(
+    "conda_forge_webservices.github_actions_integration.automerge._get_github_checks"
+)
+@unittest.mock.patch(
+    "conda_forge_webservices.github_actions_integration.automerge._get_github_statuses"
+)
+def test_automerge_pr_feedstock_status_or_check_fail(
+    stat_mock, check_mock, req_mock, get_cfg_mock, fail
+):
+    check_mock.return_value = {"check1": True, "check2": True, "check3": False}
+    stat_mock.return_value = {"status1": True, "status2": True, "status3": True}
+    req_mock.return_value = ["check1", "check2", "status1", "status3"]
+    get_cfg_mock.return_value = {"bot": {"automerge": True}}
+
+    if fail == "check":
+        check_mock.return_value["check2"] = False
+    else:
+        stat_mock.return_value["status1"] = False
+
+    repo = MagicMock()
+    repo.full_name = "go"
+
+    pr = MagicMock()
+    pr.user.login = "regro-cf-autotick-bot"
+    pr.title = "[bot-automerge] blah"
+
+    did_merge, reason = automerge_pr(repo, pr)
+
+    assert not did_merge
+    assert "pending statuses" in reason
+    get_cfg_mock.assert_called_once_with(pr)
+    check_mock.assert_called_once_with(repo, pr)
+    stat_mock.assert_called_once_with(repo, pr)
+    req_mock.assert_called_once_with(pr, get_cfg_mock.return_value)
+
+
+@unittest.mock.patch(
+    "conda_forge_webservices.github_actions_integration.automerge._get_conda_forge_config"
+)
+@unittest.mock.patch(
+    "conda_forge_webservices.github_actions_integration.automerge._get_required_checks_and_statuses"
+)
+@unittest.mock.patch(
+    "conda_forge_webservices.github_actions_integration.automerge._get_github_checks"
+)
+@unittest.mock.patch(
+    "conda_forge_webservices.github_actions_integration.automerge._get_github_statuses"
+)
+def test_automerge_pr_feedstock_no_statuses_or_checks(
+    stat_mock, check_mock, req_mock, get_cfg_mock
+):
+    check_mock.return_value = {}
+    stat_mock.return_value = {}
+    req_mock.return_value = []
+    get_cfg_mock.return_value = {"bot": {"automerge": True}}
+
+    repo = MagicMock()
+    repo.full_name = "go"
+
+    pr = MagicMock()
+    pr.user.login = "regro-cf-autotick-bot"
+    pr.title = "[bot-automerge] blah"
+
+    did_merge, reason = automerge_pr(repo, pr)
+
+    assert not did_merge
+    assert "At least one status or check must be required" in reason
+    get_cfg_mock.assert_called_once_with(pr)
+    check_mock.assert_called_once_with(repo, pr)
+    stat_mock.assert_called_once_with(repo, pr)
+    req_mock.assert_called_once_with(pr, get_cfg_mock.return_value)

--- a/conda_forge_webservices/github_actions_integration/tests/test_circle_is_active.py
+++ b/conda_forge_webservices/github_actions_integration/tests/test_circle_is_active.py
@@ -1,0 +1,59 @@
+import os
+
+import pytest
+
+from ..automerge import _circle_is_active, pushd
+
+
+@pytest.mark.parametrize(
+    "fname", ["fast_finish_ci_pr_build.sh", "checkout_merge_commit.sh"]
+)
+def test_circle_is_active_file(tmpdir, fname):
+    with pushd(tmpdir):
+        os.makedirs(os.path.join(tmpdir, ".circleci"))
+        with open(os.path.join(tmpdir, ".circleci", fname), "w") as fp:
+            fp.write("dummy")
+        assert _circle_is_active()
+
+
+@pytest.mark.parametrize(
+    "txt,val",
+    [
+        (
+            """\
+  filters:
+    branches:
+      ignore:
+        - /.*/
+""",
+            False,
+        ),
+        (
+            """\
+   filters:
+
+     branches:
+       ignore:
+         - /.*/
+""",
+            True,
+        ),
+        (
+            """\
+     branches:
+       ignore:
+         - /.*/
+""",
+            True,
+        ),
+    ],
+)
+def test_circle_is_active_config(tmpdir, txt, val):
+    with pushd(tmpdir):
+        os.makedirs(os.path.join(tmpdir, ".circleci"))
+        with open(os.path.join(tmpdir, ".circleci", "config.yml"), "w") as fp:
+            fp.write(txt)
+        if val:
+            assert _circle_is_active()
+        else:
+            assert not _circle_is_active()

--- a/conda_forge_webservices/github_actions_integration/tests/test_github_checks.py
+++ b/conda_forge_webservices/github_actions_integration/tests/test_github_checks.py
@@ -1,0 +1,180 @@
+import unittest
+
+from ..automerge import _get_github_checks
+
+
+@unittest.mock.patch(
+    "conda_forge_webservices.github_actions_integration.automerge._get_checks"
+)
+def test_get_github_checks_nochecks(get_mock):
+    get_mock.return_value = {}
+    stat = _get_github_checks(1, 2)
+    get_mock.assert_called_once_with(1, 2)
+    assert stat == {}
+
+
+@unittest.mock.patch(
+    "conda_forge_webservices.github_actions_integration.automerge._get_checks"
+)
+def test_check_github_checks_all_pending(get_mock):
+    get_mock.return_value = [
+        {
+            "app": {"slug": "c1"},
+            "status": "blah",
+            "conclusion": "blah",
+        },
+        {
+            "app": {"slug": "c2"},
+            "status": "blah",
+            "conclusion": "blah",
+        },
+    ]
+    stat = _get_github_checks(1, 2)
+    get_mock.assert_called_once_with(1, 2)
+    assert stat == {"c1": None, "c2": None}
+
+
+@unittest.mock.patch(
+    "conda_forge_webservices.github_actions_integration.automerge._get_checks"
+)
+def test_check_github_checks_all_fail(get_mock):
+    get_mock.return_value = [
+        {
+            "app": {"slug": "c1"},
+            "status": "completed",
+            "conclusion": "error",
+        },
+        {
+            "app": {"slug": "c2"},
+            "status": "completed",
+            "conclusion": "failure",
+        },
+    ]
+    stat = _get_github_checks(1, 2)
+    get_mock.assert_called_once_with(1, 2)
+    assert stat == {"c1": False, "c2": False}
+
+
+@unittest.mock.patch(
+    "conda_forge_webservices.github_actions_integration.automerge._get_checks"
+)
+def test_check_github_checks_all_success(get_mock):
+    get_mock.return_value = [
+        {
+            "app": {"slug": "c1"},
+            "status": "completed",
+            "conclusion": "success",
+        },
+        {
+            "app": {"slug": "c2"},
+            "status": "completed",
+            "conclusion": "success",
+        },
+    ]
+    stat = _get_github_checks(1, 2)
+    get_mock.assert_called_once_with(1, 2)
+    assert stat == {"c1": True, "c2": True}
+
+
+@unittest.mock.patch(
+    "conda_forge_webservices.github_actions_integration.automerge._get_checks"
+)
+def test_check_github_checks_success_plus_pending(get_mock):
+    get_mock.return_value = [
+        {
+            "app": {"slug": "c1"},
+            "status": "blah",
+            "conclusion": "success",
+        },
+        {
+            "app": {"slug": "c2"},
+            "status": "completed",
+            "conclusion": "success",
+        },
+    ]
+    stat = _get_github_checks(1, 2)
+    get_mock.assert_called_once_with(1, 2)
+    assert stat == {"c1": None, "c2": True}
+
+
+@unittest.mock.patch(
+    "conda_forge_webservices.github_actions_integration.automerge._get_checks"
+)
+def test_check_github_checks_success_plus_fail(get_mock):
+    get_mock.return_value = [
+        {
+            "app": {"slug": "c1"},
+            "status": "completed",
+            "conclusion": "error",
+        },
+        {
+            "app": {"slug": "c2"},
+            "status": "completed",
+            "conclusion": "failure",
+        },
+        {
+            "app": {"slug": "c3"},
+            "status": "completed",
+            "conclusion": "success",
+        },
+    ]
+    stat = _get_github_checks(1, 2)
+    get_mock.assert_called_once_with(1, 2)
+    assert stat == {"c1": False, "c2": False, "c3": True}
+
+
+@unittest.mock.patch(
+    "conda_forge_webservices.github_actions_integration.automerge._get_checks"
+)
+def test_check_github_checks_pending_plus_fail(get_mock):
+    get_mock.return_value = [
+        {
+            "app": {"slug": "c1"},
+            "status": "completed",
+            "conclusion": "error",
+        },
+        {
+            "app": {"slug": "c2"},
+            "status": "completed",
+            "conclusion": "failure",
+        },
+        {
+            "app": {"slug": "c3"},
+            "status": "blah",
+            "conclusion": "success",
+        },
+    ]
+    stat = _get_github_checks(1, 2)
+    get_mock.assert_called_once_with(1, 2)
+    assert stat == {"c1": False, "c2": False, "c3": None}
+
+
+@unittest.mock.patch(
+    "conda_forge_webservices.github_actions_integration.automerge._get_checks"
+)
+def test_check_github_checks_pending_plus_success_plus_fail(get_mock):
+    get_mock.return_value = [
+        {
+            "app": {"slug": "c1"},
+            "status": "completed",
+            "conclusion": "error",
+        },
+        {
+            "app": {"slug": "c2"},
+            "status": "completed",
+            "conclusion": "failure",
+        },
+        {
+            "app": {"slug": "c3"},
+            "status": "blah",
+            "conclusion": "success",
+        },
+        {
+            "app": {"slug": "c4"},
+            "status": "completed",
+            "conclusion": "success",
+        },
+    ]
+    stat = _get_github_checks(1, 2)
+    get_mock.assert_called_once_with(1, 2)
+    assert stat == {"c1": False, "c2": False, "c3": None, "c4": True}

--- a/conda_forge_webservices/github_actions_integration/tests/test_github_statuses.py
+++ b/conda_forge_webservices/github_actions_integration/tests/test_github_statuses.py
@@ -1,0 +1,94 @@
+import datetime
+import unittest
+
+import pytest
+
+from ..automerge import _get_github_statuses
+
+
+class DummyStatus:
+    """Dummy object to mock up something from the API.
+
+    We could use an actual mock, but shrug.
+    """
+
+    def __init__(self, context, state, updated_at):
+        self.context = context
+        self.state = state
+        self.updated_at = updated_at
+
+
+@pytest.mark.parametrize(
+    "stats,ret",
+    [
+        ([], {}),
+        (
+            [
+                DummyStatus("blah", "pending", datetime.datetime.now()),
+                DummyStatus("blah", "success", datetime.datetime.now()),
+            ],
+            {"blah": True},
+        ),
+        (
+            [
+                DummyStatus("blah", "pending", datetime.datetime.now()),
+                DummyStatus("blah1", "pending", datetime.datetime.now()),
+            ],
+            {"blah": None, "blah1": None},
+        ),
+        (
+            [
+                DummyStatus("blah", "failure", datetime.datetime.now()),
+                DummyStatus("blah1", "error", datetime.datetime.now()),
+            ],
+            {"blah": False, "blah1": False},
+        ),
+        (
+            [
+                DummyStatus("blah", "success", datetime.datetime.now()),
+                DummyStatus("blah1", "success", datetime.datetime.now()),
+            ],
+            {"blah": True, "blah1": True},
+        ),
+        (
+            [
+                DummyStatus("blah", "failure", datetime.datetime.now()),
+                DummyStatus("blah1", "error", datetime.datetime.now()),
+                DummyStatus("blah2", "pending", datetime.datetime.now()),
+            ],
+            {"blah": False, "blah1": False, "blah2": None},
+        ),
+        (
+            [
+                DummyStatus("blah", "success", datetime.datetime.now()),
+                DummyStatus("blah1", "error", datetime.datetime.now()),
+                DummyStatus("blah2", "pending", datetime.datetime.now()),
+            ],
+            {"blah": True, "blah1": False, "blah2": None},
+        ),
+        (
+            [
+                DummyStatus("blah", "success", datetime.datetime.now()),
+                DummyStatus("blah1", "error", datetime.datetime.now()),
+                DummyStatus("blah2", "failure", datetime.datetime.now()),
+            ],
+            {"blah": True, "blah1": False, "blah2": False},
+        ),
+        (
+            [
+                DummyStatus("blah", "success", datetime.datetime.now()),
+                DummyStatus("blah1", "error", datetime.datetime.now()),
+                DummyStatus("blah2", "failure", datetime.datetime.now()),
+                DummyStatus("blah3", "pending", datetime.datetime.now()),
+            ],
+            {"blah": True, "blah1": False, "blah2": False, "blah3": None},
+        ),
+    ],
+)
+def test_get_github_statuses(stats, ret):
+    repo = unittest.mock.MagicMock()
+    pr = unittest.mock.MagicMock()
+    repo.get_commit.return_value.get_statuses.return_value = stats
+    stat = _get_github_statuses(repo, pr)
+    assert stat == ret
+    repo.get_commit.assert_called_once_with(pr.head.sha)

--- a/conda_forge_webservices/github_actions_integration/tests/test_only_bot.py
+++ b/conda_forge_webservices/github_actions_integration/tests/test_only_bot.py
@@ -1,0 +1,5 @@
+from ..automerge import ALLOWED_USERS
+
+
+def test_only_bot():
+    assert ALLOWED_USERS == ["regro-cf-autotick-bot"]

--- a/conda_forge_webservices/github_actions_integration/tests/test_optout.py
+++ b/conda_forge_webservices/github_actions_integration/tests/test_optout.py
@@ -1,0 +1,19 @@
+import pytest
+
+from ..automerge import _automerge_me
+
+
+@pytest.mark.parametrize(
+    "cfg_bool",
+    [
+        ({}, False),
+        ({"bot": {}}, False),
+        ({"bot": {"automerge": False}}, False),
+        ({"bot": {"automerge": True}}, True),
+    ],
+)
+def test_automerge_me(cfg_bool):
+    if cfg_bool[1]:
+        assert _automerge_me(cfg_bool[0])
+    else:
+        assert not _automerge_me(cfg_bool[0])

--- a/conda_forge_webservices/github_actions_integration/tests/test_required_checks.py
+++ b/conda_forge_webservices/github_actions_integration/tests/test_required_checks.py
@@ -1,0 +1,95 @@
+import os
+import unittest
+
+import pytest
+
+from ..automerge import (
+    _all_statuses_and_checks_ok,
+    _get_required_checks_and_statuses,
+    pushd,
+)
+
+
+@pytest.mark.parametrize("val", [True, False])
+def test_all_statuses_and_checks_ok(val):
+    status_states = {
+        "A-ci": val,
+        "b-CI": None if not val else True,
+        "c-ci": False,
+    }
+    check_states = {
+        "e-ci": None if not val else True,
+        "e-ci-1": False if not val else True,
+        "e-ci-2": True,
+        "d-ci": True,
+        "f-ci": val,
+    }
+    req_checks_and_states = ["a", "b-ci", "e-c", "f-"]
+    ok, stats = _all_statuses_and_checks_ok(
+        status_states, check_states, req_checks_and_states
+    )
+    if val:
+        assert ok
+        assert stats == {"a": True, "b-ci": True, "e-c": True, "f-": True}
+    else:
+        assert not ok
+        assert stats == {"a": False, "b-ci": None, "e-c": None, "f-": False}
+
+
+@pytest.mark.parametrize(
+    "fname",
+    [
+        "appveyor.yml",
+        ".appveyor.yml",
+        ".drone.yml",
+        ".travis.yml",
+        "azure-pipelines.yml",
+        ".circleci/config.yml",
+    ],
+)
+@pytest.mark.parametrize("ignore_linter", ["conda-forge-linter", "linter", None])
+@unittest.mock.patch(
+    "conda_forge_webservices.github_actions_integration.automerge._run_git_command"
+)
+@unittest.mock.patch(
+    "conda_forge_webservices.github_actions_integration.automerge.tempfile"
+)
+def test_get_required_checks_and_statuses(
+    tmpmock, submock, tmpdir, fname, ignore_linter
+):
+    tmpmock.TemporaryDirectory.return_value.__enter__.return_value = str(tmpdir)
+
+    pr = unittest.mock.MagicMock()
+    if ignore_linter is not None:
+        cfg = {"bot": {"automerge_options": {"ignored_statuses": [ignore_linter]}}}
+    else:
+        cfg = {}
+
+    with pushd(tmpdir):
+        os.makedirs(".circleci")
+        with open(fname, "w") as fp:
+            fp.write("dummy")
+
+    req = _get_required_checks_and_statuses(pr, cfg)
+
+    if fname in ["appveyor.yml", ".appveyor.yml"]:
+        name = "appveyor"
+    elif fname == ".drone.yml":
+        name = "drone"
+    elif fname == ".travis.yml":
+        name = "travis"
+    elif fname == "azure-pipelines.yml":
+        name = "azure"
+    else:
+        name = "circle"
+
+    assert name in req
+    if ignore_linter is None:
+        assert "linter" in req
+        assert len(req) == 2, req
+    else:
+        assert "linter" not in req
+        assert len(req) == 1, req
+
+    submock.assert_any_call("clone", pr.head.repo.clone_url, str(tmpdir))
+    submock.assert_any_call("checkout", pr.head.sha)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ cache-status-data = "conda_forge_webservices.status_monitor:cache_status_data"
 conda-forge-webservices-init-task = "conda_forge_webservices.github_actions_integration.__main__:main_init_task"
 conda-forge-webservices-run-task = "conda_forge_webservices.github_actions_integration.__main__:main_run_task"
 conda-forge-webservices-finalize-task = "conda_forge_webservices.github_actions_integration.__main__:main_finalize_task"
+conda-forge-webservices-automerge = "conda_forge_webservices.github_actions_integration.__main__:main_automerge"
 
 [tool.setuptools]
 packages = ["conda_forge_webservices"]


### PR DESCRIPTION
### Description

This PR moves the automerge integration code here so we can automerge GHA-based feedstocks.

Future PRs will add the actual integration.

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
