### PR TITLE
fix: do not remove from staging until copy done

### DIFF
--- a/conda_forge_webservices/feedstock_outputs.py
+++ b/conda_forge_webservices/feedstock_outputs.py
@@ -892,7 +892,7 @@ def stage_dist_to_prestage_and_possibly_copy_to_prod(
             else:
                 errors.append(
                     f"output {dist} does not have a valid checksum "
-                    f"and staging label on {PROD}"
+                    f"and staging label on {PRE_STAGING}"
                 )
         else:
             errors.append(f"output {dist} did not copy to {PRE_STAGING}")

--- a/conda_forge_webservices/feedstock_outputs.py
+++ b/conda_forge_webservices/feedstock_outputs.py
@@ -864,7 +864,7 @@ def stage_dist_to_prestage_and_possibly_copy_to_prod(
             dest_ac=ac_pre_staging,
             dest_channel=PRE_STAGING,
             dest_label=dest_label,
-            delete=True,
+            delete=False,
             update_metadata=True,
             replace_metadata=False,
         )[dist]
@@ -899,6 +899,10 @@ def stage_dist_to_prestage_and_possibly_copy_to_prod(
     finally:
         # always remove the dist from pre-staging
         _remove_dist(ac_pre_staging, PRE_STAGING, dist, force=True)
+
+        # if we copied the dist to prod, remove it from staging
+        if copied:
+            _remove_dist(ac_staging, STAGING, dist, force=True)
 
     return pre_copied and copied, errors
 


### PR DESCRIPTION
### Description

This PR ensures that the dist is not removed from the staging channel until the copy works. It ensures that the feedstock CI job trying to copy still sees that the dist exists on staging and so will wait before trying the copy again. This matches the how the copies used to work without the extra staging step.

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
