### PR TITLE
fix: move conda-build locks to allow for rerendering w/ local sources

### DIFF
--- a/Dockerfile_wda
+++ b/Dockerfile_wda
@@ -68,6 +68,9 @@ ENV HOME=/home/conda \
     MAIL=/var/spool/mail/conda \
     PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/conda/bin
 RUN <<EOF
+    # make symlink for conda-build locks (actual directory gets made at run time in the entrypoint)
+    # see https://github.com/conda-forge/conda-forge-feedstock-ops/pull/59
+    ln -s $TMPDIR/conda_user_conda_build_locks $HOME/.conda_build_locks
     chown conda:conda $HOME
     # cp -R /etc/skel $HOME
     # chown -R conda:conda $HOME/skel

--- a/entrypoint_wda
+++ b/entrypoint_wda
@@ -6,5 +6,8 @@ source ~/.bashrc
 # activate env
 micromamba activate $CF_FEEDSTOCK_OPS_ENV
 
+# make special locks location for conda-build for conda user
+mkdir -p ${TMPDIR}/conda_user_conda_build_locks
+
 # Run whatever the user wants.
 exec "$@"


### PR DESCRIPTION
### Description

See https://github.com/conda-forge/conda-forge-feedstock-ops/pull/59 for more details. Unfortunately, adding a test of this here would be non-trivial and so I am going to skip that. The solution here is tested in the PR linked above.

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
