### PR TITLE
fix: emit log items in one call

### DIFF
--- a/conda_forge_webservices/tokens.py
+++ b/conda_forge_webservices/tokens.py
@@ -77,10 +77,11 @@ def get_app_token_for_webservices_only():
 
         APP_TOKEN = token
     else:
-        log_title_and_message_at_level(
-            level="info",
-            title=f"app token exists - timeout {(APP_TOKEN_RESET_TIME - now) / 60}m",
-        )
+        pass
+        # log_title_and_message_at_level(
+        #     level="info",
+        #     title=f"app token exists - timeout {(APP_TOKEN_RESET_TIME - now) / 60}m",
+        # )
 
     assert APP_TOKEN is not None, "app token is None!"
 

--- a/conda_forge_webservices/tokens.py
+++ b/conda_forge_webservices/tokens.py
@@ -17,6 +17,8 @@ from github import (
 )
 from github.InstallationAuthorization import InstallationAuthorization
 
+from conda_forge_webservices.utils import log_title_and_message_at_level
+
 LOGGER = logging.getLogger("conda_forge_webservices.tokens")
 
 FEEDSTOCK_TOKEN_RESET_TIMES: dict[str, Any] = {}
@@ -62,26 +64,23 @@ def get_app_token_for_webservices_only():
                     auth=Auth.Token(token)
                 ).rate_limiting_resettime
             except Exception:
-                LOGGER.info("")
-                LOGGER.info("===================================================")
-                LOGGER.info("app token did not generate proper reset time")
-                LOGGER.info("===================================================")
+                log_title_and_message_at_level(
+                    level="info",
+                    title="app token did not generate proper reset time",
+                )
                 token = None
         else:
-            LOGGER.info("")
-            LOGGER.info("===================================================")
-            LOGGER.info("app token could not be made")
-            LOGGER.info("===================================================")
+            log_title_and_message_at_level(
+                level="info",
+                title="app token could not be made",
+            )
 
         APP_TOKEN = token
     else:
-        LOGGER.info("")
-        LOGGER.info("===================================================")
-        LOGGER.info(
-            "app token exists - timeout %sm",
-            (APP_TOKEN_RESET_TIME - now) / 60,
+        log_title_and_message_at_level(
+            level="info",
+            title=f"app token exists - timeout {(APP_TOKEN_RESET_TIME - now) / 60}m",
         )
-        LOGGER.info("===================================================")
 
     assert APP_TOKEN is not None, "app token is None!"
 
@@ -241,22 +240,19 @@ def _inject_app_token_into_feedstock(full_name, repo=None, readonly=False):
                 reset_times_dict[repo_name] = Github(
                     auth=Auth.Token(token)
                 ).rate_limiting_resettime
-                LOGGER.info("")
-                LOGGER.info("===================================================")
-                LOGGER.info(
-                    "injected app token for repo %s - timeout %sm",
-                    repo_name,
-                    (reset_times_dict[repo_name] - now) / 60,
+                log_title_and_message_at_level(
+                    level="info",
+                    title=(
+                        f"injected app token for repo {repo_name} - "
+                        f"timeout {(reset_times_dict[repo_name] - now) / 60}m"
+                    ),
                 )
-                LOGGER.info("===================================================")
                 worked = True
             except Exception:
-                LOGGER.info("")
-                LOGGER.info("===================================================")
-                LOGGER.info(
-                    "app token could not be pushed to secrets for %s", repo_name
+                log_title_and_message_at_level(
+                    level="info",
+                    title=f"app token could not be pushed to secrets for {repo_name}",
                 )
-                LOGGER.info("===================================================")
                 worked = False
 
             return worked
@@ -267,14 +263,13 @@ def _inject_app_token_into_feedstock(full_name, repo=None, readonly=False):
             LOGGER.info("===================================================")
             return False
     else:
-        LOGGER.info("")
-        LOGGER.info("===================================================")
-        LOGGER.info(
-            "app token exists for repo %s - timeout %sm",
-            repo_name,
-            (reset_times_dict[repo_name] - now) / 60,
+        log_title_and_message_at_level(
+            level="info",
+            title=(
+                f"app token exists for repo {repo_name} "
+                f"- timeout {(reset_times_dict[repo_name] - now) / 60}m"
+            ),
         )
-        LOGGER.info("===================================================")
         return True
 
 

--- a/conda_forge_webservices/utils.py
+++ b/conda_forge_webservices/utils.py
@@ -1,4 +1,5 @@
 import os
+import logging
 import shutil
 import time
 import tempfile
@@ -7,6 +8,7 @@ from contextlib import contextmanager
 import github
 
 ALLOWED_CMD_NON_FEEDSTOCKS = ["staged-recipes", "admin-requests"]
+LOGGER = logging.getLogger("conda_forge_webservices")
 
 
 @contextmanager
@@ -82,3 +84,14 @@ def _test_and_raise_besides_file_not_exists(e: github.GithubException):
     if e.status == 404 and "No object found" in e.data["message"]:
         return
     raise e
+
+
+def log_title_and_message_at_level(*, level, title, msg=None):
+    func = getattr(LOGGER, level)
+    total_msg = f"""
+===================================================
+{title}
+==================================================="""
+    if msg is not None:
+        total_msg += f"\n{msg}"
+    func(total_msg)

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -744,7 +744,7 @@ class OutputsCopyHandler(WriteErrorAsJSONRequestHandler):
             log_title_and_message_at_level(
                 level="warning",
                 title=f"invalid outputs copy request for feedstock '{feedstock}'",
-                msg=f"""    feedstock exists: {feedstock_exists}"
+                msg=f"""    feedstock exists: {feedstock_exists}
     outputs: {outputs}
     label: {label}
     valid token: {valid_token}

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -98,7 +98,18 @@ def get_commit_message(full_name, commit):
     )
 
 
-def print_rate_limiting_info_for_token(token):
+def _log_title_and_message_at_level(*, level, title, msg=None):
+    func = getattr(LOGGER, level)
+    total_msg = f"""
+===================================================
+{title}
+==================================================="""
+    if msg is not None:
+        total_msg += f"\n{msg}"
+    func(total_msg)
+
+
+def _get_rate_limiting_info_for_token(token):
     # Compute some info about our GitHub API Rate Limit.
     # Note that it doesn't count against our limit to
     # get this info. So, we should be doing this regularly
@@ -120,9 +131,8 @@ def print_rate_limiting_info_for_token(token):
     gh_api_reset_time = gh.get_rate_limit().core.reset
     gh_api_reset_time -= datetime.now(timezone.utc)
     msg = f"{user} - remaining {gh_api_remaining} out of {gh_api_total}."
-    LOGGER.info(
-        "github api requests: %s - %s", msg, f"Will reset in {gh_api_reset_time}."
-    )
+    msg = f"github api requests: {msg} - Will reset in {gh_api_reset_time}."
+    return msg
 
 
 def print_rate_limiting_info():
@@ -133,11 +143,15 @@ def print_rate_limiting_info():
     if "AUTOTICK_BOT_GH_TOKEN" in os.environ:
         d.append(os.environ["AUTOTICK_BOT_GH_TOKEN"])
 
-    LOGGER.info("")
-    LOGGER.info("GitHub API Rate Limit Info:")
+    msg = []
     for k in d:
-        print_rate_limiting_info_for_token(k)
-    LOGGER.info("")
+        msg.append(_get_rate_limiting_info_for_token(k))
+    msg = "\n".join(msg)
+    _log_title_and_message_at_level(
+        level="info",
+        title="GitHub API Rate Limit Info",
+        msg=msg,
+    )
 
 
 def valid_request(body, signature):
@@ -153,6 +167,44 @@ def valid_request(body, signature):
 
 
 class WriteErrorAsJSONRequestHandler(tornado.web.RequestHandler):
+    """The write_error method below was pulled from jupyter under
+    the license below.
+
+    https://github.com/jupyter-server/jupyter_server/blob/132cf044cc969fb70063666919b4d9ad3349c5d1/jupyter_server/base/handlers.py#L756-L776
+
+    BSD 3-Clause License
+
+    - Copyright (c) 2001-2015, IPython Development Team
+    - Copyright (c) 2015-, Jupyter Development Team
+
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+    3. Neither the name of the copyright holder nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+    """
+
     def write_error(self, status_code: int, **kwargs) -> None:
         """APIHandler errors are JSON, not human pages"""
         self.set_header("Content-Type", "application/json")
@@ -217,10 +269,10 @@ class LintingHookHandler(WriteErrorAsJSONRequestHandler):
             # Only do anything if we are working with conda-forge,
             # and an open PR.
             if is_open and owner == "conda-forge" and not stale:
-                LOGGER.info("")
-                LOGGER.info("===================================================")
-                LOGGER.info("linting: %s", body["repository"]["full_name"])
-                LOGGER.info("===================================================")
+                _log_title_and_message_at_level(
+                    level="info",
+                    title=f"linting: {body['repository']['full_name']}",
+                )
 
                 if linting.LINT_VIA_GHA:
                     linting.lint_via_github_actions(
@@ -291,10 +343,10 @@ class UpdateFeedstockHookHandler(WriteErrorAsJSONRequestHandler):
                 and "[cf admin skip]" not in commit_msg
                 and repo_name.endswith("-feedstock")
             ):
-                LOGGER.info("")
-                LOGGER.info("===================================================")
-                LOGGER.info("feedstocks service: %s", body["repository"]["full_name"])
-                LOGGER.info("===================================================")
+                _log_title_and_message_at_level(
+                    level="info",
+                    title=f"feedstocks service: {body['repository']['full_name']}",
+                )
                 handled = await tornado.ioloop.IOLoop.current().run_in_executor(
                     _worker_pool(),
                     feedstocks_service.handle_feedstock_event,
@@ -344,10 +396,10 @@ class UpdateTeamHookHandler(WriteErrorAsJSONRequestHandler):
                 and "[cf admin skip teams]" not in commit_msg
                 and "[cf admin skip]" not in commit_msg
             ):
-                LOGGER.info("")
-                LOGGER.info("===================================================")
-                LOGGER.info("updating team: %s", body["repository"]["full_name"])
-                LOGGER.info("===================================================")
+                _log_title_and_message_at_level(
+                    level="info",
+                    title=f"update teams: {body['repository']['full_name']}",
+                )
                 await tornado.ioloop.IOLoop.current().run_in_executor(
                     _thread_pool(),  # always threads due to expensive lru_cache
                     update_teams.update_team,
@@ -421,10 +473,10 @@ class CommandHookHandler(WriteErrorAsJSONRequestHandler):
                 review_id = body["comment"]["id"]
 
             if comment:
-                LOGGER.info("")
-                LOGGER.info("===================================================")
-                LOGGER.info("PR command: %s", body["repository"]["full_name"])
-                LOGGER.info("===================================================")
+                _log_title_and_message_at_level(
+                    level="info",
+                    title=f"PR command: {body['repository']['full_name']}",
+                )
 
                 await tornado.ioloop.IOLoop.current().run_in_executor(
                     _worker_pool(),
@@ -463,10 +515,10 @@ class CommandHookHandler(WriteErrorAsJSONRequestHandler):
             if pull_request and action != "deleted":
                 comment = body["comment"]["body"]
                 comment_id = body["comment"]["id"]
-                LOGGER.info("")
-                LOGGER.info("===================================================")
-                LOGGER.info("PR command: %s", body["repository"]["full_name"])
-                LOGGER.info("===================================================")
+                _log_title_and_message_at_level(
+                    level="info",
+                    title=f"PR command: {body['repository']['full_name']}",
+                )
 
                 await tornado.ioloop.IOLoop.current().run_in_executor(
                     _worker_pool(),
@@ -494,10 +546,10 @@ class CommandHookHandler(WriteErrorAsJSONRequestHandler):
                     comment = body["issue"]["body"]
                     comment_id = -1  # will react to issue/PR description #issue_num
 
-                LOGGER.info("")
-                LOGGER.info("===================================================")
-                LOGGER.info("issue command: %s", body["repository"]["full_name"])
-                LOGGER.info("===================================================")
+                _log_title_and_message_at_level(
+                    level="info",
+                    title=f"issue command: {body['repository']['full_name']}",
+                )
 
                 await tornado.ioloop.IOLoop.current().run_in_executor(
                     _worker_pool(),
@@ -666,10 +718,10 @@ class OutputsCopyHandler(WriteErrorAsJSONRequestHandler):
         #     self.set_status(403)
         #     self.write_error(403)
 
-        LOGGER.info("")
-        LOGGER.info("===================================================")
-        LOGGER.info(f"copy outputs for feedstock '{feedstock}'")
-        LOGGER.info("===================================================")
+        _log_title_and_message_at_level(
+            level="info",
+            title=f"copy started for outputs for feedstock '{feedstock}'",
+        )
 
         if feedstock is not None and len(feedstock) > 0:
             feedstock_exists = _repo_exists(feedstock)
@@ -697,14 +749,17 @@ class OutputsCopyHandler(WriteErrorAsJSONRequestHandler):
             or (not valid_token)
             or hash_type not in ["md5", "sha256"]
         ):
-            LOGGER.warning(f"    invalid outputs copy request for {feedstock}!")
-            LOGGER.warning(f"    feedstock exists: {feedstock_exists}")
-            LOGGER.warning(f"    outputs: {outputs}")
-            LOGGER.warning(f"    label: {label}")
-            LOGGER.warning(f"    valid token: {valid_token}")
-            LOGGER.warning(f"    hash type: {hash_type}")
-            LOGGER.warning(f"    provider: {provider}")
-
+            _log_title_and_message_at_level(
+                level="warning",
+                title=f"invalid outputs copy request for feedstock '{feedstock}'",
+                msg=f"""    feedstock exists: {feedstock_exists}"
+    outputs: {outputs}
+    label: {label}
+    valid token: {valid_token}
+    hash type: {hash_type}
+    provider: {provider}
+""",
+            )
             err_msgs = []
             if outputs is None:
                 err_msgs.append("no outputs data sent for copy")
@@ -743,10 +798,16 @@ class OutputsCopyHandler(WriteErrorAsJSONRequestHandler):
 
             self.write(json.dumps({"errors": errors, "valid": valid, "copied": copied}))
 
-            LOGGER.info("    errors: %s", errors)
-            LOGGER.info("    valid: %s", valid)
-            LOGGER.info("    copied: %s", copied)
-            LOGGER.info(f"    provider: {provider}")
+            _log_title_and_message_at_level(
+                level="info",
+                title=f"copy finished for outputs for feedstock '{feedstock}'",
+                msg=f"""    feedstock exists: {feedstock_exists}
+    errors: {errors}
+    valid: {valid}
+    copied: {copied}
+    provider: {provider}
+""",
+            )
 
         print_rate_limiting_info()
 
@@ -844,12 +905,10 @@ class AutotickBotPayloadHookHandler(WriteErrorAsJSONRequestHandler):
                 and (body["action"] in ["closed", "labeled"])
                 and head_owner.startswith("regro-cf-autotick-bot/")
             ):
-                LOGGER.info("")
-                LOGGER.info("===================================================")
-                LOGGER.info(
-                    "autotick bot pull_request: %s", body["repository"]["full_name"]
+                _log_title_and_message_at_level(
+                    level="info",
+                    title=f"autotick bot PR: {body['repository']['full_name']}",
                 )
-                LOGGER.info("===================================================")
 
                 await tornado.ioloop.IOLoop.current().run_in_executor(
                     _worker_pool(),
@@ -860,10 +919,10 @@ class AutotickBotPayloadHookHandler(WriteErrorAsJSONRequestHandler):
 
             return
         elif event == "push":
-            LOGGER.info("")
-            LOGGER.info("===================================================")
-            LOGGER.info("autotick bot push: %s", body["repository"]["full_name"])
-            LOGGER.info("===================================================")
+            _log_title_and_message_at_level(
+                level="info",
+                title=f"autotick bot push: {body['repository']['full_name']}",
+            )
 
             repo_name = body["repository"]["name"]
             owner = body["repository"]["owner"]["login"]
@@ -959,10 +1018,10 @@ class StatusMonitorPayloadHookHandler(WriteErrorAsJSONRequestHandler):
 
         body = tornado.escape.json_decode(self.request.body)
         if event == "check_run":
-            LOGGER.info("")
-            LOGGER.info("===================================================")
-            LOGGER.info("check run: %s", body["repository"]["full_name"])
-            LOGGER.info("===================================================")
+            _log_title_and_message_at_level(
+                level="info",
+                title=f"check run: {body['repository']['full_name']}",
+            )
             inject_app_token_into_feedstock(body["repository"]["full_name"])
             inject_app_token_into_feedstock_readonly(body["repository"]["full_name"])
             async with STATUS_DATA_LOCK:
@@ -973,10 +1032,10 @@ class StatusMonitorPayloadHookHandler(WriteErrorAsJSONRequestHandler):
             inject_app_token_into_feedstock(body["repository"]["full_name"])
             inject_app_token_into_feedstock_readonly(body["repository"]["full_name"])
 
-            LOGGER.info("")
-            LOGGER.info("===================================================")
-            LOGGER.info("check suite: %s", body["repository"]["full_name"])
-            LOGGER.info("===================================================")
+            _log_title_and_message_at_level(
+                level="info",
+                title=f"check suite: {body['repository']['full_name']}",
+            )
 
             if body["action"] == "completed" and body["repository"][
                 "full_name"
@@ -990,10 +1049,10 @@ class StatusMonitorPayloadHookHandler(WriteErrorAsJSONRequestHandler):
 
             return
         elif event == "status":
-            LOGGER.info("")
-            LOGGER.info("===================================================")
-            LOGGER.info("status: %s", body["repository"]["full_name"])
-            LOGGER.info("===================================================")
+            _log_title_and_message_at_level(
+                level="info",
+                title=f"status: {body['repository']['full_name']}",
+            )
             inject_app_token_into_feedstock(body["repository"]["full_name"])
             inject_app_token_into_feedstock_readonly(body["repository"]["full_name"])
             async with STATUS_DATA_LOCK:
@@ -1009,12 +1068,13 @@ class StatusMonitorPayloadHookHandler(WriteErrorAsJSONRequestHandler):
 
             return
         elif event in ["pull_request", "pull_request_review"]:
-            LOGGER.info("")
-            LOGGER.info("===================================================")
-            LOGGER.info(
-                "pull request/pull request review: %s", body["repository"]["full_name"]
+            _log_title_and_message_at_level(
+                level="info",
+                title=(
+                    "pull request/pull request review: "
+                    f"{body['repository']['full_name']}"
+                ),
             )
-            LOGGER.info("===================================================")
 
             if body["repository"]["full_name"].endswith("-feedstock"):
                 await tornado.ioloop.IOLoop.current().run_in_executor(
@@ -1085,10 +1145,11 @@ class UpdateTeamsEndpointHandler(WriteErrorAsJSONRequestHandler):
             feedstock = data.get("feedstock", None)
 
             if feedstock is not None:
-                LOGGER.info("")
-                LOGGER.info("===================================================")
-                LOGGER.info("updating team endpoint: %s", f"conda-forge/{feedstock}")
-                LOGGER.info("===================================================")
+                _log_title_and_message_at_level(
+                    level="info",
+                    title=f"update teams endpoint: conda-forge/{feedstock}",
+                )
+
                 await tornado.ioloop.IOLoop.current().run_in_executor(
                     _thread_pool(),  # always threads due to expensive lru_cache
                     update_teams.update_team,
@@ -1130,10 +1191,10 @@ def create_webapp():
 
 async def _cache_data():
     if "CF_WEBSERVICES_TEST" not in os.environ:
-        LOGGER.info("")
-        LOGGER.info("===================================================")
-        LOGGER.info("caching status data")
-        LOGGER.info("===================================================")
+        _log_title_and_message_at_level(
+            level="info",
+            title="caching status data",
+        )
         async with STATUS_DATA_LOCK:
             await tornado.ioloop.IOLoop.current().run_in_executor(
                 _thread_pool(),


### PR DESCRIPTION
### Description

This should help clean out the overlapping log items and make things more legible.

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
