### PR TITLE
fix: see if we can keep the recipe in working order

### DIFF
--- a/tests/test_live_version_update.py
+++ b/tests/test_live_version_update.py
@@ -75,6 +75,8 @@ def _change_version(new_version="0.13", branch="main"):
     import random
 
     new_sha = "".join(random.choices("0123456789abcdef", k=64))
+    if new_version == "0.14":
+        new_sha = "f6c45d5788f51dbe1cc55e1010f3e9ebd18b6c0f21907fc35499468a59827eef"
 
     print("changing the version to an old one...", flush=True)
     subprocess.run(["git", "checkout", branch], check=True)
@@ -101,7 +103,7 @@ def _change_version(new_version="0.13", branch="main"):
             "commit",
             "--allow-empty",
             "-m",
-            "[ci skip] moved version to older 0.13",
+            f"[ci skip] moved version to {new_version}",
         ],
         check=True,
     )


### PR DESCRIPTION
### Description

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

This PR tries to get the version tests to leave the main branch in working order.

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
