### PR TITLE
perf: see if heroku can tolerate more workers

### DIFF
--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -84,14 +84,14 @@ def _worker_pool(kind):
                 # needed for mocks in testing
                 COPYLOCK = threading.Lock()
                 UPLOAD_POOL = ThreadPoolExecutor(
-                    max_workers=2,
+                    max_workers=4,
                     initializer=_init_upload_pool_processes,
                     initargs=(COPYLOCK,),
                 )
             else:
                 COPYLOCK = multiprocessing.Lock()
                 UPLOAD_POOL = ProcessPoolExecutor(
-                    max_workers=2,
+                    max_workers=4,
                     initializer=_init_upload_pool_processes,
                     initargs=(COPYLOCK,),
                 )


### PR DESCRIPTION
### Description

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

The workers should mostly block on i/o so more processes might be OK. We could also try to switch to threads with non-block HHTP calls, but that is a lot more work.

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
