### PR TITLE
fix: parse out jinja2 when updating the team

### DIFF
--- a/conda_forge_webservices/tests/test_update_teams.py
+++ b/conda_forge_webservices/tests/test_update_teams.py
@@ -3,9 +3,11 @@ from conda_forge_webservices.update_teams import get_recipe_dummy_meta
 import pytest
 
 
-@pytest.mark.parametrize("recipe_content, res", [
-    (
-        """\
+@pytest.mark.parametrize(
+    "recipe_content, res",
+    [
+        (
+            """\
 {% set version = "0.1" %}
 
 blah: five
@@ -16,10 +18,10 @@ extra:
         - b
         - c
 """,
-        {"a", "b", "c"},
-    ),
-    (
-        """\
+            {"a", "b", "c"},
+        ),
+        (
+            """\
 {% set version = "0.1" %}
 
 extra:
@@ -28,10 +30,10 @@ extra:
         - a
         - b
 """,
-        {"a", "b"},
-    ),
-    (
-        """\
+            {"a", "b"},
+        ),
+        (
+            """\
 {% set version = "0.1" %}
 
 extra:
@@ -40,9 +42,10 @@ extra:
         - a
         - d
 """,
-        {"a", "d"},
-    )
-])
+            {"a", "d"},
+        ),
+    ],
+)
 def test_get_recipe_dummy_meta(recipe_content, res):
     meta = get_recipe_dummy_meta(recipe_content)
     assert set(meta.meta["extra"]["recipe-maintainers"]) == res

--- a/conda_forge_webservices/tests/test_update_teams.py
+++ b/conda_forge_webservices/tests/test_update_teams.py
@@ -1,0 +1,48 @@
+from conda_forge_webservices.update_teams import get_recipe_dummy_meta
+
+import pytest
+
+
+@pytest.mark.parametrize("recipe_content, res", [
+    (
+        """\
+{% set version = "0.1" %}
+
+blah: five
+
+extra:
+    recipe-maintainers:
+        - a
+        - b
+        - c
+""",
+        {"a", "b", "c"},
+    ),
+    (
+        """\
+{% set version = "0.1" %}
+
+extra:
+    feedstock-name: {{ name }}
+    recipe-maintainers:
+        - a
+        - b
+""",
+        {"a", "b"},
+    ),
+    (
+        """\
+{% set version = "0.1" %}
+
+extra:
+    feedstock-name: ${{ name }}
+    recipe-maintainers:
+        - a
+        - d
+""",
+        {"a", "d"},
+    )
+])
+def test_get_recipe_dummy_meta(recipe_content, res):
+    meta = get_recipe_dummy_meta(recipe_content)
+    assert set(meta.meta["extra"]["recipe-maintainers"]) == res


### PR DESCRIPTION
### Description

This PR parses out jinja2 when updating the team by pre-pending `$` to the variables to ensure valid yaml.

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
