### PR TITLE
feat: turn on automerge for everyone

### DIFF
--- a/conda_forge_webservices/github_actions_integration/__main__.py
+++ b/conda_forge_webservices/github_actions_integration/__main__.py
@@ -492,4 +492,9 @@ def main_automerge(repo, sha):
             found_pr = True
 
     if not found_pr:
-        raise RuntimeError(f"No PR found for {full_repo_name}@{sha}!")
+        LOGGER.error(f"No PR found for {full_repo_name}@{sha}!")
+        print(
+            "::warning title=No PR Found for Automerge::"
+            f"No PR found for {full_repo_name}@{sha}",
+            flush=True,
+        )

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -734,12 +734,6 @@ class OutputsCopyHandler(tornado.web.RequestHandler):
 
 
 def _dispatch_automerge_job(repo, sha):
-    if repo != "cf-autotick-bot-test-package-feedstock":
-        LOGGER.info(
-            "    skipping automerge job dispatch for conda-forge/%s@%s", repo, sha
-        )
-        return
-
     gh = get_gh_client()
 
     skip_test_pr = False
@@ -859,6 +853,7 @@ class StatusMonitorPayloadHookHandler(tornado.web.RequestHandler):
                     body["repository"]["name"],
                     body["pull_request"]["head"]["sha"],
                 )
+            return
         else:
             LOGGER.info(f'Unhandled event "{event}".')
 


### PR DESCRIPTION
### Description

This PR turns on new automerge for everyone.

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
