### PR TITLE
fix: need to add review-requested label too

### DIFF
--- a/conda_forge_webservices/staged_recipes.py
+++ b/conda_forge_webservices/staged_recipes.py
@@ -49,6 +49,8 @@ def label_pr(
             if team_regex.search(comment):
                 if label not in curr_label_names:
                     pr.add_to_labels(label)
+                if AWAITING_REV_LABEL not in curr_label_names:
+                    pr.add_to_labels(AWAITING_REV_LABEL)
 
                 if label == "staged-recipes":
                     found_sr_team = True


### PR DESCRIPTION
### Description

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->

Fixing one bug in labeler.