### PR TITLE
Add emojis to visually distinguish between hints and lints

### DIFF
--- a/conda_forge_webservices/github_actions_integration/linting.py
+++ b/conda_forge_webservices/github_actions_integration/linting.py
@@ -135,14 +135,15 @@ def build_and_make_lint_comment(gh, repo, pr_id, lints, hints):
                 all_pass = False
                 messages.append(
                     "\nFor **{}**:\n\n{}".format(
-                        fname, "\n".join(f" * {lint}" for lint in _lints)
+                        fname, "\n".join(f" * ❌ {lint}" for lint in _lints)
                     )
                 )
             if _hints:
                 hints_found = True
                 messages.append(
                     "\nFor **{}**:\n\n{}".format(
-                        fname, "\n".join(f" * {hint}" for hint in _hints)
+                        fname,
+                        "\n".join(f" * ℹ️ {hint}" for hint in _hints),  # noqa: RUF001
                     )
                 )
 

--- a/conda_forge_webservices/linting.py
+++ b/conda_forge_webservices/linting.py
@@ -123,14 +123,15 @@ def lint_all_recipes(all_recipe_dir: Path, base_recipes: list[Path]) -> tuple[st
             all_pass = False
             messages.append(
                 "\nFor **{}**:\n\n{}".format(
-                    rel_path, "\n".join(f" * {lint}" for lint in lints)
+                    rel_path, "\n".join(f" * ❌ {lint}" for lint in lints)
                 )
             )
         if hints:
             hints_found = True
             messages.append(
                 "\nFor **{}**:\n\n{}".format(
-                    rel_path, "\n".join(f" * {hint}" for hint in hints)
+                    rel_path,
+                    "\n".join(f" * ℹ️ {hint}" for hint in hints),  # noqa: RUF001
                 )
             )
 


### PR DESCRIPTION
### Description

As I explain [here](https://github.com/conda-forge/conda-smithy/pull/2126#discussion_r1834476654) it can be really easy to miss the distinction between hints and linting errors. (The difference is indicated in a big block of boilerplate text.) Using :information_source: for hints and :x: for linter errors, I hope to make this easier to understand the severity at a glance.

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
