### PR TITLE
feat: handle autotick bot events

### DIFF
--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -128,8 +128,9 @@ def print_rate_limiting_info():
     d = [
         os.environ["GH_TOKEN"],
         get_app_token_for_webservices_only(),
-        os.environ["AUTOTICKBOT_GH_TOKEN"],
     ]
+    if "AUTOTICK_BOT_GH_TOKEN" in os.environ:
+        d.append(os.environ["AUTOTICK_BOT_GH_TOKEN"])
 
     LOGGER.info("")
     LOGGER.info("GitHub API Rate Limit Info:")
@@ -739,7 +740,7 @@ class OutputsCopyHandler(tornado.web.RequestHandler):
 
 
 def _dispatch_autotickbot_job(event, uid):
-    gh = github.Github(auth=github.Auth.Token(os.environ["AUTOTICKBOT_GH_TOKEN"]))
+    gh = github.Github(auth=github.Auth.Token(os.environ["AUTOTICK_BOT_GH_TOKEN"]))
     repo = gh.get_repo("regro/cf-scripts")
     wf = repo.get_workflow("bot-events.yml")
     running = wf.create_dispatch(

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -740,6 +740,14 @@ class OutputsCopyHandler(tornado.web.RequestHandler):
 
 
 def _dispatch_autotickbot_job(event, uid):
+    if "AUTOTICK_BOT_GH_TOKEN" not in os.environ:
+        LOGGER.info(
+            "    autotick bot job dispatch skipped: event|uid = %s|%s - no token",
+            event,
+            uid,
+        )
+        return
+
     gh = github.Github(auth=github.Auth.Token(os.environ["AUTOTICK_BOT_GH_TOKEN"]))
     repo = gh.get_repo("regro/cf-scripts")
     wf = repo.get_workflow("bot-events.yml")

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -125,7 +125,11 @@ def print_rate_limiting_info_for_token(token):
 
 
 def print_rate_limiting_info():
-    d = [os.environ["GH_TOKEN"], get_app_token_for_webservices_only()]
+    d = [
+        os.environ["GH_TOKEN"],
+        get_app_token_for_webservices_only(),
+        os.environ["AUTOTICKBOT_GH_TOKEN"],
+    ]
 
     LOGGER.info("")
     LOGGER.info("GitHub API Rate Limit Info:")
@@ -734,6 +738,103 @@ class OutputsCopyHandler(tornado.web.RequestHandler):
         # return
 
 
+def _dispatch_autotickbot_job(event, uid):
+    gh = github.Github(auth=github.Auth.Token(os.environ["AUTOTICKBOT_GH_TOKEN"]))
+    repo = gh.get_repo("regro/cf-scripts")
+    wf = repo.get_workflow("bot-events.yml")
+    running = wf.create_dispatch(
+        "main",
+        inputs={
+            "event": str(event),
+            "uid": str(uid),
+        },
+    )
+    LOGGER.info(
+        "    autotick bot job dispatched: event|uid|running = %s|%s|%s",
+        event,
+        uid,
+        running,
+    )
+
+
+class AutotickBotPayloadHookHandler(tornado.web.RequestHandler):
+    async def post(self):
+        headers = self.request.headers
+        event = headers.get("X-GitHub-Event", None)
+
+        if not valid_request(
+            self.request.body,
+            headers.get("X-Hub-Signature", ""),
+        ):
+            self.set_status(403)
+            self.write_error(403)
+            return
+
+        if event == "ping":
+            self.write("pong")
+            return
+
+        body = tornado.escape.json_decode(self.request.body)
+        if event == "pull_request":
+            head_owner = body["pull_request"]["head"]["repo"]["full_name"]
+
+            if (
+                body["repository"]["full_name"].endswith("-feedstock")
+                and (body["action"] in ["closed", "labeled"])
+                and head_owner.startswith("regro-cf-autotick-bot/")
+            ):
+                LOGGER.info("")
+                LOGGER.info("===================================================")
+                LOGGER.info(
+                    "autotick bot pull_request: %s", body["repository"]["full_name"]
+                )
+                LOGGER.info("===================================================")
+
+                await tornado.ioloop.IOLoop.current().run_in_executor(
+                    _worker_pool(),
+                    _dispatch_autotickbot_job,
+                    "pr",
+                    body["pull_request"]["id"],
+                )
+
+            return
+        elif event == "push":
+            LOGGER.info("")
+            LOGGER.info("===================================================")
+            LOGGER.info("autotick bot push: %s", body["repository"]["full_name"])
+            LOGGER.info("===================================================")
+
+            repo_name = body["repository"]["name"]
+            owner = body["repository"]["owner"]["login"]
+            ref = body["ref"]
+            commit_msg = (body.get("head_commit", None) or {}).get("message", "")
+
+            # Only do anything if we are working with conda-forge, and a
+            # push to main.
+            if (
+                # this weird thing happens with master to main branch changes maybe?
+                body["after"] != "0000000000000000000000000000000000000000"
+                and owner == "conda-forge"
+                and (ref == "refs/heads/master" or ref == "refs/heads/main")
+                and "[cf admin skip feedstocks]" not in commit_msg
+                and "[cf admin skip]" not in commit_msg
+                and repo_name.endswith("-feedstock")
+            ):
+                await tornado.ioloop.IOLoop.current().run_in_executor(
+                    _worker_pool(),
+                    _dispatch_autotickbot_job,
+                    "push",
+                    repo_name.split("-feedstock")[0],
+                )
+
+            return
+        else:
+            LOGGER.info(f'Unhandled event "{event}".')
+
+        self.set_status(404)
+        self.write_error(404)
+
+
 def _dispatch_automerge_job(repo, sha):
     gh = get_gh_client()
 
@@ -952,6 +1053,7 @@ def create_webapp():
             (r"/conda-webservice-update/versions", UpdateWebservicesVersionsHandler),
             (r"/feedstock-outputs/validate", OutputsValidationHandler),
             (r"/feedstock-outputs/copy", OutputsCopyHandler),
+            (r"/autotickbot/payload", AutotickBotPayloadHookHandler),
             (r"/status-monitor/payload", StatusMonitorPayloadHookHandler),
             (r"/status-monitor/azure", StatusMonitorAzureHandler),
             (r"/status-monitor/open-gpu-server", StatusMonitorOpenGPUServerHandler),


### PR DESCRIPTION
### Description

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->

This PR adds a handler for autotick bot events.

closes #289
