### PR TITLE
fix: handle missing extra.recipe-maintainers section in recipes for team updates

### DIFF
--- a/conda_forge_webservices/update_teams.py
+++ b/conda_forge_webservices/update_teams.py
@@ -151,9 +151,7 @@ def get_recipe_dummy_meta(recipe_content):
     elif skip == 1:
         return DummyMeta("\n".join(keep_lines))
     else:
-        raise RuntimeError(
-            f"team update failed due to {skip} 'extra:' sections"
-        )
+        raise RuntimeError(f"team update failed due to {skip} 'extra:' sections")
 
 
 def update_team(org_name, repo_name, commit=None):

--- a/conda_forge_webservices/update_teams.py
+++ b/conda_forge_webservices/update_teams.py
@@ -145,8 +145,15 @@ def get_recipe_dummy_meta(recipe_content):
             skip += 1
         if skip > 0:
             keep_lines.append(_filter_jinja2(line))
-    assert skip == 1, "team update failed due to > 1 'extra:' sections"
-    return DummyMeta("\n".join(keep_lines))
+
+    if skip == 0:
+        return DummyMeta('{"extra": {"recipe-maintainers": []}}')
+    elif skip == 1:
+        return DummyMeta("\n".join(keep_lines))
+    else:
+        raise RuntimeError(
+            f"team update failed due to {skip} 'extra:' sections"
+        )
 
 
 def update_team(org_name, repo_name, commit=None):


### PR DESCRIPTION
### Description

Some folks have simply deleted this entire section from their recipe and that causes the webservices to choke. We can handle it if it is missing.

