### PR TITLE
fix: use a random number to ensure cache is busted on heroku

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,8 @@ ENV PYTHONDONTWRITEBYTECODE=1
 
 # bust the docker cache so that we always rerun the installs below
 # ADD https://loripsum.net/api /opt/docker/etc/gibberish
-ADD https://worldtimeapi.org/api/timezone/Etc/UTC /opt/docker/etc/gibberish
+# ADD https://worldtimeapi.org/api/timezone/Etc/UTC /opt/docker/etc/gibberish
+ADD http://www.randomnumberapi.com/api/v1.0/randomnumber /opt/docker/etc/gibberish
 
 # Install conda
 COPY conda-lock.yml /

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ ENV PYTHONDONTWRITEBYTECODE=1
 # bust the docker cache so that we always rerun the installs below
 # ADD https://loripsum.net/api /opt/docker/etc/gibberish
 # ADD https://worldtimeapi.org/api/timezone/Etc/UTC /opt/docker/etc/gibberish
-ADD https://www.randomnumberapi.com/api/v1.0/randomnumber?min=1&max=10000000&count=100 /opt/docker/etc/gibberish
+ADD https://www.random.org/cgi-bin/randbyte?nbytes=4096&format=h /opt/docker/etc/gibberish
 
 # Install conda
 COPY conda-lock.yml /

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ ENV PYTHONDONTWRITEBYTECODE=1
 # bust the docker cache so that we always rerun the installs below
 # ADD https://loripsum.net/api /opt/docker/etc/gibberish
 # ADD https://worldtimeapi.org/api/timezone/Etc/UTC /opt/docker/etc/gibberish
-ADD http://www.randomnumberapi.com/api/v1.0/randomnumber /opt/docker/etc/gibberish
+ADD https://www.randomnumberapi.com/api/v1.0/randomnumber?min=1&max=100000&count=5 /opt/docker/etc/gibberish
 
 # Install conda
 COPY conda-lock.yml /

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ ENV PYTHONDONTWRITEBYTECODE=1
 # bust the docker cache so that we always rerun the installs below
 # ADD https://loripsum.net/api /opt/docker/etc/gibberish
 # ADD https://worldtimeapi.org/api/timezone/Etc/UTC /opt/docker/etc/gibberish
-ADD https://www.randomnumberapi.com/api/v1.0/randomnumber?min=1&max=100000&count=5 /opt/docker/etc/gibberish
+ADD https://www.randomnumberapi.com/api/v1.0/randomnumber?min=1&max=10000000&count=100 /opt/docker/etc/gibberish
 
 # Install conda
 COPY conda-lock.yml /

--- a/Dockerfile_wda
+++ b/Dockerfile_wda
@@ -6,7 +6,7 @@ USER root
 # make sure the install below is not cached by docker
 # ADD https://loripsum.net/api /opt/docker/etc/gibberish-to-bust-docker-image-cache
 # ADD https://worldtimeapi.org/api/timezone/Etc/UTC /opt/docker/etc/gibberish-to-bust-docker-image-cache
-ADD http://www.randomnumberapi.com/api/v1.0/randomnumber /opt/docker/etc/gibberish-to-bust-docker-image-cache
+ADD https://www.randomnumberapi.com/api/v1.0/randomnumber?min=1&max=100000&count=5 /opt/docker/etc/gibberish-to-bust-docker-image-cache
 
 COPY conda-lock.yml /tmp/conda-lock.yml
 

--- a/Dockerfile_wda
+++ b/Dockerfile_wda
@@ -6,7 +6,7 @@ USER root
 # make sure the install below is not cached by docker
 # ADD https://loripsum.net/api /opt/docker/etc/gibberish-to-bust-docker-image-cache
 # ADD https://worldtimeapi.org/api/timezone/Etc/UTC /opt/docker/etc/gibberish-to-bust-docker-image-cache
-ADD https://www.randomnumberapi.com/api/v1.0/randomnumber?min=1&max=10000000&count=100 /opt/docker/etc/gibberish-to-bust-docker-image-cache
+ADD https://www.random.org/cgi-bin/randbyte?nbytes=4096&format=h /opt/docker/etc/gibberish-to-bust-docker-image-cache
 
 COPY conda-lock.yml /tmp/conda-lock.yml
 

--- a/Dockerfile_wda
+++ b/Dockerfile_wda
@@ -6,7 +6,7 @@ USER root
 # make sure the install below is not cached by docker
 # ADD https://loripsum.net/api /opt/docker/etc/gibberish-to-bust-docker-image-cache
 # ADD https://worldtimeapi.org/api/timezone/Etc/UTC /opt/docker/etc/gibberish-to-bust-docker-image-cache
-ADD https://www.randomnumberapi.com/api/v1.0/randomnumber?min=1&max=100000&count=5 /opt/docker/etc/gibberish-to-bust-docker-image-cache
+ADD https://www.randomnumberapi.com/api/v1.0/randomnumber?min=1&max=10000000&count=100 /opt/docker/etc/gibberish-to-bust-docker-image-cache
 
 COPY conda-lock.yml /tmp/conda-lock.yml
 

--- a/Dockerfile_wda
+++ b/Dockerfile_wda
@@ -5,7 +5,8 @@ USER root
 
 # make sure the install below is not cached by docker
 # ADD https://loripsum.net/api /opt/docker/etc/gibberish-to-bust-docker-image-cache
-ADD https://worldtimeapi.org/api/timezone/Etc/UTC /opt/docker/etc/gibberish-to-bust-docker-image-cache
+# ADD https://worldtimeapi.org/api/timezone/Etc/UTC /opt/docker/etc/gibberish-to-bust-docker-image-cache
+ADD http://www.randomnumberapi.com/api/v1.0/randomnumber /opt/docker/etc/gibberish-to-bust-docker-image-cache
 
 COPY conda-lock.yml /tmp/conda-lock.yml
 


### PR DESCRIPTION
### Description

cc @jaimergp 

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
