### PR TITLE
fix: pre- to post-staging, remove old code, refactor upload test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -193,7 +193,7 @@ jobs:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
           PROD_BINSTAR_TOKEN: ${{ secrets.PROD_BINSTAR_TOKEN }}
           STAGING_BINSTAR_TOKEN: ${{ secrets.HEROKU_ONLY_STAGING_BINSTAR_TOKEN }}
-          PRE_STAGING_BINSTAR_TOKEN: ${{ secrets.PRE_STAGING_BINSTAR_TOKEN }}
+          POST_STAGING_BINSTAR_TOKEN: ${{ secrets.POST_STAGING_BINSTAR_TOKEN }}
           CF_WEBSERVICES_TOKEN: ${{ secrets.CF_WEBSERVICES_TOKEN }}
           CF_WEBSERVICES_APP_ID: ${{ secrets.CF_CURATOR_APP_ID }}
           CF_WEBSERVICES_PRIVATE_KEY: ${{ secrets.CF_CURATOR_PRIVATE_KEY }}

--- a/conda_forge_webservices/feedstock_outputs.py
+++ b/conda_forge_webservices/feedstock_outputs.py
@@ -326,7 +326,7 @@ def _is_valid_output_hash(outputs, hash_type, channel, label):
         The hash key to look for. One of sha256 or md5.
     channel : str
         The channel to check the hashes on. Should be one of
-        `cf-staging` or `conda-forge`.
+        `cf-staging`, `cf-post-staging`, or `conda-forge`.
     label : str
         The label for the packages to validate. The packages must have this label and
         only this labvel to be considered valid.
@@ -637,6 +637,28 @@ def validate_feedstock_outputs(
 def stage_dist_to_post_staging_and_possibly_copy_to_prod(
     dist, dest_label, hash_type, hash_value
 ):
+    """Copy the dist to `cf-post-staging`, check hash again, then copy to `conda-forge`
+    if the hash is valid.
+
+    Parameters
+    ----------
+    dist : str
+        The name of the dist to copy. This should be the full name with the
+        platform directory, version/build info, and file extension
+        (e.g., `noarch/blah-fa31b0-2020.04.13.15.54.07-py_0.conda`).
+    dest_label : str
+        The destination label for the package. The package must also have
+        this label on the staging channel `cf-staging`.
+    hash_type : str
+        The hash key to look for. One of "sha256" or "md5".
+    hash_value : str
+        The hash value to check.
+
+    Returns
+    -------
+    copied : bool
+        True if the dist was copied to `conda-forge` and False otherwise.
+    """
     ac_staging = _get_ac_api_staging()
     ac_post_staging = _get_ac_api_post_staging()
     ac_prod = _get_ac_api_prod()

--- a/conda_forge_webservices/tests/conftest.py
+++ b/conda_forge_webservices/tests/conftest.py
@@ -12,6 +12,7 @@ TOKENS = [
     "GH_TOKEN",
     "PROD_BINSTAR_TOKEN",
     "STAGING_BINSTAR_TOKEN",
+    "POST_STAGING_BINSTAR_TOKEN",
 ]
 MISSING_TOKENS = any(token not in os.environ for token in TOKENS)
 

--- a/conda_forge_webservices/tests/test_feedstock_outputs.py
+++ b/conda_forge_webservices/tests/test_feedstock_outputs.py
@@ -16,9 +16,7 @@ from conda_forge_webservices.feedstock_outputs import (
     _get_ac_api_prod,
     _get_dist,
     _is_valid_feedstock_output,
-    relabel_feedstock_outputs,
     validate_feedstock_outputs,
-    PROD,
 )
 
 
@@ -393,55 +391,3 @@ def test_is_valid_feedstock_output(
         assert afs_mock.called_once_with(project.replace("-feedstock", ""), "glob")
     else:
         afs_mock.assert_not_called()
-
-
-@pytest.mark.parametrize("error", [True, False])
-@pytest.mark.parametrize("remove_src_label", [True, False])
-@mock.patch("conda_forge_webservices.feedstock_outputs._get_ac_api_prod")
-def test_relabel_feedstock_outputs(
-    ac_prod,
-    remove_src_label,
-    error,
-):
-    if error:
-        ac_prod.return_value.copy.side_effect = BinstarError("error in add")
-
-    outputs = ["noarch/boo-0.1-py_10.conda"]
-
-    ac_prod.return_value.distribution.return_value = {"labels": ["foo"]}
-
-    relabeled = relabel_feedstock_outputs(
-        outputs,
-        "foo",
-        "bar",
-        remove_src_label=remove_src_label,
-    )
-
-    assert relabeled == {"noarch/boo-0.1-py_10.conda": not error}
-
-    ac_prod.assert_called_once()
-
-    ac_prod.return_value.copy.assert_called_once()
-    ac_prod.return_value.copy.assert_any_call(
-        PROD,
-        "boo",
-        "0.1",
-        basename=urllib.parse.quote("noarch/boo-0.1-py_10.conda", safe=""),
-        to_owner=PROD,
-        from_label="foo",
-        to_label="bar",
-        update=False,
-        replace=True,
-    )
-
-    if remove_src_label and not error:
-        ac_prod.return_value.remove_channel.assert_called_once()
-        ac_prod.return_value.remove_channel.assert_any_call(
-            "foo",
-            "conda-forge",
-            package="boo",
-            version="0.1",
-            filename=urllib.parse.quote("noarch/boo-0.1-py_10.conda", safe=""),
-        )
-    else:
-        ac_prod.return_value.remove_channel.assert_not_called()

--- a/conda_forge_webservices/tests/test_feedstock_outputs.py
+++ b/conda_forge_webservices/tests/test_feedstock_outputs.py
@@ -125,11 +125,10 @@ def test_copy_feedstock_outputs_from_staging_to_prod_not_exists(
             ac_staging.return_value.remove_dist.assert_not_called()
 
 
-@pytest.mark.parametrize("same_label", [False])  # add True if change func back
 @pytest.mark.parametrize("valid_output", [True, False])
-@pytest.mark.parametrize("valid_copy", [True])  # add False if change func back
+@pytest.mark.parametrize("valid_copy", [True])
 @pytest.mark.parametrize("valid_staging_hash", [True, False])
-@pytest.mark.parametrize("valid_prod_hash", [True])  # add False if change func back
+@pytest.mark.parametrize("valid_prod_hash", [True])
 @mock.patch(
     "conda_forge_webservices.feedstock_outputs._copy_feedstock_outputs_from_staging_to_prod"
 )
@@ -143,7 +142,6 @@ def test_validate_feedstock_outputs_badoutputhash(
     valid_staging_hash,
     valid_copy,
     valid_prod_hash,
-    same_label,
 ):
     valid_out.return_value = {
         "noarch/a-0.1-py_0.conda": valid_output,
@@ -156,13 +154,11 @@ def test_validate_feedstock_outputs_badoutputhash(
         },
         {
             "noarch/a-0.1-py_0.conda": valid_prod_hash,
-            # change to not valid_prod_hash if change func back
             "noarch/b-0.1-py_0.conda": valid_prod_hash,
         },
     ]
     copy_fo.return_value = {
         "noarch/a-0.1-py_0.conda": valid_copy,
-        # change to not valid_copy if change func back
         "noarch/b-0.1-py_0.conda": valid_copy,
     }
     staging_label = "cf-staging-do-not-use-h" + uuid.uuid4().hex
@@ -174,75 +170,40 @@ def test_validate_feedstock_outputs_badoutputhash(
         },
         "md5",
         staging_label,
-        # "main",
-        # staging_label if not same_label else "main",
     )
 
     assert valid == {
         "noarch/a-0.1-py_0.conda": valid_output
         and valid_staging_hash
         and valid_copy
-        and valid_prod_hash
-        and (not same_label),
+        and valid_prod_hash,
         "noarch/b-0.1-py_0.conda": (not valid_output)
         and (not valid_staging_hash)
-        # change to not valid_copy if change func back
         and (valid_copy)
-        # change to not valid_prod_hash if change func back
-        and (valid_prod_hash)
-        and (not same_label),
+        and (valid_prod_hash),
     }
 
-    if same_label:
-        assert errs == ["destination label must be different from staging label"]
-    else:
-        valid_staging_hash_a_err = (
-            "output noarch/a-0.1-py_0.conda does not "
-            "have a valid checksum or correct label on cf-staging"
-        ) in errs
-        valid_staging_hash_b_err = (
-            "output noarch/b-0.1-py_0.conda does not "
-            "have a valid checksum or correct label on cf-staging"
-        ) in errs
-        assert valid_staging_hash_a_err is not valid_staging_hash
-        assert valid_staging_hash_b_err is valid_staging_hash
+    valid_staging_hash_a_err = (
+        "output noarch/a-0.1-py_0.conda does not "
+        "have a valid checksum or correct label on cf-staging"
+    ) in errs
+    valid_staging_hash_b_err = (
+        "output noarch/b-0.1-py_0.conda does not "
+        "have a valid checksum or correct label on cf-staging"
+    ) in errs
+    assert valid_staging_hash_a_err is not valid_staging_hash
+    assert valid_staging_hash_b_err is valid_staging_hash
 
-        valid_output_a_err = (
-            "output noarch/a-0.1-py_0.conda not allowed for conda-forge/bar-feedstock"
-        ) in errs
-        valid_output_b_err = (
-            "output noarch/b-0.1-py_0.conda not allowed for conda-forge/bar-feedstock"
-        ) in errs
-        if valid_staging_hash:
-            assert valid_output_a_err is not valid_output
-        if not valid_staging_hash:
-            assert valid_output_b_err is valid_output
-
-        # valid_copy_a_err = (
-        #     "output noarch/a-0.1-py_0.conda did not copy to "
-        #     f"conda-forge under staging label {staging_label}"
-        # ) in errs
-        # valid_copy_b_err = (
-        #     "output noarch/b-0.1-py_0.conda did not copy to "
-        #     f"conda-forge under staging label {staging_label}"
-        # ) in errs
-        # if valid_output and valid_staging_hash:
-        #     assert valid_copy_a_err is not valid_copy
-        # if (not valid_output) and (not valid_staging_hash):
-        #     assert valid_copy_b_err is valid_copy
-
-        # valid_prod_hash_a_err = (
-        #     "output noarch/a-0.1-py_0.conda does not "
-        #     "have a valid checksum or correct label on conda-forge"
-        # ) in errs
-        # valid_prod_hash_b_err = (
-        #     "output noarch/b-0.1-py_0.conda does not "
-        #     "have a valid checksum or correct label on conda-forge"
-        # ) in errs
-        # if valid_output and valid_staging_hash and valid_copy:
-        #     assert valid_prod_hash_a_err is not valid_prod_hash
-        # if (not valid_output) and (not valid_staging_hash) and (not valid_copy):
-        #     assert valid_prod_hash_b_err is valid_prod_hash
+    valid_output_a_err = (
+        "output noarch/a-0.1-py_0.conda not allowed for conda-forge/bar-feedstock"
+    ) in errs
+    valid_output_b_err = (
+        "output noarch/b-0.1-py_0.conda not allowed for conda-forge/bar-feedstock"
+    ) in errs
+    if valid_staging_hash:
+        assert valid_output_a_err is not valid_output
+    if not valid_staging_hash:
+        assert valid_output_b_err is valid_output
 
 
 @pytest.mark.skipif(

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -36,7 +36,7 @@ from conda_forge_webservices.feedstock_outputs import (
     validate_feedstock_outputs,
     is_valid_feedstock_token,
     comment_on_outputs_copy,
-    stage_dist_to_prestage_and_possibly_copy_to_prod,
+    stage_dist_to_post_staging_and_possibly_copy_to_prod,
     STAGING_LABEL,
 )
 from conda_forge_webservices.utils import (
@@ -658,7 +658,7 @@ def _do_copy(
                 (
                     dist_copied,
                     dist_errors,
-                ) = stage_dist_to_prestage_and_possibly_copy_to_prod(
+                ) = stage_dist_to_post_staging_and_possibly_copy_to_prod(
                     dist, dest_label, hash_type, hash_value
                 )
                 errors.extend(dist_errors)

--- a/scripts/test_cfep13_copy.py
+++ b/scripts/test_cfep13_copy.py
@@ -393,7 +393,6 @@ def test_feedstock_outputs_copy_works(build_test_package, should_fail, hash_type
                         with open(output_fname) as fp:
                             data = json.load(fp)
                             assert data["feedstocks"] == ["staged-recipes"]
-
     finally:
         _print_step("cleaning up repos and dists")
         for dist in outputs:


### PR DESCRIPTION
### Description

This PR changes cf-pre-staging to cf-post-staging as that makes more sense.

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
