### PR TITLE
fix: do final relabel in lock to cleanup properly

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -142,7 +142,6 @@ jobs:
     runs-on: "ubuntu-latest"
     needs:
       - tests
-      - docker-build
     concurrency:
       group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests-upload' || format('{0}-{1}', github.workflow, github.ref) }}
     steps:

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -220,7 +220,7 @@ def pr_detailed_comment(
                 except github.GithubException:
                     LOGGER.info(
                         "PR from branch warning failure for "
-                        "repo {pull.head.repo.full_name}",
+                        f"repo {pull.head.repo.full_name}",
                     )
                 return
 

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -205,7 +205,10 @@ def pr_detailed_comment(
         repo = gh.get_repo(f"{org_name}/{repo_name}")
         pull = repo.get_pull(int(pr_num))
         if pull.head.repo.full_name.split("/")[0] == "conda-forge":
-            if "upload_on_branch" not in _get_conda_forge_yml(org_name, repo_name):
+            if (
+                "upload_on_branch" not in _get_conda_forge_yml(org_name, repo_name)
+                and repo_name != "cf-autotick-bot-test-package-feedstock"
+            ):
                 message = textwrap.dedent("""
                         Hi! This is the friendly automated conda-forge-webservice.
 
@@ -218,7 +221,7 @@ def pr_detailed_comment(
                 try:
                     pull.create_issue_comment(message)
                 except github.GithubException:
-                    LOGGER.info(
+                    LOGGER.warning(
                         "PR from branch warning failure for "
                         f"repo {pull.head.repo.full_name}",
                     )

--- a/conda_forge_webservices/feedstock_outputs.py
+++ b/conda_forge_webservices/feedstock_outputs.py
@@ -670,6 +670,7 @@ def validate_feedstock_outputs(
     outputs,
     hash_type,
     dest_label,
+    # staging_label,
 ):
     """Validate feedstock outputs on the staging channel.
 
@@ -686,6 +687,8 @@ def validate_feedstock_outputs(
     dest_label : str
         The destination label for the packages. The packages must also have
         this label on the staging channel `cf-staging`.
+    # staging_label : str
+    #     The label to use for the staging dists to the prod channel.
 
     Returns
     -------
@@ -696,6 +699,15 @@ def validate_feedstock_outputs(
         A list of any errors encountered.
     """
     valid = dict.fromkeys(outputs, False)
+
+    # if dest_label == staging_label:
+    #     LOGGER.critical(
+    #         "    destination label must be different "
+    #         "from staging label: dest=%s staging=%s",
+    #         dest_label,
+    #         staging_label,
+    #     )
+    #     return valid, ["destination label must be different from staging label"]
 
     errors = []
 

--- a/conda_forge_webservices/feedstock_outputs.py
+++ b/conda_forge_webservices/feedstock_outputs.py
@@ -994,9 +994,12 @@ class KeyedLock:
                 if not lock.locked():
                     del self._locks[key]
 
-    def __enter__(self, key):
-        self.acquire(key)
+    def __call__(self, key):
         self._local_data.key = key
+        return self
+
+    def __enter__(self):
+        self.acquire(self._local_data.key)
         return self
 
     def __exit__(self, *args):

--- a/conda_forge_webservices/feedstock_outputs.py
+++ b/conda_forge_webservices/feedstock_outputs.py
@@ -22,7 +22,6 @@ from conda_forge_metadata.feedstock_outputs import (
     feedstock_outputs_config,
 )
 from conda_forge_metadata.feedstock_outputs import sharded_path as _get_sharded_path
-import binstar_client.errors
 
 from .utils import parse_conda_pkg, _test_and_raise_besides_file_not_exists
 from conda_forge_webservices.tokens import (
@@ -104,7 +103,7 @@ def _dist_exists(ac, channel, dist):
             basename=urllib.parse.quote(dist, safe=""),
         )
         return True
-    except binstar_client.errors.NotFound:
+    except BinstarError:
         return False
 
 
@@ -128,7 +127,7 @@ def _dist_has_label(ac, channel, dist, label):
         ).get("labels", ())
 
         return label in labels
-    except binstar_client.errors.NotFound as e:
+    except BinstarError as e:
         LOGGER.critical(
             "    could not get dist info for label check: %s",
             dist,
@@ -317,7 +316,7 @@ def _dist_has_label_exclusively(ac, channel, dist, label):
                 label,
             )
             return False
-    except binstar_client.errors.NotFound as e:
+    except BinstarError as e:
         LOGGER.critical(
             "    could not get dist info for label check: %s",
             dist,
@@ -354,7 +353,7 @@ def _dist_has_only_staging_labels(ac, channel, dist):
                 labels,
             )
             return False
-    except binstar_client.errors.NotFound as e:
+    except BinstarError as e:
         LOGGER.critical(
             "    could not get dist info for label check: %s",
             dist,

--- a/conda_forge_webservices/feedstock_outputs.py
+++ b/conda_forge_webservices/feedstock_outputs.py
@@ -841,9 +841,6 @@ def stage_dist_to_prod_for_relabeling(
     copied = copied[dist]
     if not copied:
         yield False
-
-        # attempt to delete from staging
-        _remove_dist(_get_ac_api_staging(), STAGING, dist)
     else:
         valid_hashes_prod = _is_valid_output_hash(
             outputs_to_test, hash_type, PROD, staging_label

--- a/conda_forge_webservices/feedstock_outputs.py
+++ b/conda_forge_webservices/feedstock_outputs.py
@@ -3,7 +3,6 @@ This module registers and validates feedstock outputs.
 """
 
 import contextlib
-import threading
 import os
 import json
 import hmac
@@ -970,38 +969,3 @@ community [channel](https://conda-forge.zulipchat.com/#narrow/channel/457337-gen
         if issue.state == "closed":
             issue.edit(state="open")
         issue.create_comment(message)
-
-
-class KeyedLock:
-    _lock = threading.Lock()
-    _local_data = threading.local()
-
-    def __init__(self):
-        self._locks = {}
-
-    def acquire(self, key):
-        with self._lock:
-            if key not in self._locks:
-                self._locks[key] = threading.Lock()
-            lock = self._locks[key]
-        lock.acquire()
-
-    def release(self, key):
-        with self._lock:
-            if key in self._locks:
-                lock = self._locks[key]
-                lock.release()
-                if not lock.locked():
-                    del self._locks[key]
-
-    def __call__(self, key):
-        self._local_data.key = key
-        return self
-
-    def __enter__(self):
-        self.acquire(self._local_data.key)
-        return self
-
-    def __exit__(self, *args):
-        self.release(self._local_data.key)
-        self._local_data.key = None

--- a/conda_forge_webservices/feedstock_outputs.py
+++ b/conda_forge_webservices/feedstock_outputs.py
@@ -772,7 +772,10 @@ def validate_feedstock_outputs(
     )
     for o in outputs_to_test:
         if not valid_hashes_staging[o]:
-            errors.append(f"output {o} does not have a valid checksum on {STAGING}")
+            errors.append(
+                f"output {o} does not have a valid checksum or "
+                f"correct label on {STAGING}"
+            )
     outputs_to_test = {
         o: v for o, v in outputs_to_test.items() if valid_hashes_staging[o]
     }

--- a/conda_forge_webservices/feedstock_outputs.py
+++ b/conda_forge_webservices/feedstock_outputs.py
@@ -2,6 +2,8 @@
 This module registers and validates feedstock outputs.
 """
 
+import contextlib
+import threading
 import os
 import json
 import hmac
@@ -324,6 +326,30 @@ def _dist_has_label_exclusively(ac, channel, dist, label):
         return False
 
 
+def _remove_dist(ac, channel, dist):
+    try:
+        _, name, version, _ = parse_conda_pkg(dist)
+    except RuntimeError as e:
+        LOGGER.critical(
+            "    could not parse dist for removing: %s",
+            dist,
+            exc_info=e,
+        )
+        return False
+
+    try:
+        ac.remove_dist(
+            channel,
+            name,
+            version,
+            basename=urllib.parse.quote(dist, safe=""),
+        )
+        LOGGER.info("    removed from %s: %s", channel, dist)
+    except BinstarError as e:
+        LOGGER.info("    could not remove from %s: %s", channel, dist, exc_info=e)
+        pass
+
+
 def _copy_feedstock_outputs_from_staging_to_prod(
     outputs, src_label, dest_label, delete=True
 ):
@@ -356,16 +382,6 @@ def _copy_feedstock_outputs_from_staging_to_prod(
 
     for dist in outputs:
         try:
-            _, name, version, _ = parse_conda_pkg(dist)
-        except RuntimeError as e:
-            LOGGER.critical(
-                "    could not parse dist for copy: %s",
-                dist,
-                exc_info=e,
-            )
-            continue
-
-        try:
             copied[dist] = _copy_dist_if_not_exists(
                 STAGING,
                 src_label,
@@ -381,19 +397,7 @@ def _copy_feedstock_outputs_from_staging_to_prod(
             pass
 
         if copied[dist] and _dist_exists(ac_staging, STAGING, dist) and delete:
-            try:
-                ac_staging.remove_dist(
-                    STAGING,
-                    name,
-                    version,
-                    basename=urllib.parse.quote(dist, safe=""),
-                )
-                LOGGER.info("    removed from %s: %s", STAGING, dist)
-            except BinstarError as e:
-                LOGGER.info(
-                    "    could not remove from %s: %s", STAGING, dist, exc_info=e
-                )
-                pass
+            _remove_dist(ac_staging, STAGING, dist)
 
     return copied
 
@@ -666,7 +670,6 @@ def validate_feedstock_outputs(
     outputs,
     hash_type,
     dest_label,
-    staging_label,
 ):
     """Validate feedstock outputs on the staging channel.
 
@@ -683,8 +686,6 @@ def validate_feedstock_outputs(
     dest_label : str
         The destination label for the packages. The packages must also have
         this label on the staging channel `cf-staging`.
-    staging_label : str
-        The label to use for the staging dists to the prod channel.
 
     Returns
     -------
@@ -695,15 +696,6 @@ def validate_feedstock_outputs(
         A list of any errors encountered.
     """
     valid = dict.fromkeys(outputs, False)
-
-    if dest_label == staging_label:
-        LOGGER.critical(
-            "    destination label must be different "
-            "from staging label: dest=%s staging=%s",
-            dest_label,
-            staging_label,
-        )
-        return valid, ["destination label must be different from staging label"]
 
     errors = []
 
@@ -748,27 +740,28 @@ def validate_feedstock_outputs(
     for o in outputs_to_test:
         if not valid_outputs[o]:
             errors.append(f"output {o} not allowed for conda-forge/{project}")
-    outputs_to_test = {o: v for o, v in outputs_to_test.items() if valid_outputs[o]}
+    # outputs_to_test = {o: v for o, v in outputs_to_test.items() if valid_outputs[o]}
 
-    # next copy outputs to the production channel under the staging label
-    # again do not pass any invalid outputs to the rest of the functions
-    copied = _copy_feedstock_outputs_from_staging_to_prod(
-        outputs_to_test, dest_label, staging_label, delete=True
-    )
-    for o in outputs_to_test:
-        if not copied[o]:
-            errors.append(
-                f"output {o} did not copy to {PROD} under staging label {staging_label}"
-            )
-    outputs_to_test = {o: v for o, v in outputs_to_test.items() if copied[o]}
+    # # next copy outputs to the production channel under the staging label
+    # # again do not pass any invalid outputs to the rest of the functions
+    # copied = _copy_feedstock_outputs_from_staging_to_prod(
+    #     outputs_to_test, dest_label, staging_label, delete=True
+    # )
+    # for o in outputs_to_test:
+    #     if not copied[o]:
+    #         errors.append(
+    #             f"output {o} did not copy to {PROD} under "
+    #             f"staging label {staging_label}"
+    #         )
+    # outputs_to_test = {o: v for o, v in outputs_to_test.items() if copied[o]}
 
-    # finally validate the hashes on the production channel
-    valid_hashes_prod = _is_valid_output_hash(
-        outputs_to_test, hash_type, PROD, staging_label
-    )
-    for o in outputs_to_test:
-        if not valid_hashes_prod[o]:
-            errors.append(f"output {o} does not have a valid checksum on {PROD}")
+    # # finally validate the hashes on the production channel
+    # valid_hashes_prod = _is_valid_output_hash(
+    #     outputs_to_test, hash_type, PROD, staging_label
+    # )
+    # for o in outputs_to_test:
+    #     if not valid_hashes_prod[o]:
+    #         errors.append(f"output {o} does not have a valid checksum on {PROD}")
 
     # combine all validations
     for o in outputs:
@@ -776,14 +769,41 @@ def validate_feedstock_outputs(
             correctly_formatted.get(o)
             and valid_outputs.get(o)
             and valid_hashes_staging.get(o)
-            and copied.get(o)
-            and valid_hashes_prod.get(o)
+            # and copied.get(o)
+            # and valid_hashes_prod.get(o)
         ):
             valid[o] = True
         else:
             valid[o] = False
 
     return valid, errors
+
+
+@contextlib.contextmanager
+def stage_dist_to_prod_for_relabeling(
+    dist, dest_label, staging_label, hash_type, hash_value
+):
+    outputs_to_test = {dist: hash_value}
+    copied = _copy_feedstock_outputs_from_staging_to_prod(
+        outputs_to_test, dest_label, staging_label, delete=True
+    )
+    copied = copied[dist]
+    if not copied:
+        yield False
+
+        # attempt to delete from staging
+        _remove_dist(_get_ac_api_staging(), STAGING, dist)
+    else:
+        valid_hashes_prod = _is_valid_output_hash(
+            outputs_to_test, hash_type, PROD, staging_label
+        )
+        valid_hashes_prod = valid_hashes_prod[dist]
+        yield valid_hashes_prod
+
+        # attempt to delete from prod if not relabeled
+        ac_prod = _get_ac_api_prod()
+        if _dist_has_label_exclusively(ac_prod, PROD, dist, staging_label):
+            _remove_dist(ac_prod, PROD, dist)
 
 
 def comment_on_outputs_copy(feedstock, git_sha, errors, valid, copied):
@@ -900,3 +920,35 @@ community [channel](https://conda-forge.zulipchat.com/#narrow/channel/457337-gen
         if issue.state == "closed":
             issue.edit(state="open")
         issue.create_comment(message)
+
+
+class KeyedLock:
+    _lock = threading.Lock()
+    _local_data = threading.local()
+
+    def __init__(self):
+        self._locks = {}
+
+    def acquire(self, key):
+        with self._lock:
+            if key not in self._locks:
+                self._locks[key] = threading.Lock()
+            lock = self._locks[key]
+        lock.acquire()
+
+    def release(self, key):
+        with self._lock:
+            if key in self._locks:
+                lock = self._locks[key]
+                lock.release()
+                if not lock.locked():
+                    del self._locks[key]
+
+    def __enter__(self, key):
+        self.acquire(key)
+        self._local_data.key = key
+        return self
+
+    def __exit__(self, *args):
+        self.release(self._local_data.key)
+        self._local_data.key = None

--- a/conda_forge_webservices/tests/test_feedstock_outputs.py
+++ b/conda_forge_webservices/tests/test_feedstock_outputs.py
@@ -193,11 +193,11 @@ def test_validate_feedstock_outputs_badoutputhash(
     else:
         valid_staging_hash_a_err = (
             "output noarch/a-0.1-py_0.conda does not "
-            "have a valid checksum on cf-staging"
+            "have a valid checksum or correct label on cf-staging"
         ) in errs
         valid_staging_hash_b_err = (
             "output noarch/b-0.1-py_0.conda does not "
-            "have a valid checksum on cf-staging"
+            "have a valid checksum or correct label on cf-staging"
         ) in errs
         assert valid_staging_hash_a_err is not valid_staging_hash
         assert valid_staging_hash_b_err is valid_staging_hash
@@ -228,11 +228,11 @@ def test_validate_feedstock_outputs_badoutputhash(
 
         # valid_prod_hash_a_err = (
         #     "output noarch/a-0.1-py_0.conda does not "
-        #     "have a valid checksum on conda-forge"
+        #     "have a valid checksum or correct label on conda-forge"
         # ) in errs
         # valid_prod_hash_b_err = (
         #     "output noarch/b-0.1-py_0.conda does not "
-        #     "have a valid checksum on conda-forge"
+        #     "have a valid checksum or correct label on conda-forge"
         # ) in errs
         # if valid_output and valid_staging_hash and valid_copy:
         #     assert valid_prod_hash_a_err is not valid_prod_hash

--- a/conda_forge_webservices/tests/test_feedstock_outputs.py
+++ b/conda_forge_webservices/tests/test_feedstock_outputs.py
@@ -120,11 +120,11 @@ def test_copy_feedstock_outputs_from_staging_to_prod_not_exists(
             ac_staging.return_value.remove_dist.assert_not_called()
 
 
-@pytest.mark.parametrize("same_label", [True, False])
+@pytest.mark.parametrize("same_label", [False])  # add True if change func back
 @pytest.mark.parametrize("valid_output", [True, False])
-@pytest.mark.parametrize("valid_copy", [True, False])
+@pytest.mark.parametrize("valid_copy", [True])  # add False if change func back
 @pytest.mark.parametrize("valid_staging_hash", [True, False])
-@pytest.mark.parametrize("valid_prod_hash", [True, False])
+@pytest.mark.parametrize("valid_prod_hash", [True])  # add False if change func back
 @mock.patch(
     "conda_forge_webservices.feedstock_outputs._copy_feedstock_outputs_from_staging_to_prod"
 )
@@ -151,12 +151,14 @@ def test_validate_feedstock_outputs_badoutputhash(
         },
         {
             "noarch/a-0.1-py_0.conda": valid_prod_hash,
-            "noarch/b-0.1-py_0.conda": not valid_prod_hash,
+            # change to not valid_prod_hash if change func back
+            "noarch/b-0.1-py_0.conda": valid_prod_hash,
         },
     ]
     copy_fo.return_value = {
         "noarch/a-0.1-py_0.conda": valid_copy,
-        "noarch/b-0.1-py_0.conda": not valid_copy,
+        # change to not valid_copy if change func back
+        "noarch/b-0.1-py_0.conda": valid_copy,
     }
     staging_label = "cf-staging-do-not-use-h" + uuid.uuid4().hex
     valid, errs = validate_feedstock_outputs(
@@ -166,8 +168,9 @@ def test_validate_feedstock_outputs_badoutputhash(
             "noarch/b-0.1-py_0.conda": "safdsa",
         },
         "md5",
-        "main",
-        staging_label if not same_label else "main",
+        staging_label,
+        # "main",
+        # staging_label if not same_label else "main",
     )
 
     assert valid == {
@@ -178,8 +181,10 @@ def test_validate_feedstock_outputs_badoutputhash(
         and (not same_label),
         "noarch/b-0.1-py_0.conda": (not valid_output)
         and (not valid_staging_hash)
-        and (not valid_copy)
-        and (not valid_prod_hash)
+        # change to not valid_copy if change func back
+        and (valid_copy)
+        # change to not valid_prod_hash if change func back
+        and (valid_prod_hash)
         and (not same_label),
     }
 
@@ -208,31 +213,31 @@ def test_validate_feedstock_outputs_badoutputhash(
         if not valid_staging_hash:
             assert valid_output_b_err is valid_output
 
-        valid_copy_a_err = (
-            "output noarch/a-0.1-py_0.conda did not copy to "
-            f"conda-forge under staging label {staging_label}"
-        ) in errs
-        valid_copy_b_err = (
-            "output noarch/b-0.1-py_0.conda did not copy to "
-            f"conda-forge under staging label {staging_label}"
-        ) in errs
-        if valid_output and valid_staging_hash:
-            assert valid_copy_a_err is not valid_copy
-        if (not valid_output) and (not valid_staging_hash):
-            assert valid_copy_b_err is valid_copy
+        # valid_copy_a_err = (
+        #     "output noarch/a-0.1-py_0.conda did not copy to "
+        #     f"conda-forge under staging label {staging_label}"
+        # ) in errs
+        # valid_copy_b_err = (
+        #     "output noarch/b-0.1-py_0.conda did not copy to "
+        #     f"conda-forge under staging label {staging_label}"
+        # ) in errs
+        # if valid_output and valid_staging_hash:
+        #     assert valid_copy_a_err is not valid_copy
+        # if (not valid_output) and (not valid_staging_hash):
+        #     assert valid_copy_b_err is valid_copy
 
-        valid_prod_hash_a_err = (
-            "output noarch/a-0.1-py_0.conda does not "
-            "have a valid checksum on conda-forge"
-        ) in errs
-        valid_prod_hash_b_err = (
-            "output noarch/b-0.1-py_0.conda does not "
-            "have a valid checksum on conda-forge"
-        ) in errs
-        if valid_output and valid_staging_hash and valid_copy:
-            assert valid_prod_hash_a_err is not valid_prod_hash
-        if (not valid_output) and (not valid_staging_hash) and (not valid_copy):
-            assert valid_prod_hash_b_err is valid_prod_hash
+        # valid_prod_hash_a_err = (
+        #     "output noarch/a-0.1-py_0.conda does not "
+        #     "have a valid checksum on conda-forge"
+        # ) in errs
+        # valid_prod_hash_b_err = (
+        #     "output noarch/b-0.1-py_0.conda does not "
+        #     "have a valid checksum on conda-forge"
+        # ) in errs
+        # if valid_output and valid_staging_hash and valid_copy:
+        #     assert valid_prod_hash_a_err is not valid_prod_hash
+        # if (not valid_output) and (not valid_staging_hash) and (not valid_copy):
+        #     assert valid_prod_hash_b_err is valid_prod_hash
 
 
 @pytest.mark.skipif(

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -1,4 +1,5 @@
 import os
+import threading
 import subprocess
 import asyncio
 import tornado.escape
@@ -34,7 +35,6 @@ from conda_forge_webservices.feedstock_outputs import (
     comment_on_outputs_copy,
     relabel_feedstock_outputs,
     stage_dist_to_prod_for_relabeling,
-    KeyedLock,
     STAGING_LABEL,
 )
 from conda_forge_webservices.utils import (
@@ -636,7 +636,7 @@ def _dist_exists_on_prod_with_label_and_hash(dist, dest_label, hash_type, hash_v
         return False
 
 
-COPYLOCK = KeyedLock()
+COPYLOCK = threading.Lock()
 
 
 def _do_copy(

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -691,11 +691,7 @@ def _do_copy(
         ):
             copied[o] = True
             valid[o] = True
-            errors = [
-                err
-                for err in errors
-                if o not in err
-            ]
+            errors = [err for err in errors if o not in err]
         else:
             copied[o] = False
 

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -35,6 +35,7 @@ from conda_forge_webservices.feedstock_outputs import (
     relabel_feedstock_outputs,
     stage_dist_to_prod_for_relabeling,
     KeyedLock,
+    STAGING_LABEL,
 )
 from conda_forge_webservices.utils import (
     ALLOWED_CMD_NON_FEEDSTOCKS,
@@ -784,7 +785,7 @@ class OutputsCopyHandler(WriteErrorAsJSONRequestHandler):
             self.set_status(403)
             self.write_error(403)
         else:
-            staging_label = "cf-staging-do-not-use-h" + uuid.uuid4().hex
+            staging_label = STAGING_LABEL + "-h" + uuid.uuid4().hex
             (
                 valid,
                 errors,

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -690,6 +690,12 @@ def _do_copy(
             o, dest_label, hash_type, hash_value
         ):
             copied[o] = True
+            valid[o] = True
+            errors = [
+                err
+                for err in errors
+                if o not in err
+            ]
         else:
             copied[o] = False
 

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -657,7 +657,7 @@ def _do_copy(
     copied = {}
     if outputs_to_copy:
         for dist, hash_value in outputs_to_copy.items():
-            with COPYLOCK(dist):
+            with COPYLOCK:
                 with stage_dist_to_prod_for_relabeling(
                     dist, dest_label, staging_label, hash_type, hash_value
                 ) as staged:

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -33,6 +33,8 @@ from conda_forge_webservices.feedstock_outputs import (
     is_valid_feedstock_token,
     comment_on_outputs_copy,
     relabel_feedstock_outputs,
+    stage_dist_to_prod_for_relabeling,
+    KeyedLock,
 )
 from conda_forge_webservices.utils import (
     ALLOWED_CMD_NON_FEEDSTOCKS,
@@ -79,7 +81,7 @@ THREAD_POOL = None
 def _thread_pool():
     global THREAD_POOL
     if THREAD_POOL is None:
-        THREAD_POOL = ThreadPoolExecutor(max_workers=2)
+        THREAD_POOL = ThreadPoolExecutor(max_workers=4)
     return THREAD_POOL
 
 
@@ -633,6 +635,9 @@ def _dist_exists_on_prod_with_label_and_hash(dist, dest_label, hash_type, hash_v
         return False
 
 
+COPYLOCK = KeyedLock()
+
+
 def _do_copy(
     feedstock, outputs, dest_label, git_sha, comment_on_error, hash_type, staging_label
 ):
@@ -641,7 +646,6 @@ def _do_copy(
         outputs,
         hash_type,
         dest_label,
-        staging_label,
     )
 
     outputs_to_copy = {}
@@ -649,15 +653,27 @@ def _do_copy(
         if valid[o]:
             outputs_to_copy[o] = outputs[o]
 
+    copied = {}
     if outputs_to_copy:
-        copied = relabel_feedstock_outputs(
-            outputs_to_copy,
-            staging_label,
-            dest_label,
-            remove_src_label=True,
-        )
-    else:
-        copied = {}
+        for dist, hash_value in outputs_to_copy.items():
+            with COPYLOCK(dist):
+                with stage_dist_to_prod_for_relabeling(
+                    dist, dest_label, staging_label, hash_type, hash_value
+                ) as staged:
+                    if staged:
+                        dist_copied = relabel_feedstock_outputs(
+                            {dist: hash_value},
+                            staging_label,
+                            dest_label,
+                            remove_src_label=True,
+                        )
+                        copied.update(dist_copied)
+                    else:
+                        valid[dist] = False
+                        errors.append(
+                            f"failed to stage {dist} to "
+                            f"conda-forge/label/{staging_label} for copying"
+                        )
 
     for o in outputs:
         if o not in copied:
@@ -774,7 +790,7 @@ class OutputsCopyHandler(WriteErrorAsJSONRequestHandler):
                 errors,
                 copied,
             ) = await tornado.ioloop.IOLoop.current().run_in_executor(
-                _worker_pool(),
+                _thread_pool(),
                 _do_copy,
                 feedstock,
                 outputs,


### PR DESCRIPTION
### Description

This PR does the final relabeling step for output copies in a lock so we can clean up failed copies properly.

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
