### PR TITLE
feat: rebuild docker images when webservices is relocked

### DIFF
--- a/.github/workflows/clean-and-update.yml
+++ b/.github/workflows/clean-and-update.yml
@@ -16,7 +16,8 @@ jobs:
           token: ${{ secrets.CF_ADMIN_GITHUB_TOKEN }}
 
       - name: relock
-        uses: beckermr/relock-conda@1187b776400478c5ff35d4cf423da23a80bbdd4c
+        id: relock
+        uses: conda-incubator/relock-conda@1187b776400478c5ff35d4cf423da23a80bbdd4c
         with:
           github-token: ${{ secrets.CF_ADMIN_GITHUB_TOKEN }}
           automerge: true
@@ -28,12 +29,30 @@ jobs:
             conda-build
             conda-libmamba-solver
             mamba
+            conda-forge-ci-setup
             conda-forge-tick
             conda-forge-feedstock-ops
             conda-recipe-manager
             conda-souschef
             rattler-build
             rattler-build-conda-compat
+
+      - name: generate token
+        id: generate_token
+        uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b
+        with:
+          app-id: ${{ secrets.CF_CURATOR_APP_ID }}
+          private-key: ${{ secrets.CF_CURATOR_PRIVATE_KEY }}
+          owner: conda-forge
+          repositories: docker-images
+
+      - name: rebuild docker images for CI jobs
+        uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1.2.4
+        if: github.event_name != 'issue_comment' && steps.relock.outputs.relocked == 'true'
+        with:
+          repo: conda-forge/docker-images
+          workflow: ci.yaml
+          token: ${{ steps.generate_token.outputs.token }}
 
   clean-and-cache:
     name: clean-and-cache


### PR DESCRIPTION
### Description

@jaimergp would this work? It should help us rebuild less often maybe?

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
