### PR TITLE
fix: dispatch to new bot location

### DIFF
--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -999,9 +999,7 @@ def _dispatch_autotickbot_job(repo_full_name, event, uid):
                 "uid": str(uid),
             },
         )
-        msg = (
-            f"conda-forge-bot job dispatched: event|uid|running = {event}|{uid}|{running}"
-        )
+        msg = f"conda-forge-bot job dispatched: event|uid|running = {event}|{uid}|{running}"
 
     log_title_and_message_at_level(
         level="info",

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -990,7 +990,10 @@ def _cached_bot_workflow():
 def _dispatch_autotickbot_job(repo_full_name, event, uid):
     wf = _cached_bot_workflow()
     if wf is None:
-        msg = f"conda-forge-bot job dispatch skipped: event|uid = {event}|{uid} - no token"
+        msg = (
+            "conda-forge-bot job dispatch skipped: "
+            f"event|uid = {event}|{uid} - no token"
+        )
     else:
         running = wf.create_dispatch(
             "main",
@@ -999,7 +1002,10 @@ def _dispatch_autotickbot_job(repo_full_name, event, uid):
                 "uid": str(uid),
             },
         )
-        msg = f"conda-forge-bot job dispatched: event|uid|running = {event}|{uid}|{running}"
+        msg = (
+            "conda-forge-bot job dispatched: "
+            f"event|uid|running = {event}|{uid}|{running}"
+        )
 
     log_title_and_message_at_level(
         level="info",

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -983,14 +983,14 @@ def _cached_bot_workflow():
         return None
 
     gh = github.Github(auth=github.Auth.Token(os.environ["AUTOTICK_BOT_GH_TOKEN"]))
-    repo = gh.get_repo("regro/cf-scripts")
+    repo = gh.get_repo("conda-forge/conda-forge-bot")
     return repo.get_workflow("bot-events.yml")
 
 
 def _dispatch_autotickbot_job(repo_full_name, event, uid):
     wf = _cached_bot_workflow()
     if wf is None:
-        msg = f"autotick bot job dispatch skipped: event|uid = {event}|{uid} - no token"
+        msg = f"conda-forge-bot job dispatch skipped: event|uid = {event}|{uid} - no token"
     else:
         running = wf.create_dispatch(
             "main",
@@ -1000,12 +1000,12 @@ def _dispatch_autotickbot_job(repo_full_name, event, uid):
             },
         )
         msg = (
-            f"autotick bot job dispatched: event|uid|running = {event}|{uid}|{running}"
+            f"conda-forge-bot job dispatched: event|uid|running = {event}|{uid}|{running}"
         )
 
     log_title_and_message_at_level(
         level="info",
-        title=f"autotick bot {event}: {repo_full_name}",
+        title=f"conda-forge-bot {event}: {repo_full_name}",
         msg=msg,
     )
 

--- a/tests/meta.yaml
+++ b/tests/meta.yaml
@@ -26,7 +26,7 @@ test:
     - echo "works!"
 
 about:
-  home: https://github.com/regro/cf-scripts
+  home: https://github.com/conda-forge/conda-forge-bot
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE


### PR DESCRIPTION
### Description

Dispatch bot update jobs to new bot location.

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
