### PR TITLE
Use Zulip link in welcome message

### DIFF
--- a/conda_forge_webservices/update_teams.py
+++ b/conda_forge_webservices/update_teams.py
@@ -125,7 +125,7 @@ def update_team(org_name, repo_name, commit=None):
                 Your package won't be available for installation locally until it is built
                 and synced to the anaconda.org CDN (takes 1-2 hours after the build finishes).
 
-                Feel free to join the community [Element channel](https://app.element.io/#/room/#conda-forge:matrix.org).
+                Feel free to join the community on [Zulip](https://conda-forge.zulipchat.com).
 
                 NOTE: Please make sure to not push to the repository directly.
                       Use branches in your fork for any changes and send a PR.


### PR DESCRIPTION
### Description

Changes the chatroom link in the welcome message to point to Zulip in line with [CFEP 23]( https://github.com/conda-forge/cfep/blob/main/cfep-23.md )

Fixes messages like [this one]( https://github.com/conda-forge/cuda_histogram-feedstock/commit/34a2ff44a3acd4ad626ca6ee9f72f2df835086e4#commitcomment-148713846 ) to point to Zulip instead of Element