### PR TITLE
perf: reduce memory usage again

### DIFF
--- a/conda_forge_webservices/feedstock_outputs.py
+++ b/conda_forge_webservices/feedstock_outputs.py
@@ -76,10 +76,10 @@ def is_valid_feedstock_token(user, project, feedstock_token, provider=None):
     return False
 
 
-def _get_ac_api_with_timeout(token, timeout=10):
+def _get_ac_api_with_timeout(token):
     # see https://stackoverflow.com/a/59317604/1745538
     ac = get_server_api(token=token)
-    ac.session.request = functools.partial(ac.session.request, timeout=timeout)
+    ac.session.request = functools.partial(ac.session.request, timeout=120)
     return ac
 
 

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -70,15 +70,15 @@ def _worker_pool(kind):
     global UPLOAD_POOL
     global COPYLOCK
 
-    if kind == "command":
-        if COMMAND_POOL is None:
-            if "PYTEST_CURRENT_TEST" in os.environ:
-                # needed for mocks in testing
-                COMMAND_POOL = ThreadPoolExecutor(max_workers=2)
-            else:
-                COMMAND_POOL = ProcessPoolExecutor(max_workers=2)
-        return COMMAND_POOL
-    elif kind == "upload":
+    # if kind == "command":
+    #     if COMMAND_POOL is None:
+    #         if "PYTEST_CURRENT_TEST" in os.environ:
+    #             # needed for mocks in testing
+    #             COMMAND_POOL = ThreadPoolExecutor(max_workers=2)
+    #         else:
+    #             COMMAND_POOL = ProcessPoolExecutor(max_workers=2)
+    #     return COMMAND_POOL
+    if kind == "upload" or kind == "command":
         if UPLOAD_POOL is None:
             if "PYTEST_CURRENT_TEST" in os.environ:
                 # needed for mocks in testing


### PR DESCRIPTION
### Description

I am still seeing some out of memory issues.

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
