### PR TITLE
fix: use machine user token to enable relock from branch

### DIFF
--- a/.github/workflows/clean-and-update.yml
+++ b/.github/workflows/clean-and-update.yml
@@ -13,18 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - name: generate token
-        id: generate_token
-        uses: actions/create-github-app-token@c1a285145b9d317df6ced56c09f525b5c2b6f755 # v1
-        with:
-          app-id: ${{ secrets.CF_CURATOR_APP_ID }}
-          private-key: ${{ secrets.CF_CURATOR_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
       - name: relock
         uses: beckermr/relock-conda@7dd1c7ebd71d3389ba3dad4864b9fb6c2208a1d9
         with:
-          github-token: ${{ steps.generate_token.outputs.token }}
+          github-token: ${{ secrets.CF_ADMIN_GITHUB_TOKEN }}
           automerge: true
           skip-if-pr-exists: true
           include-only-packages:
@@ -38,6 +30,8 @@ jobs:
             conda-forge-feedstock-ops
             conda-recipe-manager
             conda-souschef
+            rattler-build
+            rattler-build-conda-compat
 
   clean-and-cache:
     name: clean-and-cache


### PR DESCRIPTION
### Description

Hopefully this fixes relocking from a branch.

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
