### PR TITLE
fix: pass merge queue info in linter

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -39,6 +39,7 @@ jobs:
       - name: setup conda
         uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
+          micromamba-version: "2.7.0-0"
           environment-file: conda-lock.yml
           environment-name: webservices
           condarc: |

--- a/.github/workflows/clean-and-update.yml
+++ b/.github/workflows/clean-and-update.yml
@@ -78,6 +78,7 @@ jobs:
       - name: setup conda
         uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
+          micromamba-version: "2.7.0-0"
           environment-file: conda-lock.yml
           environment-name: webservices
           condarc: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
 
       - uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
+          micromamba-version: "2.7.0-0"
           environment-file: conda-lock.yml
           environment-name: webservices
           condarc: |
@@ -69,6 +70,7 @@ jobs:
 
       - uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
+          micromamba-version: "2.7.0-0"
           environment-file: conda-lock.yml
           environment-name: webservices
           condarc: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,6 +99,7 @@ jobs:
         uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         if: ${{ needs.check.outputs.skip-check != 'true' }}
         with:
+          micromamba-version: "2.7.0-0"
           environment-file: conda-lock.yml
           environment-name: webservices
           condarc: |
@@ -173,6 +174,7 @@ jobs:
         uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         if: ${{ needs.check.outputs.skip-check != 'true' }}
         with:
+          micromamba-version: "2.7.0-0"
           environment-file: conda-lock.yml
           environment-name: webservices
           condarc: |
@@ -232,6 +234,7 @@ jobs:
         if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
         uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
+          micromamba-version: "2.7.0-0"
           environment-file: conda-lock.yml
           environment-name: webservices
           condarc: |
@@ -296,6 +299,7 @@ jobs:
         if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
         uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
+          micromamba-version: "2.7.0-0"
           environment-file: conda-lock.yml
           environment-name: webservices
           condarc: |
@@ -363,6 +367,7 @@ jobs:
         if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
         uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
+          micromamba-version: "2.7.0-0"
           environment-file: conda-lock.yml
           environment-name: webservices
           condarc: |
@@ -430,6 +435,7 @@ jobs:
         if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
         uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
+          micromamba-version: "2.7.0-0"
           environment-file: conda-lock.yml
           environment-name: webservices
           condarc: |
@@ -496,6 +502,7 @@ jobs:
         if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
         uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
+          micromamba-version: "2.7.0-0"
           environment-file: conda-lock.yml
           environment-name: webservices
           condarc: |

--- a/.github/workflows/webservices-workflow-dispatch.yml
+++ b/.github/workflows/webservices-workflow-dispatch.yml
@@ -36,6 +36,11 @@ on:
         required: false
         type: string
         default: 'null'
+      merge_queue:
+        description: 'string `false` or `true` indicating if the PR is in a merge queue'
+        required: false
+        type: string
+        default: 'false'
 
 env:
   PY_COLORS: 1
@@ -86,7 +91,8 @@ jobs:
             --pr-number=${{ inputs.pr_number }} \
             --task-data-dir=${{ github.workspace }}/task-data \
             --requested-version=${{ inputs.requested_version }} \
-            --sha=${{ inputs.sha }}
+            --sha=${{ inputs.sha }} \
+            --merge-queue=${{ inputs.merge_queue }}
 
       - name: upload task data
         id: upload-task-data

--- a/.github/workflows/webservices-workflow-dispatch.yml
+++ b/.github/workflows/webservices-workflow-dispatch.yml
@@ -65,6 +65,7 @@ jobs:
       - name: setup conda
         uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
+          micromamba-version: "2.7.0-0"
           environment-file: conda-lock.yml
           environment-name: webservices
           condarc: |
@@ -118,6 +119,7 @@ jobs:
       - name: setup conda
         uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
+          micromamba-version: "2.7.0-0"
           environment-file: conda-lock.yml
           environment-name: webservices
           condarc: |

--- a/conda_forge_webservices/github_actions_integration/__main__.py
+++ b/conda_forge_webservices/github_actions_integration/__main__.py
@@ -59,7 +59,10 @@ def _pull_docker_image():
 @click.option("--task-data-dir", required=True, type=str)
 @click.option("--requested-version", required=False, type=str, default=None)
 @click.option("--sha", required=False, type=str, default=None)
-def main_run_task(task, repo, pr_number, task_data_dir, requested_version, sha):
+@click.option("--merge-queue", type=str, default="false")
+def main_run_task(
+    task, repo, pr_number, task_data_dir, requested_version, sha, merge_queue
+):
     setup_logging(level="DEBUG")
 
     action_desc = f"task `{task}` for conda-forge/{repo}#{pr_number}"
@@ -88,6 +91,7 @@ def main_run_task(task, repo, pr_number, task_data_dir, requested_version, sha):
         "repo": repo,
         "pr_number": pr_number,
         "sha": sha,
+        "merge_queue": merge_queue,
         "task_results": {},
     }
 
@@ -257,6 +261,7 @@ def main_finalize_task(task_data_dir):
     pr_number = task_data["pr_number"]
     task_results = task_data["task_results"]
     sha_for_status = task_data["sha"]
+    merge_queue = task_data["merge_queue"]
 
     LOGGER.info("finalizing task `%s` for conda-forge/%s#%s", task, repo, pr_number)
     LOGGER.info("task results:")
@@ -480,7 +485,12 @@ def main_finalize_task(task_data_dir):
                 status = "bad"
             else:
                 msg, status = build_and_make_lint_comment(
-                    gh, gh_repo, pr.number, task_results["lints"], task_results["hints"]
+                    gh,
+                    gh_repo,
+                    pr.number,
+                    task_results["lints"],
+                    task_results["hints"],
+                    skip_mergeable_check=False if merge_queue == "false" else True,
                 )
 
             set_pr_status(gh_repo, sha_for_status, status, target_url=msg.html_url)

--- a/conda_forge_webservices/github_actions_integration/linting.py
+++ b/conda_forge_webservices/github_actions_integration/linting.py
@@ -98,8 +98,13 @@ def make_lint_comment(repo, pr_id, message):
     return msg
 
 
-def build_and_make_lint_comment(gh, repo, pr_id, lints, hints):
-    mergeable = _is_mergeable(repo, pr_id)
+def build_and_make_lint_comment(
+    gh, repo, pr_id, lints, hints, skip_mergeable_check=False
+):
+    if not skip_mergeable_check:
+        mergeable = _is_mergeable(repo, pr_id)
+    else:
+        mergeable = True
     if not mergeable:
         message = dedent_with_escaped_continue(
             """

--- a/conda_forge_webservices/linting.py
+++ b/conda_forge_webservices/linting.py
@@ -62,6 +62,7 @@ def lint_via_github_actions(
             "container_tag": ref,
             "uuid": uid,
             "sha": sha,
+            "merge_queue": "true" if sha is not None else "false",
         },
     )
 

--- a/conda_forge_webservices/linting.py
+++ b/conda_forge_webservices/linting.py
@@ -40,7 +40,7 @@ def lint_via_github_actions(
     repo = gh.get_repo(full_name)
     repo_owner, repo_name = full_name.split("/")
     pr = repo.get_pull(pr_num)
-    sha = sha or pr.head.sha
+    sha_to_use = sha or pr.head.sha
     commit = gh.get_repo(pr.head.repo.full_name).get_git_commit(sha)
     commit_msg = commit.message
 
@@ -61,7 +61,7 @@ def lint_via_github_actions(
             "pr_number": str(pr_num),
             "container_tag": ref,
             "uuid": uid,
-            "sha": sha,
+            "sha": sha_to_use,
             "merge_queue": "true" if sha is not None else "false",
         },
     )

--- a/conda_forge_webservices/linting.py
+++ b/conda_forge_webservices/linting.py
@@ -41,7 +41,7 @@ def lint_via_github_actions(
     repo_owner, repo_name = full_name.split("/")
     pr = repo.get_pull(pr_num)
     sha_to_use = sha or pr.head.sha
-    commit = gh.get_repo(pr.head.repo.full_name).get_git_commit(sha)
+    commit = gh.get_repo(pr.head.repo.full_name).get_git_commit(sha_to_use)
     commit_msg = commit.message
 
     should_skip = any([msg in commit_msg for msg in SKIP_MSGS])
@@ -74,7 +74,9 @@ def lint_via_github_actions(
             target_url = run.html_url
         else:
             target_url = None
-        _set_pr_status(repo_owner, repo_name, sha, "pending", target_url=target_url)
+        _set_pr_status(
+            repo_owner, repo_name, sha_to_use, "pending", target_url=target_url
+        )
     else:
         msg = "linting job dispatch failed"
 

--- a/conda_forge_webservices/linting.py
+++ b/conda_forge_webservices/linting.py
@@ -45,7 +45,9 @@ def lint_via_github_actions(
     commit_msg = commit.message
 
     should_skip = any([msg in commit_msg for msg in SKIP_MSGS])
-    if should_skip:
+    # the sha is only not None if a PR is in a merge queue
+    # we never skip linting in the merge queue
+    if should_skip and sha is None:
         return False
 
     uid = uuid.uuid4().hex


### PR DESCRIPTION
### Description

GitHub's API doesn't consistently report mergeable status for PRs when they are in the merge queue. So we bypass that...

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
