### PR TITLE
Branch comment return

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -142,7 +142,6 @@ jobs:
     runs-on: "ubuntu-latest"
     needs:
       - tests
-      - docker-build
     concurrency:
       group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests-upload' || format('{0}-{1}', github.workflow, github.ref) }}
     steps:

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -215,7 +215,14 @@ def pr_detailed_comment(
 
                         Have a great day!
                         """)  # noqa
-                pull.create_issue_comment(message)
+                try:
+                    pull.create_issue_comment(message)
+                except github.GithubException:
+                    LOGGER.info(
+                        "PR from branch warning failure for "
+                        "repo {pull.head.repo.full_name}",
+                    )
+                return
 
     if RESTART_CI.search(comment):
         gh = get_gh_client()


### PR DESCRIPTION
### Description

Trying to figure out what is happening here.

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
