### PR TITLE
Add check of conda-forge status page for outages

### DIFF
--- a/conda_forge_webservices/feedstock_outputs.py
+++ b/conda_forge_webservices/feedstock_outputs.py
@@ -450,6 +450,7 @@ Below we have put some information about the failure to help you debug it.
 
 Common ways to fix this problem include:
 
+- First check the [conda-forge status page](https://conda-forge.org/status/) for any infrastructure outages.
 - Retry the package build and upload by pushing an empty commit to the feedstock.
 - Rerender the feedstock in a PR from a fork of the feedstock and merge.
 - Request a feedstock token reset via our [admin-requests repo](https://github.com/conda-forge/admin-requests?tab=readme-ov-file#reset-your-feedstock-token).


### PR DESCRIPTION
### Description

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

* Add conda-forge status page check as first item on the failed package validation output. The status page https://conda-forge.org/status/ will note any infrastructure outages, which might block uploads.
   - c.f. https://github.com/conda-forge/admin-requests/pull/1473#issuecomment-2770421641
   - c.f. https://github.com/conda-forge/wiscopy-feedstock/issues/2

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
