### PR TITLE
feat: set target url

### DIFF
--- a/conda_forge_webservices/github_actions_integration/linting.py
+++ b/conda_forge_webservices/github_actions_integration/linting.py
@@ -158,13 +158,17 @@ def build_and_make_lint_comment(gh, repo, pr_id, lints, hints):
             """,
         )
 
-        mixed = good + "\n" + dedent_with_escaped_continue(
-            """
+        mixed = (
+            good
+            + "\n"
+            + dedent_with_escaped_continue(
+                """
             I do have some suggestions for making it better though...
 
             {}
             """
-        ).format("\n".join(messages))
+            ).format("\n".join(messages))
+        )
 
         bad = dedent_with_escaped_continue(
             f"""

--- a/conda_forge_webservices/github_actions_integration/linting.py
+++ b/conda_forge_webservices/github_actions_integration/linting.py
@@ -158,7 +158,7 @@ def build_and_make_lint_comment(gh, repo, pr_id, lints, hints):
             """,
         )
 
-        mixed = good + dedent_with_escaped_continue(
+        mixed = good + "\n" + dedent_with_escaped_continue(
             """
             I do have some suggestions for making it better though...
 

--- a/conda_forge_webservices/linting.py
+++ b/conda_forge_webservices/linting.py
@@ -59,7 +59,16 @@ def lint_via_github_actions(full_name: str, pr_num: int) -> bool:
     )
 
     if running:
-        _set_pr_status(repo_owner, repo_name, sha, "pending")
+        run = None
+        for _run in workflow.get_runs(branch=ref, event="workflow_dispatch"):
+            if uid in run.name:
+                run = _run
+                break
+        if run:
+            target_url = run.html_url
+        else:
+            target_url = None
+        _set_pr_status(repo_owner, repo_name, sha, "pending", target_url=target_url)
 
     return running
 

--- a/conda_forge_webservices/linting.py
+++ b/conda_forge_webservices/linting.py
@@ -30,12 +30,17 @@ class LintInfo(TypedDict):
 
 
 def _get_workflow_run_from_uid(workflow, uid, ref):
-    run = None
-    for _run in workflow.get_runs(branch=ref, event="workflow_dispatch"):
+    num_try = 0
+    max_try = 20
+    for run in workflow.get_runs(branch=ref, event="workflow_dispatch"):
         if uid in run.name:
-            run = _run
+            return run
+
+        num_try += 1
+        if num_try > max_try:
             break
-    return run
+
+    return None
 
 
 def lint_via_github_actions(full_name: str, pr_num: int) -> bool:

--- a/conda_forge_webservices/linting.py
+++ b/conda_forge_webservices/linting.py
@@ -73,7 +73,9 @@ def lint_via_github_actions(full_name: str, pr_num: int) -> bool:
     )
 
     if running:
-        run = _get_workflow_run_from_uid(workflow, uid, ref)
+        for _ in range(10):
+            time.sleep(1)
+            run = _get_workflow_run_from_uid(workflow, uid, ref)
         if run:
             target_url = run.html_url
         else:

--- a/conda_forge_webservices/linting.py
+++ b/conda_forge_webservices/linting.py
@@ -30,6 +30,15 @@ class LintInfo(TypedDict):
 
 
 def _get_workflow_run_from_uid(workflow, uid, ref):
+    for _ in range(10):
+        time.sleep(1)
+        run = _inner_get_workflow_run_from_uid(workflow, uid, ref)
+        if run:
+            return run
+    return None
+
+
+def _inner_get_workflow_run_from_uid(workflow, uid, ref):
     num_try = 0
     max_try = 20
     for run in workflow.get_runs(branch=ref, event="workflow_dispatch"):
@@ -73,9 +82,7 @@ def lint_via_github_actions(full_name: str, pr_num: int) -> bool:
     )
 
     if running:
-        for _ in range(10):
-            time.sleep(1)
-            run = _get_workflow_run_from_uid(workflow, uid, ref)
+        run = _get_workflow_run_from_uid(workflow, uid, ref)
         if run:
             target_url = run.html_url
         else:

--- a/conda_forge_webservices/linting.py
+++ b/conda_forge_webservices/linting.py
@@ -29,6 +29,15 @@ class LintInfo(TypedDict):
     sha: str
 
 
+def _get_workflow_run_from_uid(workflow, uid, ref):
+    run = None
+    for _run in workflow.get_runs(branch=ref, event="workflow_dispatch"):
+        if uid in run.name:
+            run = _run
+            break
+    return run
+
+
 def lint_via_github_actions(full_name: str, pr_num: int) -> bool:
     gh = get_gh_client()
     repo = gh.get_repo(full_name)
@@ -59,11 +68,7 @@ def lint_via_github_actions(full_name: str, pr_num: int) -> bool:
     )
 
     if running:
-        run = None
-        for _run in workflow.get_runs(branch=ref, event="workflow_dispatch"):
-            if uid in run.name:
-                run = _run
-                break
+        run = _get_workflow_run_from_uid(workflow, uid, ref)
         if run:
             target_url = run.html_url
         else:

--- a/tests/test_live_linter.py
+++ b/tests/test_live_linter.py
@@ -111,6 +111,7 @@ def test_linter_pr(pytestconfig):
             target_url = run.html_url
         else:
             target_url = None
+        print(f"target_url: {target_url}", flush=True)
         set_pr_status(repo, pr.head.sha, "pending", target_url=target_url)
 
     print("\nsleeping for four minutes to let the linter work...", flush=True)

--- a/tests/test_live_linter.py
+++ b/tests/test_live_linter.py
@@ -107,11 +107,7 @@ def test_linter_pr(pytestconfig):
             },
         )
         assert workflow_ran, f"Workflow did not run for PR {pr_number}!"
-        for _ in range(10):
-            time.sleep(1)
-            run = _get_workflow_run_from_uid(workflow, uid, branch)
-            if run:
-                break
+        run = _get_workflow_run_from_uid(workflow, uid, branch)
         if run:
             target_url = run.html_url
         else:

--- a/tests/test_live_linter.py
+++ b/tests/test_live_linter.py
@@ -103,7 +103,7 @@ def test_linter_pr(pytestconfig):
                 "repo": "conda-forge-webservices",
                 "pr_number": str(pr_number),
                 "container_tag": conda_forge_webservices.__version__.replace("+", "."),
-                "uid": uid,
+                "uuid": uid,
             },
         )
         assert workflow_ran, f"Workflow did not run for PR {pr_number}!"
@@ -112,7 +112,8 @@ def test_linter_pr(pytestconfig):
             target_url = run.html_url
         else:
             target_url = None
-        print(f"target_url: {target_url}", flush=True)
+        assert target_url is not None
+        print(f"target_url for PR {pr_number}: {target_url}", flush=True)
         set_pr_status(repo, pr.head.sha, "pending", target_url=target_url)
 
     print("\nsleeping for four minutes to let the linter work...", flush=True)

--- a/tests/test_live_linter.py
+++ b/tests/test_live_linter.py
@@ -96,7 +96,7 @@ def test_linter_pr(pytestconfig):
         uid = uuid.uuid4().hex
         pr = repo.get_pull(pr_number)
         workflow = repo.get_workflow("webservices-workflow-dispatch.yml")
-        workflow.create_dispatch(
+        workflow_ran = workflow.create_dispatch(
             ref=branch,
             inputs={
                 "task": "lint",
@@ -106,6 +106,7 @@ def test_linter_pr(pytestconfig):
                 "uid": uid,
             },
         )
+        assert workflow_ran, f"Workflow did not run for PR {pr_number}!"
         run = _get_workflow_run_from_uid(workflow, uid, branch)
         if run:
             target_url = run.html_url

--- a/tests/test_live_linter.py
+++ b/tests/test_live_linter.py
@@ -107,7 +107,11 @@ def test_linter_pr(pytestconfig):
             },
         )
         assert workflow_ran, f"Workflow did not run for PR {pr_number}!"
-        run = _get_workflow_run_from_uid(workflow, uid, branch)
+        for _ in range(10):
+            time.sleep(1)
+            run = _get_workflow_run_from_uid(workflow, uid, branch)
+            if run:
+                break
         if run:
             target_url = run.html_url
         else:

--- a/tests/test_live_linter.py
+++ b/tests/test_live_linter.py
@@ -5,6 +5,7 @@ import uuid
 import github
 
 import conda_forge_webservices
+from conda_forge_webservices.linting import _set_pr_status, _get_workflow_run_from_uid
 
 TEST_CASES = [
     (
@@ -103,6 +104,18 @@ def test_linter_pr(pytestconfig):
                 "container_tag": conda_forge_webservices.__version__.replace("+", "."),
                 "uid": uid,
             },
+        )
+        run = _get_workflow_run_from_uid(workflow, uid, branch)
+        if run:
+            target_url = run.html_url
+        else:
+            target_url = None
+        _set_pr_status(
+            "conda-forge",
+            "conda-forge-webservices",
+            pr.head.sha,
+            "pending",
+            target_url=target_url,
         )
 
     print("\nsleeping for four minutes to let the linter work...", flush=True)

--- a/tests/test_live_linter.py
+++ b/tests/test_live_linter.py
@@ -5,7 +5,8 @@ import uuid
 import github
 
 import conda_forge_webservices
-from conda_forge_webservices.linting import _set_pr_status, _get_workflow_run_from_uid
+from conda_forge_webservices.linting import _get_workflow_run_from_uid
+from conda_forge_webservices.github_actions_integration.linting import set_pr_status
 
 TEST_CASES = [
     (
@@ -110,13 +111,7 @@ def test_linter_pr(pytestconfig):
             target_url = run.html_url
         else:
             target_url = None
-        _set_pr_status(
-            "conda-forge",
-            "conda-forge-webservices",
-            pr.head.sha,
-            "pending",
-            target_url=target_url,
-        )
+        set_pr_status(repo, pr.head.sha, "pending", target_url=target_url)
 
     print("\nsleeping for four minutes to let the linter work...", flush=True)
     tot = 0


### PR DESCRIPTION
### Description

This PR sets the target url for the pending linter to see if we can get it to appear in the PR checks.

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
