### PR TITLE
perf: remove init stage to run faster

### DIFF
--- a/.github/workflows/webservices-workflow-dispatch.yml
+++ b/.github/workflows/webservices-workflow-dispatch.yml
@@ -47,52 +47,9 @@ defaults:
 permissions: {}
 
 jobs:
-  init-task:
-    name: init-task
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-        with:
-          fetch-depth: 0
-          ref: ${{ github.ref }}
-
-      - name: setup conda
-        uses: mamba-org/setup-micromamba@617811f69075e3fd3ae68ca64220ad065877f246
-        with:
-          environment-file: conda-lock.yml
-          environment-name: webservices
-          condarc: |
-            show_channel_urls: true
-            channel_priority: strict
-            channels:
-              - conda-forge
-
-      - name: install code
-        run: |
-          pip install --no-deps --no-build-isolation -e .
-
-      - name: init task
-        run: |
-          git config --global user.name "conda-forge-webservices[bot]"
-          git config --global user.email "91080706+conda-forge-webservices[bot]@users.noreply.github.com"
-
-          export CF_FEEDSTOCK_OPS_CONTAINER_NAME=condaforge/webservices-dispatch-action
-          export CF_FEEDSTOCK_OPS_CONTAINER_TAG="${{ inputs.container_tag }}"
-
-          conda-forge-webservices-init-task \
-            --task=${{ inputs.task }} \
-            --repo=${{ inputs.repo }} \
-            --pr-number=${{ inputs.pr_number }} \
-            --sha=${{ inputs.sha }}
-        env:
-          GH_TOKEN: ${{ secrets.CF_ADMIN_GITHUB_TOKEN }}
-
   run-task:
     name: run-task
     runs-on: ubuntu-latest
-    needs:
-      - init-task
     steps:
       - name: checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/conda_forge_webservices/github_actions_integration/__main__.py
+++ b/conda_forge_webservices/github_actions_integration/__main__.py
@@ -52,34 +52,6 @@ def _pull_docker_image():
         print("::endgroup::", flush=True)
 
 
-@click.command(name="conda-forge-webservices-init-task")
-@click.option("--task", required=True, type=str)
-@click.option("--repo", required=True, type=str)
-@click.option("--pr-number", required=True, type=str)
-@click.option("--sha", required=False, type=str, default=None)
-def main_init_task(task, repo, pr_number, sha):
-    logging.basicConfig(level=logging.INFO)
-
-    action_desc = f"task `{task}` for conda-forge/{repo}#{pr_number}"
-    print(
-        f"::notice title=conda-forge-webservices job information::{action_desc}",
-        flush=True,
-    )
-
-    if task in ["rerender", "version_update"]:
-        pass
-    elif task == "lint":
-        _, gh = create_api_sessions()
-        gh_repo = gh.get_repo(f"conda-forge/{repo}")
-        target_url = (
-            f"https://github.com/conda-forge/conda-forge-webservices/"
-            f"actions/runs/{os.environ['GITHUB_RUN_ID']}"
-        )
-        set_pr_status(gh_repo, sha, "pending", target_url=target_url)
-    else:
-        raise ValueError(f"Task `{task}` is not valid!")
-
-
 @click.command(name="conda-forge-webservices-run-task")
 @click.option("--task", required=True, type=str)
 @click.option("--repo", required=True, type=str)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
 [project.scripts]
 update-webservices = "conda_forge_webservices.update_me:main"
 cache-status-data = "conda_forge_webservices.status_monitor:cache_status_data"
-conda-forge-webservices-init-task = "conda_forge_webservices.github_actions_integration.__main__:main_init_task"
 conda-forge-webservices-run-task = "conda_forge_webservices.github_actions_integration.__main__:main_run_task"
 conda-forge-webservices-finalize-task = "conda_forge_webservices.github_actions_integration.__main__:main_finalize_task"
 conda-forge-webservices-automerge = "conda_forge_webservices.github_actions_integration.__main__:main_automerge"


### PR DESCRIPTION
### Description

This PR removes the init stage in order to run the tasks faster. We can do this because we now set the linting status directly in the webserver.

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
