### PR TITLE
fix: import was wrong?

### DIFF
--- a/conda_forge_webservices/github_actions_integration/version_updating.py
+++ b/conda_forge_webservices/github_actions_integration/version_updating.py
@@ -23,6 +23,7 @@ def update_version(
     import conda_forge_tick.update_recipe
     from conda_forge_tick.feedstock_parser import load_feedstock
     from conda_forge_tick.update_recipe.version import update_version_feedstock_dir
+    from conda_forge_tick.update_recipe import v1_recipe
     from conda_forge_tick.update_upstream_versions import (
         all_version_sources,
         get_latest_version,
@@ -106,7 +107,7 @@ def update_version(
             )
             meta_yaml_path.write_text(new_meta_yaml)
         elif recipe_yaml_path.exists():
-            conda_forge_tick.update_recipe.v1_recipe.update_build_number(
+            v1_recipe.update_build_number(
                 recipe_yaml_path,
                 0,
             )


### PR DESCRIPTION
I observed the following crash here: https://github.com/conda-forge/conda-forge-webservices/actions/runs/12832851160/job/35786520770


```
2025-01-17 16:20:41,736 ERROR    conda_forge_webservices.github_actions_integration.version_updating || error while updating the recipe!
Traceback (most recent call last):
  File "/home/runner/work/conda-forge-webservices/conda-forge-webservices/conda_forge_webservices/github_actions_integration/version_updating.py", line 109, in update_version
    conda_forge_tick.update_recipe.v1_recipe.update_build_number(
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'conda_forge_tick.update_recipe' has no attribute 'v1_recipe'
```