### PR TITLE
feat: use admin token for merge and comments when doing automerge

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -54,8 +54,8 @@ jobs:
 
       - name: automerge
         run: |
-          git config --global user.email "79913779+conda-forge-curator[bot]@users.noreply.github.com"
-          git config --global user.name "conda-forge-curator[bot]"
+          git config --global user.name "conda-forge-webservices[bot]"
+          git config --global user.email "91080706+conda-forge-webservices[bot]@users.noreply.github.com"
           git config --global pull.rebase false
 
           conda-forge-webservices-automerge \
@@ -63,4 +63,5 @@ jobs:
             --sha=${{ inputs.sha }}
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+          GH_TOKEN_FOR_ADMIN: ${{ secrets.CF_ADMIN_GITHUB_TOKEN }}
 

--- a/conda_forge_webservices/github_actions_integration/__main__.py
+++ b/conda_forge_webservices/github_actions_integration/__main__.py
@@ -21,7 +21,7 @@ from .utils import (
     get_git_patch_relative_to_commit,
     mark_pr_as_ready_for_review,
 )
-from .api_sessions import create_api_sessions
+from .api_sessions import create_api_sessions, create_api_sessions_for_admin
 from .rerendering import rerender
 from .linting import (
     make_lint_comment,
@@ -488,7 +488,10 @@ def main_automerge(repo, sha):
     gh_repo = gh.get_repo(full_repo_name)
     for pr in gh_repo.get_pulls():
         if pr.head.sha == sha:
-            automerge_pr(gh_repo, pr)
+            _, gh_for_admin = create_api_sessions_for_admin()
+            gh_repo_for_admin = gh_for_admin.get_repo(full_repo_name)
+            pr_for_admin = gh_repo_for_admin.get_pull(pr.number)
+            automerge_pr(gh_repo, pr, pr_for_admin)
             found_pr = True
 
     if not found_pr:

--- a/conda_forge_webservices/github_actions_integration/api_sessions.py
+++ b/conda_forge_webservices/github_actions_integration/api_sessions.py
@@ -19,7 +19,20 @@ def create_api_sessions():
     return _create_api_sessions(os.environ["GH_TOKEN"])
 
 
-@lru_cache(maxsize=1)
+def create_api_sessions_for_admin():
+    """Create API sessions for GitHub using the admin token.
+
+    Returns
+    -------
+    session : requests.Session
+        A `requests` session w/ the beta `check_run` API configured.
+    gh : github.MainClass.Github
+        A `Github` object from the PyGithub package.
+    """
+    return _create_api_sessions(os.environ["GH_TOKEN_FOR_ADMIN"])
+
+
+@lru_cache(maxsize=2)
 def _create_api_sessions(github_token):
     # based on
     #  https://alexwlchan.net/2019/03/

--- a/conda_forge_webservices/github_actions_integration/automerge.py
+++ b/conda_forge_webservices/github_actions_integration/automerge.py
@@ -335,7 +335,9 @@ def _no_extra_pr_commits(pr):
     return all(e.event != "committed" for e in events[label_ind + 1 :])
 
 
-def _check_pr(pr: PullRequest, cfg) -> tuple[bool, str | None]:
+def _check_pr(
+    pr: PullRequest, pr_for_admin: PullRequest, cfg
+) -> tuple[bool, str | None]:
     """make sure a PR is ok to automerge"""
 
     pr_has_automerge_label = any(label.name == "automerge" for label in pr.get_labels())
@@ -351,7 +353,7 @@ def _check_pr(pr: PullRequest, cfg) -> tuple[bool, str | None]:
                 return True, None
             else:
                 pr.remove_from_labels("automerge")
-                pr.create_issue_comment(
+                pr_for_admin.create_issue_comment(
                     """\
 Hi! This is the friendly conda-forge automerge bot!
 
@@ -378,7 +380,7 @@ like to enable automerge again!
         committers = {getattr(c.author, "login", None) for c in pr.get_commits()}
         if not all(c in ALLOWED_USERS for c in committers):
             _comment_on_pr_with_race(
-                pr,
+                pr_for_admin,
                 """\
 Hi! This is the friendly conda-forge automerge bot!
 
@@ -438,7 +440,7 @@ def _automerge_pr(
     pr_for_admin: PullRequest,
 ) -> tuple[bool, str | None]:
     cfg = _get_conda_forge_config(pr)
-    allowed, msg = _check_pr(pr, cfg)
+    allowed, msg = _check_pr(pr, pr_for_admin, cfg)
 
     if not allowed:
         return False, msg


### PR DESCRIPTION
### Description

This PR uses the admin token for merges and comments when doing automerge. It will make things look nicer. 

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
