### PR TITLE
fix: ignore broken recipes; log info about missing recipes

### DIFF
--- a/conda_forge_webservices/github_actions_integration/__main__.py
+++ b/conda_forge_webservices/github_actions_integration/__main__.py
@@ -440,6 +440,16 @@ def main_finalize_task(task_data_dir):
                 recipes_to_lint, _ = get_recipes_for_linting(
                     gh, gh_repo, pr.number, task_results["lints"], task_results["hints"]
                 )
+                LOGGER.info("recipes to lint: %r", sorted(recipes_to_lint))
+                for rec in recipes_to_lint:
+                    if rec not in task_results["errors"]:
+                        LOGGER.info(
+                            "could not find task results for recipe "
+                            "%r - assuming it failed!",
+                            rec,
+                        )
+                flush_logger(LOGGER)
+
                 if any(
                     task_results["errors"].get(rec, True) for rec in recipes_to_lint
                 ):

--- a/conda_forge_webservices/github_actions_integration/linting.py
+++ b/conda_forge_webservices/github_actions_integration/linting.py
@@ -18,6 +18,7 @@ def get_recipes_for_linting(gh, repo, pr_id, lints, hints):
                 not in ["recipes/example/meta.yaml", "recipes/example-v1/recipe.yaml"]
             )
             and os.path.basename(fname) in ["meta.yaml", "recipe.yaml"]
+            and (not fname.startswith("broken-recipes/"))
         )
     else:
         recipes_to_lint = set(fnames)


### PR DESCRIPTION
### Description

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
