### PR TITLE
perf: use "fire and forget" w/ completed futures

### DIFF
--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -517,8 +517,9 @@ class UpdateFeedstockHookHandler(WriteErrorAsJSONRequestHandler):
                 return
         else:
             LOGGER.info(f'Unhandled event "{event}".')
-            self.set_status(404)
-            self.write_error(404)
+
+        self.set_status(404)
+        self.write_error(404)
 
 
 class UpdateTeamHookHandler(WriteErrorAsJSONRequestHandler):

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -727,8 +727,8 @@ class CommandHookHandler(WriteErrorAsJSONRequestHandler):
 
         else:
             LOGGER.info(f'Unhandled event "{event}".')
-            self.set_status(404)
-            self.write_error(404)
+        self.set_status(404)
+        self.write_error(404)
 
 
 def _get_current_versions():

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -906,7 +906,11 @@ class OutputsCopyHandler(WriteErrorAsJSONRequestHandler):
         )
 
         if feedstock_repo_name is not None and len(feedstock_repo_name) > 0:
-            feedstock_exists = _repo_exists(feedstock_repo_name)
+            feedstock_exists = await tornado.ioloop.IOLoop.current().run_in_executor(
+                _thread_pool(),
+                _repo_exists,
+                feedstock_repo_name,
+            )
         else:
             feedstock_exists = False
 

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -862,6 +862,15 @@ def _do_copy(
     return valid, errors, copied, time.time() - start_time
 
 
+def _is_valid_feedstock_token_pure_args(feedstock_repo_name, feedstock_token, provider):
+    return is_valid_feedstock_token(
+        "conda-forge",
+        feedstock_repo_name,
+        feedstock_token,
+        provider=provider,
+    )
+
+
 class OutputsCopyHandler(WriteErrorAsJSONRequestHandler):
     async def post(self):
         headers = self.request.headers
@@ -905,14 +914,18 @@ class OutputsCopyHandler(WriteErrorAsJSONRequestHandler):
             feedstock_exists
             and feedstock_token is not None
             and len(feedstock_token) > 0
-            and is_valid_feedstock_token(
-                "conda-forge",
-                feedstock_repo_name,
-                feedstock_token,
-                provider=provider,
-            )
         ):
-            valid_token = True
+            token_validation_check = (
+                await tornado.ioloop.IOLoop.current().run_in_executor(
+                    _thread_pool(),
+                    _is_valid_feedstock_token_pure_args,
+                    feedstock_repo_name,
+                    feedstock_token,
+                    provider,
+                )
+            )
+            if token_validation_check:
+                valid_token = True
 
         if (
             (not feedstock_exists)

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -251,6 +251,10 @@ class WriteErrorAsJSONRequestHandler(tornado.web.RequestHandler):
         self.finish(json.dumps(reply))
 
 
+def _run_gha_linting_pure_args(full_name, pr_id, sha):
+    linting.lint_via_github_actions(full_name, pr_id, sha=sha)
+
+
 class LintingHookHandler(WriteErrorAsJSONRequestHandler):
     async def post(self):
         headers = self.request.headers
@@ -317,14 +321,13 @@ class LintingHookHandler(WriteErrorAsJSONRequestHandler):
             if is_open and owner == "conda-forge" and not stale:
                 if linting.LINT_VIA_GHA:
                     # for merge groups, we pass the SHA of the merge commit
-                    linting.lint_via_github_actions(
+                    tornado.ioloop.IOLoop.current().spawn_callback(
+                        _run_gha_linting_pure_args,
                         body["repository"]["full_name"],
                         pr_id,
-                        sha=(
-                            None
-                            if event == "pull_request"
-                            else body["merge_group"]["head_sha"]
-                        ),
+                        None
+                        if event == "pull_request"
+                        else body["merge_group"]["head_sha"],
                     )
                 else:
                     log_title_and_message_at_level(
@@ -358,6 +361,19 @@ class LintingHookHandler(WriteErrorAsJSONRequestHandler):
             LOGGER.info(f'Unhandled event "{event}".')
             self.set_status(404)
             self.write_error(404)
+
+
+def _staged_recipes_label_pure_args(
+    full_name, pr_id, action, curr_label_names, comment, label
+):
+    staged_recipes.label_pr(
+        full_name,
+        pr_id,
+        action,
+        curr_label_names,
+        comment=comment,
+        label=label,
+    )
 
 
 class StagedRecipesLabelerHandler(WriteErrorAsJSONRequestHandler):
@@ -430,19 +446,27 @@ class StagedRecipesLabelerHandler(WriteErrorAsJSONRequestHandler):
                     f"current labels: {curr_label_names!r}\n"
                 ),
             )
-            staged_recipes.label_pr(
+            tornado.ioloop.IOLoop.current().spawn_callback(
+                _staged_recipes_label_pure_args,
                 f"{owner}/{repo_name}",
                 pr_id,
                 action,
                 curr_label_names,
-                comment=comment,
-                label=label,
+                comment,
+                label,
             )
 
         else:
             LOGGER.info(f'Unhandled event "{event}".')
             self.set_status(404)
             self.write_error(404)
+
+
+def _complete_future(fut):
+    try:
+        fut.result()
+    except Exception:
+        LOGGER.exception("Background task exception!")
 
 
 class UpdateFeedstockHookHandler(WriteErrorAsJSONRequestHandler):
@@ -483,18 +507,18 @@ class UpdateFeedstockHookHandler(WriteErrorAsJSONRequestHandler):
                     level="info",
                     title=f"feedstocks service: {body['repository']['full_name']}",
                 )
-                handled = await tornado.ioloop.IOLoop.current().run_in_executor(
+                handled = tornado.ioloop.IOLoop.current().run_in_executor(
                     _worker_pool("command"),
                     feedstocks_service.handle_feedstock_event,
                     owner,
                     repo_name,
                 )
-                if handled:
-                    return
+                tornado.ioloop.IOLoop.current().add_future(handled, _complete_future)
+                return
         else:
             LOGGER.info(f'Unhandled event "{event}".')
-        self.set_status(404)
-        self.write_error(404)
+            self.set_status(404)
+            self.write_error(404)
 
 
 class UpdateTeamHookHandler(WriteErrorAsJSONRequestHandler):
@@ -536,13 +560,14 @@ class UpdateTeamHookHandler(WriteErrorAsJSONRequestHandler):
                     level="info",
                     title=f"update teams: {body['repository']['full_name']}",
                 )
-                await tornado.ioloop.IOLoop.current().run_in_executor(
+                fut = tornado.ioloop.IOLoop.current().run_in_executor(
                     _thread_pool(),  # always threads due to expensive lru_cache
                     update_teams.update_team,
                     owner,
                     repo_name,
                     commit,
                 )
+                tornado.ioloop.IOLoop.current().add_future(fut, _complete_future)
                 return
         else:
             LOGGER.info(f'Unhandled event "{event}".')
@@ -613,7 +638,7 @@ class CommandHookHandler(WriteErrorAsJSONRequestHandler):
                     title=f"PR command: {body['repository']['full_name']}",
                 )
 
-                await tornado.ioloop.IOLoop.current().run_in_executor(
+                fut = tornado.ioloop.IOLoop.current().run_in_executor(
                     _worker_pool("command"),
                     commands.pr_detailed_comment,
                     owner,
@@ -626,6 +651,7 @@ class CommandHookHandler(WriteErrorAsJSONRequestHandler):
                     comment_id,
                     review_id,
                 )
+                tornado.ioloop.IOLoop.current().add_future(fut, _complete_future)
                 return
 
         elif event == "issue_comment" or event == "issues":
@@ -654,7 +680,7 @@ class CommandHookHandler(WriteErrorAsJSONRequestHandler):
                     title=f"PR command: {body['repository']['full_name']}",
                 )
 
-                await tornado.ioloop.IOLoop.current().run_in_executor(
+                fut = tornado.ioloop.IOLoop.current().run_in_executor(
                     _worker_pool("command"),
                     commands.pr_comment,
                     owner,
@@ -663,6 +689,7 @@ class CommandHookHandler(WriteErrorAsJSONRequestHandler):
                     comment,
                     comment_id,
                 )
+                tornado.ioloop.IOLoop.current().add_future(fut, _complete_future)
                 return
 
             if not pull_request and action in [
@@ -684,7 +711,7 @@ class CommandHookHandler(WriteErrorAsJSONRequestHandler):
                     title=f"issue command: {body['repository']['full_name']}",
                 )
 
-                await tornado.ioloop.IOLoop.current().run_in_executor(
+                fut = tornado.ioloop.IOLoop.current().run_in_executor(
                     _worker_pool("command"),
                     commands.issue_comment,
                     owner,
@@ -694,13 +721,13 @@ class CommandHookHandler(WriteErrorAsJSONRequestHandler):
                     comment,
                     comment_id,
                 )
+                tornado.ioloop.IOLoop.current().add_future(fut, _complete_future)
                 return
 
         else:
             LOGGER.info(f'Unhandled event "{event}".')
-
-        self.set_status(404)
-        self.write_error(404)
+            self.set_status(404)
+            self.write_error(404)
 
 
 def _get_current_versions():
@@ -720,7 +747,11 @@ def _get_current_versions():
 
 class UpdateWebservicesVersionsHandler(WriteErrorAsJSONRequestHandler):
     async def get(self):
-        self.write(json.dumps(_get_current_versions()))
+        vers = await tornado.ioloop.IOLoop.current().run_in_executor(
+            None,
+            _get_current_versions,
+        )
+        self.write(json.dumps(vers))
 
 
 def _repo_exists(feedstock):
@@ -917,7 +948,14 @@ class OutputsCopyHandler(WriteErrorAsJSONRequestHandler):
                 err_msgs.append("invalid hash type")
 
             if feedstock_exists and comment_on_error:
-                comment_on_outputs_copy(feedstock_repo_name, git_sha, err_msgs, {}, {})
+                tornado.ioloop.IOLoop.current().spawn_callback(
+                    comment_on_outputs_copy,
+                    feedstock_repo_name,
+                    git_sha,
+                    err_msgs,
+                    {},
+                    {},
+                )
 
             self.set_status(403)
             self.write_error(403)
@@ -1068,7 +1106,8 @@ class AutotickBotPayloadHookHandler(WriteErrorAsJSONRequestHandler):
                 and (body["action"] in ["closed", "labeled", "reopened"])
                 and head_owner.startswith("regro-cf-autotick-bot/")
             ):
-                _dispatch_autotickbot_job(
+                tornado.ioloop.IOLoop.current().spawn_callback(
+                    _dispatch_autotickbot_job,
                     body["repository"]["full_name"],
                     "pr",
                     body["pull_request"]["id"],
@@ -1091,7 +1130,8 @@ class AutotickBotPayloadHookHandler(WriteErrorAsJSONRequestHandler):
                 and "[cf admin skip]" not in commit_msg
                 and repo_name.endswith("-feedstock")
             ):
-                _dispatch_autotickbot_job(
+                tornado.ioloop.IOLoop.current().spawn_callback(
+                    _dispatch_autotickbot_job,
                     body["repository"]["full_name"],
                     "push",
                     repo_name.rsplit("-feedstock", 1)[0],
@@ -1187,7 +1227,8 @@ class StatusMonitorPayloadHookHandler(WriteErrorAsJSONRequestHandler):
             if body["action"] == "completed" and body["repository"][
                 "full_name"
             ].endswith("-feedstock"):
-                _dispatch_automerge_job(
+                tornado.ioloop.IOLoop.current().spawn_callback(
+                    _dispatch_automerge_job,
                     body["repository"]["name"],
                     body["check_suite"]["head_sha"],
                 )
@@ -1204,7 +1245,8 @@ class StatusMonitorPayloadHookHandler(WriteErrorAsJSONRequestHandler):
                 status_monitor.update_data_status(body)
 
             if body["repository"]["full_name"].endswith("-feedstock"):
-                _dispatch_automerge_job(
+                tornado.ioloop.IOLoop.current().spawn_callback(
+                    _dispatch_automerge_job,
                     body["repository"]["name"],
                     body["sha"],
                 )
@@ -1220,7 +1262,8 @@ class StatusMonitorPayloadHookHandler(WriteErrorAsJSONRequestHandler):
             # )
 
             if body["repository"]["full_name"].endswith("-feedstock"):
-                _dispatch_automerge_job(
+                tornado.ioloop.IOLoop.current().spawn_callback(
+                    _dispatch_automerge_job,
                     body["repository"]["name"],
                     body["pull_request"]["head"]["sha"],
                 )
@@ -1284,13 +1327,14 @@ class UpdateTeamsEndpointHandler(WriteErrorAsJSONRequestHandler):
                     level="info",
                     title=f"update teams endpoint: conda-forge/{feedstock}",
                 )
-                await tornado.ioloop.IOLoop.current().run_in_executor(
+                fut = tornado.ioloop.IOLoop.current().run_in_executor(
                     _thread_pool(),  # always threads due to expensive lru_cache
                     update_teams.update_team,
                     "conda-forge",
                     feedstock,
                     None,
                 )
+                tornado.ioloop.IOLoop.current().add_future(fut, _complete_future)
                 return
 
         self.set_status(404)


### PR DESCRIPTION
### Description

This PR tries to increase the webserver performance by unblocking the main event loop w/ more "fire and forget" and less awaiting for return values.

