### PR TITLE
feat: add run-names to workflows

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,6 +1,7 @@
 name: automerge
 
-run-name: 'automerge' for conda-forge/${{ inputs.repo }}@${{ inputs.sha }}
+run-name: >-
+  automerge: conda-forge/${{ inputs.repo }}@${{ inputs.sha }} [uuid=${{ inputs.uuid }}]
 
 on:
   workflow_dispatch:
@@ -11,6 +12,10 @@ on:
         type: string
       sha:
         description: 'the commit SHA to possibly merge'
+        required: true
+        type: string
+      uuid:
+        description: 'a unique identifier for this run'
         required: true
         type: string
 

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,6 +1,6 @@
 name: automerge
 
-run-name: task 'automerge' for conda-forge/${{ inputs.repo }}@${{ inputs.sha }}
+run-name: 'automerge' for conda-forge/${{ inputs.repo }}@${{ inputs.sha }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,5 +1,7 @@
 name: automerge
 
+run-name: task 'automerge' for conda-forge/${{ inputs.repo }}@${{ inputs.sha }}
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/webservices-workflow-dispatch.yml
+++ b/.github/workflows/webservices-workflow-dispatch.yml
@@ -1,5 +1,7 @@
 name: webservices-workflow-dispatch
 
+run-name: task '${{ inputs.task }}' for conda-forge/${{ inputs.repo }}#${{ inputs.pr_number }} [container=${{ inputs.container_tag }}, requested_version=${{ inputs.requested_version }}]
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/webservices-workflow-dispatch.yml
+++ b/.github/workflows/webservices-workflow-dispatch.yml
@@ -1,6 +1,7 @@
 name: webservices-workflow-dispatch
 
-run-name: '${{ inputs.task }}' for conda-forge/${{ inputs.repo }}#${{ inputs.pr_number }} [container=${{ inputs.container_tag }}, requested_version=${{ inputs.requested_version }}]
+run-name: >-
+  ${{ inputs.task }}: conda-forge/${{ inputs.repo }}#${{ inputs.pr_number }} [container=${{ inputs.container_tag }}, requested_version=${{ inputs.requested_version }}, uuid=${{ inputs.uuid }}]
 
 on:
   workflow_dispatch:
@@ -26,6 +27,10 @@ on:
         required: false
         type: string
         default: 'null'
+      uuid:
+        description: 'a unique identifier for this run'
+        required: true
+        type: string
 
 env:
   PY_COLORS: 1

--- a/.github/workflows/webservices-workflow-dispatch.yml
+++ b/.github/workflows/webservices-workflow-dispatch.yml
@@ -1,6 +1,6 @@
 name: webservices-workflow-dispatch
 
-run-name: task '${{ inputs.task }}' for conda-forge/${{ inputs.repo }}#${{ inputs.pr_number }} [container=${{ inputs.container_tag }}, requested_version=${{ inputs.requested_version }}]
+run-name: '${{ inputs.task }}' for conda-forge/${{ inputs.repo }}#${{ inputs.pr_number }} [container=${{ inputs.container_tag }}, requested_version=${{ inputs.requested_version }}]
 
 on:
   workflow_dispatch:

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -7,6 +7,7 @@ import time
 import shutil
 import tempfile
 import textwrap
+import uuid
 from ruamel.yaml import YAML
 import requests
 from requests.exceptions import RequestException
@@ -993,6 +994,7 @@ def rerender(full_name, pr_num):
     inject_app_token_into_feedstock_readonly(full_name, repo=repo)
 
     _, repo_name = full_name.split("/")
+    uid = uuid.uuid4().hex
     ref = __version__.replace("+", ".")
     workflow = gh.get_repo("conda-forge/conda-forge-webservices").get_workflow(
         "webservices-workflow-dispatch.yml"
@@ -1004,6 +1006,7 @@ def rerender(full_name, pr_num):
             "repo": repo_name,
             "pr_number": str(pr_num),
             "container_tag": ref,
+            "uuid": uid,
         },
     )
 
@@ -1017,6 +1020,7 @@ def update_version(full_name, pr_num, input_ver):
     inject_app_token_into_feedstock(full_name, repo=repo)
     inject_app_token_into_feedstock_readonly(full_name, repo=repo)
 
+    uid = uuid.uuid4().hex
     _, repo_name = full_name.split("/")
     ref = __version__.replace("+", ".")
     workflow = gh.get_repo("conda-forge/conda-forge-webservices").get_workflow(
@@ -1030,6 +1034,7 @@ def update_version(full_name, pr_num, input_ver):
             "pr_number": str(pr_num),
             "container_tag": ref,
             "requested_version": str(input_ver) or "null",
+            "uuid": uid,
         },
     )
     return not running

--- a/conda_forge_webservices/linting.py
+++ b/conda_forge_webservices/linting.py
@@ -5,6 +5,7 @@ from tempfile import TemporaryDirectory
 import logging
 from pathlib import Path
 from typing import TypedDict
+import uuid
 
 from git import GitCommandError, Repo
 import conda_smithy.lint_recipe
@@ -41,6 +42,7 @@ def lint_via_github_actions(full_name: str, pr_num: int) -> bool:
     if should_skip:
         return False
 
+    uid = uuid.uuid4().hex
     ref = __version__.replace("+", ".")
     workflow = gh.get_repo("conda-forge/conda-forge-webservices").get_workflow(
         "webservices-workflow-dispatch.yml"
@@ -52,6 +54,7 @@ def lint_via_github_actions(full_name: str, pr_num: int) -> bool:
             "repo": repo_name,
             "pr_number": str(pr_num),
             "container_tag": ref,
+            "uuid": uid,
         },
     )
 

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -8,6 +8,7 @@ import tornado.web
 import tornado.locks
 import hmac
 import hashlib
+import uuid
 import json
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 import atexit
@@ -746,6 +747,7 @@ def _dispatch_automerge_job(repo, sha):
                 break
 
     if not skip_test_pr:
+        uid = uuid.uuid4().hex
         ref = __version__.replace("+", ".")
         workflow = gh.get_repo("conda-forge/conda-forge-webservices").get_workflow(
             "automerge.yml"
@@ -755,11 +757,17 @@ def _dispatch_automerge_job(repo, sha):
             inputs={
                 "repo": repo,
                 "sha": sha,
+                "uuid": uid,
             },
         )
 
         if running:
-            LOGGER.info("    automerge job dispatched: conda-forge/%s@%s", repo, sha)
+            LOGGER.info(
+                "    automerge job dispatched: conda-forge/%s@%s [uuid=%s]",
+                repo,
+                sha,
+                uid,
+            )
         else:
             LOGGER.info("    automerge job dispatch failed")
     else:

--- a/tests/test_live_automerge.py
+++ b/tests/test_live_automerge.py
@@ -102,6 +102,7 @@ def test_live_automerge(pytestconfig):
                                 merged = True
                                 break
                             elif tot > 0:
+                                uid = uuid.uuid4().hex
                                 cfws_repo = gh.get_repo(
                                     "conda-forge/conda-forge-webservices"
                                 )
@@ -113,6 +114,7 @@ def test_live_automerge(pytestconfig):
                                             "cf-autotick-bot-test-package-feedstock"
                                         ),
                                         "sha": pr.head.sha,
+                                        "uuid": uid,
                                     },
                                 )
 

--- a/tests/test_live_linter.py
+++ b/tests/test_live_linter.py
@@ -1,5 +1,6 @@
 import os
 import time
+import uuid
 
 import github
 
@@ -90,6 +91,7 @@ def test_linter_pr(pytestconfig):
     repo = gh.get_repo("conda-forge/conda-forge-webservices")
 
     for pr_number, _, _ in TEST_CASES:
+        uid = uuid.uuid4().hex
         pr = repo.get_pull(pr_number)
         workflow = repo.get_workflow("webservices-workflow-dispatch.yml")
         workflow.create_dispatch(
@@ -99,6 +101,7 @@ def test_linter_pr(pytestconfig):
                 "repo": "conda-forge-webservices",
                 "pr_number": str(pr_number),
                 "container_tag": conda_forge_webservices.__version__.replace("+", "."),
+                "uid": uid,
             },
         )
 

--- a/tests/test_live_rerender.py
+++ b/tests/test_live_rerender.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import tempfile
 import time
+import uuid
 
 import conda_forge_webservices
 import github
@@ -13,6 +14,7 @@ from conftest import _merge_main_to_branch
 
 def _run_test(branch):
     print("sending workflow dispatch event to rerender...", flush=True)
+    uid = uuid.uuid4().hex
     gh = github.Github(auth=github.Auth.Token(os.environ["GH_TOKEN"]))
     repo = gh.get_repo("conda-forge/conda-forge-webservices")
     workflow = repo.get_workflow("webservices-workflow-dispatch.yml")
@@ -23,6 +25,7 @@ def _run_test(branch):
             "repo": "cf-autotick-bot-test-package-feedstock",
             "pr_number": "445",
             "container_tag": conda_forge_webservices.__version__.replace("+", "."),
+            "uuid": uid,
         },
     )
 

--- a/tests/test_live_version_update.py
+++ b/tests/test_live_version_update.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import tempfile
 import time
+import uuid
 
 import github
 import requests
@@ -121,6 +122,7 @@ def _pr_title(new=None):
 
 def _run_test(branch, version):
     print("sending workflow dispatch event to version updater...", flush=True)
+    uid = uuid.uuid4().hex
     repo = GH.get_repo("conda-forge/conda-forge-webservices")
     workflow = repo.get_workflow("webservices-workflow-dispatch.yml")
     workflow.create_dispatch(
@@ -131,6 +133,7 @@ def _run_test(branch, version):
             "pr_number": str(PR_NUM),
             "container_tag": conda_forge_webservices.__version__.replace("+", "."),
             "requested_version": version or "null",
+            "uuid": uid,
         },
     )
 


### PR DESCRIPTION
### Description

This PR adds run names so that we can track down workflows more easily.

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
