### PR TITLE
fix: do not automerge if rerendering is running

### DIFF
--- a/conda_forge_webservices/github_actions_integration/automerge.py
+++ b/conda_forge_webservices/github_actions_integration/automerge.py
@@ -293,10 +293,9 @@ def _all_statuses_and_checks_ok(status_states, check_states, req_checks_and_stat
         LOGGER.info("final status: name|state = %s|%s", req, final_states[req])
 
     if "conda-forge-rerendering-service" in status_states:
-        rerendering = not status_states["conda-forge-rerendering-service"]
-    else:
-        rerendering = False
-    final_states["rerendering done"] = not rerendering
+        final_states["rerender called"] = status_states[
+            "conda-forge-rerendering-service"
+        ]
 
     return all(v for v in final_states.values()), final_states
 

--- a/conda_forge_webservices/github_actions_integration/automerge.py
+++ b/conda_forge_webservices/github_actions_integration/automerge.py
@@ -169,7 +169,6 @@ def _get_github_statuses(repo, pr):
     oldest_time = None
     status_states = {}
     for status in statuses:
-        print(status.context, status.state)
         if oldest_time is None:
             if status.updated_at.tzinfo is None:
                 oldest_time = datetime.datetime.now() - datetime.timedelta(weeks=10000)
@@ -292,6 +291,12 @@ def _all_statuses_and_checks_ok(status_states, check_states, req_checks_and_stat
 
         final_states[req] = None if not found_state else state
         LOGGER.info("final status: name|state = %s|%s", req, final_states[req])
+
+    if "conda-forge-rerendering-service" in status_states:
+        rerendering = not status_states["conda-forge-rerendering-service"]
+    else:
+        rerendering = False
+    final_states["rerendering done"] = not rerendering
 
     return all(v for v in final_states.values()), final_states
 

--- a/conda_forge_webservices/github_actions_integration/automerge.py
+++ b/conda_forge_webservices/github_actions_integration/automerge.py
@@ -169,6 +169,7 @@ def _get_github_statuses(repo, pr):
     oldest_time = None
     status_states = {}
     for status in statuses:
+        print(status.context, status.state)
         if oldest_time is None:
             if status.updated_at.tzinfo is None:
                 oldest_time = datetime.datetime.now() - datetime.timedelta(weeks=10000)


### PR DESCRIPTION
### Description

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

This PR fixes the automerge job to not merge if rerendering is running.

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
