### PR TITLE
fix: remove deprecated pygithub calls

### DIFF
--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -406,7 +406,7 @@ def issue_comment(org_name, repo_name, issue_num, title, comment, comment_id=Non
             # this token has to be that of an actual bot since we use this
             # to make a fork
             # the bot used does not need admin permissions
-            gh = github.Github(os.environ["GH_TOKEN"])
+            gh = github.Github(auth=github.Auth.Token(os.environ["GH_TOKEN"]))
             repo = gh.get_repo(f"{org_name}/{repo_name}")
             default_branch = repo.default_branch
             break

--- a/conda_forge_webservices/tests/linting/test_comment_on_pr.py
+++ b/conda_forge_webservices/tests/linting/test_comment_on_pr.py
@@ -19,7 +19,7 @@ class Test_comment_on_pr(unittest.TestCase):
                 "conda-forge", "conda-forge-webservices", PR_number, message_to_post
             )
 
-        gh = github.Github(os.environ["GH_TOKEN"])
+        gh = github.Github(auth=github.Auth.Token(os.environ["GH_TOKEN"]))
         linting_repo = gh.get_user("conda-forge").get_repo("conda-forge-webservices")
         pr = linting_repo.get_issue(PR_number)
         comments = list(pr.get_comments())

--- a/conda_forge_webservices/tokens.py
+++ b/conda_forge_webservices/tokens.py
@@ -58,7 +58,7 @@ def get_app_token_for_webservices_only():
         )
         if token is not None:
             try:
-                APP_TOKEN_RESET_TIME = Github(token).rate_limiting_resettime
+                APP_TOKEN_RESET_TIME = Github(auth=Auth.Token(token)).rate_limiting_resettime
             except Exception:
                 LOGGER.info("")
                 LOGGER.info("===================================================")
@@ -236,7 +236,7 @@ def _inject_app_token_into_feedstock(full_name, repo=None, readonly=False):
                 repo = gh.get_repo(full_name)
             try:
                 repo.create_secret(token_name, token)
-                reset_times_dict[repo_name] = Github(token).rate_limiting_resettime
+                reset_times_dict[repo_name] = Github(auth=Auth.Token(token)).rate_limiting_resettime
                 LOGGER.info("")
                 LOGGER.info("===================================================")
                 LOGGER.info(

--- a/conda_forge_webservices/tokens.py
+++ b/conda_forge_webservices/tokens.py
@@ -58,7 +58,9 @@ def get_app_token_for_webservices_only():
         )
         if token is not None:
             try:
-                APP_TOKEN_RESET_TIME = Github(auth=Auth.Token(token)).rate_limiting_resettime
+                APP_TOKEN_RESET_TIME = Github(
+                    auth=Auth.Token(token)
+                ).rate_limiting_resettime
             except Exception:
                 LOGGER.info("")
                 LOGGER.info("===================================================")
@@ -236,7 +238,9 @@ def _inject_app_token_into_feedstock(full_name, repo=None, readonly=False):
                 repo = gh.get_repo(full_name)
             try:
                 repo.create_secret(token_name, token)
-                reset_times_dict[repo_name] = Github(auth=Auth.Token(token)).rate_limiting_resettime
+                reset_times_dict[repo_name] = Github(
+                    auth=Auth.Token(token)
+                ).rate_limiting_resettime
                 LOGGER.info("")
                 LOGGER.info("===================================================")
                 LOGGER.info(

--- a/conda_forge_webservices/update_teams.py
+++ b/conda_forge_webservices/update_teams.py
@@ -14,7 +14,7 @@ LOGGER = logging.getLogger("conda_forge_webservices.update_teams")
 
 @cache
 def get_filter_out_members():
-    gh = github.Github(os.environ["GH_TOKEN"])
+    gh = github.Github(auth=github.Auth.Token(os.environ["GH_TOKEN"]))
     org = gh.get_organization("conda-forge")
     teams = ["staged-recipes", "help-r", "r"]
     gh_teams = list(org.get_team_by_slug(team) for team in teams)

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -89,7 +89,7 @@ atexit.register(_shutdown_thread_pool)
 
 def get_commit_message(full_name, commit):
     return (
-        github.Github(os.environ["GH_TOKEN"])
+        github.Github(auth=github.Auth.Token(os.environ["GH_TOKEN"]))
         .get_repo(full_name)
         .get_commit(commit)
         .commit.message
@@ -105,7 +105,7 @@ def print_rate_limiting_info_for_token(token):
     # spending it and how to better optimize it.
 
     # Get GitHub API Rate Limit usage and total
-    gh = github.Github(token)
+    gh = github.Github(auth=github.Auth.Token(token))
     gh_api_remaining = gh.get_rate_limit().core.remaining
     gh_api_total = gh.get_rate_limit().core.limit
 
@@ -547,7 +547,7 @@ def _do_copy(feedstock, outputs, channel, git_sha, comment_on_error, hash_type):
         # send for github releases copy
         # if False:
         #     try:
-        #         gh = github.Github(os.environ["GH_TOKEN"])
+        #         gh = github.Github(auth=github.Auth.Token(os.environ["GH_TOKEN"]))
         #         repo = gh.get_repo("conda-forge/repodata-shards")
         #         for dist in copied:
         #             if not copied[dist]:

--- a/scripts/test_cfep13_endpoints.py
+++ b/scripts/test_cfep13_endpoints.py
@@ -41,7 +41,7 @@ bad_headers = {
 }
 
 try:
-    GH = github.Github(os.environ["GH_TOKEN"])
+    GH = github.Github(auth=github.Auth.Token(os.environ["GH_TOKEN"]))
 except Exception:
     GH = None
 


### PR DESCRIPTION
### Description

This PR fixes a warning for deprecated pygithub syntax for using tokens.

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
