### PR TITLE
fix: turn off core warning for now

### DIFF
--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -714,9 +714,9 @@ def _do_copy(
         if o not in valid:
             valid[o] = False
 
-    copied, errors = _comment_on_core_notes_if_bad_copy(
-        copied, errors, outputs, dest_label, hash_type
-    )
+    # copied, errors = _comment_on_core_notes_if_bad_copy(
+    #     copied, errors, outputs, dest_label, hash_type
+    # )
 
     if not all(copied[o] for o in outputs) and comment_on_error:
         comment_on_outputs_copy(feedstock, git_sha, errors, valid, copied)


### PR DESCRIPTION
### Description

This warning to core is not reliable enough to be useful. We get too many false positives due to race conditions and failures of the anaconda.org API.

I am turning it off for now.

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
