### PR TITLE
chore: update env for latest smithy to enable parser lints

### DIFF
--- a/.github/workflows/clean-and-update.yml
+++ b/.github/workflows/clean-and-update.yml
@@ -36,6 +36,8 @@ jobs:
             mamba
             conda-forge-tick
             conda-forge-feedstock-ops
+            conda-recipe-manager
+            conda-souschef
 
   clean-and-cache:
     name: clean-and-cache

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,9 @@ dependencies:
   - conda-forge-pinning
   - conda-forge-tick >=2024.9.26
   - conda-forge-feedstock-ops >=0.10.1  # pin to fix bug in rerenders
+  - conda-recipe-manager
   - conda-smithy >=3.34.1  # this pin is for jinja2 sandboxes
+  - conda-souschef
   - cryptography >=39
   - python-dateutil
   - git


### PR DESCRIPTION
### Description

This PR updates the env for the latest smithy to enable parser lints.
<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
