### PR TITLE
test: even more retries for tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -319,7 +319,7 @@ jobs:
           export CF_FEEDSTOCK_OPS_CONTAINER_TAG="${version}"
 
           cd tests
-          pytest -vvs --branch=${branch} test_live_linter.py
+          pytest -n 4 -vvs --branch=${branch} test_live_linter.py
         env:
           GH_TOKEN: ${{ secrets.CF_ADMIN_GITHUB_TOKEN }}
 

--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -3,7 +3,7 @@ metadata:
     - url: conda-forge
       used_env_vars: []
   content_hash:
-    linux-64: 8d7aff4081080845dff6e0bef67fb3ed7937c8f4d7c88c73fcad507b5e3d0c67
+    linux-64: 4477f9c4eb0ae4623adaa3c3d8ce7e123370cd3e6011d0035556c46778089835
   platforms:
     - linux-64
   sources:
@@ -1360,6 +1360,18 @@ package:
     url:
       https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
     version: 1.2.2
+  - category: main
+    dependencies:
+      python: '>=3.9'
+    hash:
+      md5: a71efeae2c160f6789900ba2631a2c90
+      sha256: 9abc6c128cd40733e9b24284d0462e084d4aff6afe614f0754aa8533ebe505e4
+    manager: conda
+    name: execnet
+    optional: false
+    platform: linux-64
+    url: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.1-pyhd8ed1ab_1.conda
+    version: 2.1.1
   - category: main
     dependencies:
       __glibc: '>=2.17,<3.0.a0'
@@ -4313,6 +4325,21 @@ package:
     platform: linux-64
     url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
     version: 8.3.4
+  - category: main
+    dependencies:
+      execnet: '>=2.1'
+      pytest: '>=7.0.0'
+      python: '>=3.9'
+    hash:
+      md5: 59aad4fb37cabc0bacc73cf344612ddd
+      sha256: fb35da93084d653b86918c200abb2f0b88aceb3b0526c6aaa21b844f565ae237
+    manager: conda
+    name: pytest-xdist
+    optional: false
+    platform: linux-64
+    url:
+      https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.6.1-pyhd8ed1ab_1.conda
+    version: 3.6.1
   - category: main
     dependencies:
       __glibc: '>=2.17,<3.0.a0'

--- a/environment.yml
+++ b/environment.yml
@@ -40,3 +40,4 @@ dependencies:
   # dev dependencies
   - flaky
   - pytest
+  - pytest-xdist

--- a/environment.yml
+++ b/environment.yml
@@ -38,4 +38,5 @@ dependencies:
   - tornado
   - tqdm
   # dev dependencies
-  - pytest <8.2.0
+  - flaky
+  - pytest

--- a/scripts/test_cfep13_copy.py
+++ b/scripts/test_cfep13_copy.py
@@ -32,6 +32,7 @@ from binstar_client import BinstarError
 import binstar_client.errors
 
 import pytest
+from flaky import flaky
 
 from conda_forge_webservices.utils import pushd, with_action_url
 from conda_forge_webservices.feedstock_outputs import (
@@ -244,6 +245,7 @@ def _dist_exists(ac, channel, dist):
 
 
 @pytest.mark.skipif(headers is None, reason="No feedstock token for testing!")
+@flaky
 def test_feedstock_outputs_copy_works():
     uid = uuid.uuid4().hex[0:6]
 

--- a/tests/test_live_automerge.py
+++ b/tests/test_live_automerge.py
@@ -6,6 +6,7 @@ import uuid
 
 import github
 from conda_forge_webservices.utils import pushd
+from flaky import flaky
 
 TEST_BASE_BRANCH = "automerge-live-test-base-branch"
 TEST_HEAD_BRANCH = f"automerge-live-test-head-branch-h{uuid.uuid4().hex[:6]}"
@@ -18,6 +19,7 @@ def _run_git_cmd(*args):
     subprocess.run(["git", *list(args)], check=True)
 
 
+@flaky
 def test_live_automerge(pytestconfig):
     branch = pytestconfig.getoption("branch")
 

--- a/tests/test_live_rerender.py
+++ b/tests/test_live_rerender.py
@@ -7,9 +7,10 @@ import uuid
 
 import conda_forge_webservices
 import github
+from flaky import flaky
+
 from conda_forge_webservices.utils import pushd, get_workflow_run_from_uid
 from conda_forge_webservices.commands import set_rerender_pr_status
-
 from conftest import _merge_main_to_branch
 
 WAIT_TIME = 600  # seconds
@@ -116,6 +117,7 @@ def _run_test(branch):
     print("tests passed!")
 
 
+@flaky
 def test_live_rerender(pytestconfig):
     branch = pytestconfig.getoption("branch")
 

--- a/tests/test_live_version_update.py
+++ b/tests/test_live_version_update.py
@@ -6,10 +6,11 @@ import uuid
 
 import github
 import requests
-from conftest import _merge_main_to_branch
+from flaky import flaky
 
 import conda_forge_webservices
 from conda_forge_webservices.utils import pushd
+from conftest import _merge_main_to_branch
 
 REPO_OWNER = "conda-forge"
 REPO_NAME = "cf-autotick-bot-test-package-feedstock"
@@ -239,11 +240,13 @@ def _run_test_try_finally(branch, version):
                     _set_pr_not_draft()
 
 
+@flaky
 def test_live_version_update_with_finding_version(pytestconfig):
     branch = pytestconfig.getoption("branch")
     _run_test_try_finally(branch, None)
 
 
+@flaky
 def test_live_version_update_with_input_version(pytestconfig):
     branch = pytestconfig.getoption("branch")
     _run_test_try_finally(branch, "0.14")


### PR DESCRIPTION
### Description

This PR adds even more retries for the tests.

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
