### PR TITLE
prod: update deps to avoid specific release

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -27,7 +27,7 @@ dependencies:
   - python =3.11.*
   - pytz
   - pyyaml
-  - rattler-build <0.35.0a0
+  - rattler-build !=0.35.*
   - requests
   - ruamel.yaml >=0.16
   - ruamel.yaml.jinja2

--- a/tests/test_live_linter.py
+++ b/tests/test_live_linter.py
@@ -112,7 +112,7 @@ def _make_empty_commit(pr_num):
             )
             subprocess.run(["gh", "pr", "checkout", f"{pr_num}"], check=True)
             subprocess.run(
-                ["git", "commit", "--allow-empty", "-m", "empty commit"], check=True
+                ["git", "commit", "--allow-empty", "-m", "[ci skip] empty commit"], check=True
             )
             subprocess.run(["git", "push"], check=True)
 

--- a/tests/test_live_linter.py
+++ b/tests/test_live_linter.py
@@ -112,7 +112,8 @@ def _make_empty_commit(pr_num):
             )
             subprocess.run(["gh", "pr", "checkout", f"{pr_num}"], check=True)
             subprocess.run(
-                ["git", "commit", "--allow-empty", "-m", "[ci skip] empty commit"], check=True
+                ["git", "commit", "--allow-empty", "-m", "[ci skip] empty commit"],
+                check=True,
             )
             subprocess.run(["git", "push"], check=True)
 


### PR DESCRIPTION
### Description

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

Trying to get tests running again.

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
