### PR TITLE
prod: use quay for images

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -204,15 +204,15 @@ jobs:
           build-args: |
             --no-cache
 
-      - name: push docker image to docker hub
+      - name: push docker image to quay.io
         if: ${{ needs.check.outputs.skip-check != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'conda-forge/conda-forge-webservices') }}
         uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
         with:
           image: webservices-dispatch-action
           tags: ${{ steps.install-code.outputs.version }}
-          registry: docker.io/condaforge
-          username: condaforgebot
-          password: ${{ secrets.CF_BOT_DH_PASSWORD }}
+          registry: quay.io/condaforge
+          username: conda_forge_daemon
+          password: ${{ secrets.CF_DAEMON_QUAY_PASSWORD }}
 
   live-tests-upload:
     name: live-tests-upload
@@ -336,7 +336,7 @@ jobs:
           fi
 
           version=$(python -c "import conda_forge_webservices; print(conda_forge_webservices.__version__.replace('+', '.'))")
-          export CF_FEEDSTOCK_OPS_CONTAINER_NAME=condaforge/webservices-dispatch-action
+          export CF_FEEDSTOCK_OPS_CONTAINER_NAME=quay.io/condaforge/webservices-dispatch-action
           export CF_FEEDSTOCK_OPS_CONTAINER_TAG="${version}"
 
           cd tests
@@ -403,7 +403,7 @@ jobs:
           fi
 
           version=$(python -c "import conda_forge_webservices; print(conda_forge_webservices.__version__.replace('+', '.'))")
-          export CF_FEEDSTOCK_OPS_CONTAINER_NAME=condaforge/webservices-dispatch-action
+          export CF_FEEDSTOCK_OPS_CONTAINER_NAME=quay.io/condaforge/webservices-dispatch-action
           export CF_FEEDSTOCK_OPS_CONTAINER_TAG="${version}"
 
           cd tests
@@ -470,7 +470,7 @@ jobs:
           fi
 
           version=$(python -c "import conda_forge_webservices; print(conda_forge_webservices.__version__.replace('+', '.'))")
-          export CF_FEEDSTOCK_OPS_CONTAINER_NAME=condaforge/webservices-dispatch-action
+          export CF_FEEDSTOCK_OPS_CONTAINER_NAME=quay.io/condaforge/webservices-dispatch-action
           export CF_FEEDSTOCK_OPS_CONTAINER_TAG="${version}"
 
           cd tests

--- a/.github/workflows/webservices-workflow-dispatch.yml
+++ b/.github/workflows/webservices-workflow-dispatch.yml
@@ -77,7 +77,7 @@ jobs:
           git config --global user.name "conda-forge-webservices[bot]"
           git config --global user.email "91080706+conda-forge-webservices[bot]@users.noreply.github.com"
 
-          export CF_FEEDSTOCK_OPS_CONTAINER_NAME=condaforge/webservices-dispatch-action
+          export CF_FEEDSTOCK_OPS_CONTAINER_NAME=quay.io/condaforge/webservices-dispatch-action
           export CF_FEEDSTOCK_OPS_CONTAINER_TAG="${{ inputs.container_tag }}"
 
           conda-forge-webservices-run-task \

--- a/Dockerfile_wda
+++ b/Dockerfile_wda
@@ -1,4 +1,4 @@
-FROM mambaorg/micromamba:1.5.10-noble AS build-env
+FROM mambaorg/micromamba:2.6.2-noble AS build-env
 
 ENV PYTHONDONTWRITEBYTECODE=1
 USER root

--- a/Dockerfile_wda
+++ b/Dockerfile_wda
@@ -1,4 +1,4 @@
-FROM mambaorg/micromamba:2.6.2-noble AS build-env
+FROM mambaorg/micromamba:2.6.2 AS build-env
 
 ENV PYTHONDONTWRITEBYTECODE=1
 USER root


### PR DESCRIPTION
### Description

Switches to using quay.io for images.

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
