### PR TITLE
fix: ensure we check authors and committers for automerge

### DIFF
--- a/conda_forge_webservices/github_actions_integration/automerge.py
+++ b/conda_forge_webservices/github_actions_integration/automerge.py
@@ -382,7 +382,11 @@ like to enable automerge again!
             return False, "PR does not have the '[bot-automerge]' slug in the title"
 
         # only if only ALLOWED_USERS have commits
-        committers = {getattr(c.author, "login", None) for c in pr.get_commits()}
+        committers = set()
+        for c in pr.get_commits():
+            committers.add(getattr(c.author, "login", None))
+            committers.add(getattr(c.committer, "login", None))
+
         if not all(c in ALLOWED_USERS for c in committers):
             _comment_on_pr_with_race(
                 pr_for_admin,


### PR DESCRIPTION
Refactor committers collection to include both author and committer logins.

### Description

Closes #1120 

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
