### PR TITLE
perf: try commands in a process pool outside of copy process pool

### DIFF
--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -76,6 +76,9 @@ def _worker_pool(kind):
                 # needed for mocks in testing
                 COMMAND_POOL = ThreadPoolExecutor(max_workers=2)
             else:
+                # we only use one process here to conserve memory.
+                # we have to use a process because the commands
+                # run git operations which are not thread safe.
                 COMMAND_POOL = ProcessPoolExecutor(max_workers=1)
         return COMMAND_POOL
     elif kind == "upload":

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -70,15 +70,15 @@ def _worker_pool(kind):
     global UPLOAD_POOL
     global COPYLOCK
 
-    # if kind == "command":
-    #     if COMMAND_POOL is None:
-    #         if "PYTEST_CURRENT_TEST" in os.environ:
-    #             # needed for mocks in testing
-    #             COMMAND_POOL = ThreadPoolExecutor(max_workers=2)
-    #         else:
-    #             COMMAND_POOL = ProcessPoolExecutor(max_workers=2)
-    #     return COMMAND_POOL
-    if kind == "upload" or kind == "command":
+    if kind == "command":
+        if COMMAND_POOL is None:
+            if "PYTEST_CURRENT_TEST" in os.environ:
+                # needed for mocks in testing
+                COMMAND_POOL = ThreadPoolExecutor(max_workers=2)
+            else:
+                COMMAND_POOL = ThreadPoolExecutor(max_workers=2)
+        return COMMAND_POOL
+    elif kind == "upload":
         if UPLOAD_POOL is None:
             if "PYTEST_CURRENT_TEST" in os.environ:
                 # needed for mocks in testing

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -76,7 +76,7 @@ def _worker_pool(kind):
                 # needed for mocks in testing
                 COMMAND_POOL = ThreadPoolExecutor(max_workers=2)
             else:
-                COMMAND_POOL = ThreadPoolExecutor(max_workers=2)
+                COMMAND_POOL = ProcessPoolExecutor(max_workers=1)
         return COMMAND_POOL
     elif kind == "upload":
         if UPLOAD_POOL is None:


### PR DESCRIPTION
### Description

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->

At this point, all of the commands that do significant work delegate jobs to GHA. So I think we can try to run commands in a separate process pool so they are responsive. Currently commands are run in the same process pool as uploads and this causes issues when lots of uploads are happening.
