### PR TITLE
fix: use proper http codes for events

### DIFF
--- a/conda_forge_webservices/tests/test_webapp.py
+++ b/conda_forge_webservices/tests/test_webapp.py
@@ -31,7 +31,7 @@ class TestBucketHandler(TestHandlerBase):
             body=urlencode({"a": 1}),
             headers={"X-Hub-Signature": f"sha1={hash}"},
         )
-        self.assertEqual(response.code, 404)
+        self.assertEqual(response.code, 204)
 
     def test_bad_hash(self):
         response = self.fetch(
@@ -43,7 +43,7 @@ class TestBucketHandler(TestHandlerBase):
                 "X-Hub-Signature": "sha1=43abf34",
             },
         )
-        self.assertIn(response.code, [403, 500])
+        self.assertIn(response.code, [401, 500])
 
     @mock.patch(
         "conda_forge_webservices.linting.lint_via_github_actions",
@@ -97,14 +97,13 @@ class TestBucketHandler(TestHandlerBase):
             },
         )
 
-        self.assertEqual(response.code, 200)
-
         if linting.LINT_VIA_GHA:
             lint_via_gha.assert_called_once_with(
                 "conda-forge/repo_name-feedstock",
                 PR_number,
                 sha=None,
             )
+            self.assertEqual(response.code, 202)
         else:
             compute_lint_message.assert_called_once_with(
                 "conda-forge", "repo_name-feedstock", PR_number, False
@@ -124,6 +123,8 @@ class TestBucketHandler(TestHandlerBase):
                 {"message": mock.sentinel.message},
                 target_url=mock.sentinel.html_url,
             )
+
+            self.assertEqual(response.code, 200)
 
     @mock.patch(
         "conda_forge_webservices.linting.lint_via_github_actions", return_value=None
@@ -180,7 +181,9 @@ class TestBucketHandler(TestHandlerBase):
                         "pull_request": {
                             "number": 16,
                             "state": "open",
-                            "labels": [{"name": "stale"}],
+                            "labels": [{"name": "stale"}]
+                            if name != "staged-recipes"
+                            else [],
                             "head": {
                                 "repo": {
                                     "name": "pr_repo_name",
@@ -225,13 +228,13 @@ class TestBucketHandler(TestHandlerBase):
                         ):
                             self.assertEqual(
                                 response.code,
-                                200,
+                                202,
                                 msg=f"event: {event}, slug: {slug}, hook: {hook}",
                             )
                         else:
-                            self.assertNotEqual(
+                            self.assertEqual(
                                 response.code,
-                                200,
+                                204,
                                 msg=f"event: {event}, slug: {slug}, hook: {hook}",
                             )
 
@@ -327,13 +330,13 @@ class TestBucketHandler(TestHandlerBase):
                                 assert commit_msg == "blah"
                                 self.assertEqual(
                                     response.code,
-                                    200,
+                                    202,
                                     msg=f"event: {event}, slug: {slug}, hook: {hook}",
                                 )
                             else:
-                                self.assertNotEqual(
+                                self.assertEqual(
                                     response.code,
-                                    200,
+                                    204,
                                     msg=f"event: {event}, slug: {slug}, hook: {hook}",
                                 )
 
@@ -385,13 +388,13 @@ class TestBucketHandler(TestHandlerBase):
             },
         )
 
-        self.assertEqual(response.code, 200)
         if linting.LINT_VIA_GHA:
             lint_via_gha.assert_called_once_with(
                 "conda-forge/staged-recipes",
                 PR_number,
                 sha=None,
             )
+            self.assertEqual(response.code, 202)
         else:
             compute_lint_message.assert_called_once_with(
                 "conda-forge", "staged-recipes", PR_number, True
@@ -411,6 +414,7 @@ class TestBucketHandler(TestHandlerBase):
                 {"message": mock.sentinel.message},
                 target_url=mock.sentinel.html_url,
             )
+            self.assertEqual(response.code, 200)
 
     @mock.patch(
         "conda_forge_webservices.linting.lint_via_github_actions",
@@ -460,14 +464,15 @@ class TestBucketHandler(TestHandlerBase):
             },
         )
 
-        self.assertEqual(response.code, 200)
         if linting.LINT_VIA_GHA:
             lint_via_gha.assert_called_once_with(
                 "conda-forge/staged-recipes",
                 PR_number,
                 sha=sha,
             )
+            self.assertEqual(response.code, 202)
         else:
+            self.assertEqual(response.code, 200)
             assert False, "Cannot process merge group events without GHA linting"
 
     @mock.patch(
@@ -514,7 +519,7 @@ class TestBucketHandler(TestHandlerBase):
             },
         )
 
-        self.assertEqual(response.code, 200)
+        self.assertEqual(response.code, 204)
         compute_lint_message.assert_not_called()
 
         comment_on_pr.assert_not_called()
@@ -526,10 +531,10 @@ class TestBucketHandler(TestHandlerBase):
         hook = "/conda-forge-teams/update"
 
         for token, feedstock, expected_code in [
-            (os.environ["CF_WEBSERVICES_TOKEN"], "repo-feedstock", 200),
-            ("dummy", "repo-feedstock", 404),
-            (os.environ["CF_WEBSERVICES_TOKEN"], None, 404),
-            (None, "repo-feedstock", 404),
+            (os.environ["CF_WEBSERVICES_TOKEN"], "repo-feedstock", 202),
+            ("dummy", "repo-feedstock", 401),
+            (os.environ["CF_WEBSERVICES_TOKEN"], None, 204),
+            (None, "repo-feedstock", 401),
         ]:
             if feedstock is not None:
                 body = {"feedstock": feedstock}

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -1,3 +1,14 @@
+"""the main webserver event handlers and IO loop.
+
+We use the following HTTP status codes for events:
+
+- 400: used for failed output uploads
+- 401: used if the webhook event fails validation w/ the webhook secret
+- 200: used for an event that is successfully processed completely
+- 202: used for events that launch a background task, but are not done processing
+- 204: used for unhandled webhook events
+"""
+
 import functools
 import time
 import os
@@ -194,7 +205,9 @@ class WriteErrorAsJSONRequestHandler(tornado.web.RequestHandler):
     """The write_error method below was pulled from jupyter under
     the license below.
 
-    https://github.com/jupyter-server/jupyter_server/blob/132cf044cc969fb70063666919b4d9ad3349c5d1/jupyter_server/base/handlers.py#L756-L776
+    https://github.com/jupyter-server/jupyter_server
+    /blob/132cf044cc969fb70063666919b4d9ad3349c5d1/jupyter_server
+    /base/handlers.py#L756-L776
 
     BSD 3-Clause License
 
@@ -264,8 +277,8 @@ class LintingHookHandler(WriteErrorAsJSONRequestHandler):
             self.request.body,
             headers.get("X-Hub-Signature", ""),
         ):
-            self.set_status(403)
-            self.write_error(403)
+            self.set_status(401)
+            self.write_error(401)
             return
 
         if event == "ping":
@@ -283,8 +296,7 @@ class LintingHookHandler(WriteErrorAsJSONRequestHandler):
                     or repo_name != "staged-recipes"
                 ):
                     # only do merge group events for staged recipes
-                    self.set_status(404)
-                    self.write_error(404)
+                    self.set_status(204)
                     return
                 else:
                     # format is
@@ -295,72 +307,85 @@ class LintingHookHandler(WriteErrorAsJSONRequestHandler):
                     )
                     is_open = True
 
-            if owner != "conda-forge" or not (
-                repo_name == "staged-recipes" or repo_name.endswith("-feedstock")
-            ):
-                self.set_status(404)
-                self.write_error(404)
+            # we skip events where
+            #
+            # - the PR is closed
+            # - the org is not conda-forge
+            # - the repo is not staged-recipes or a feedstock
+            # - the PR is not updated in content
+            # - the repo is staged-recipes and the PR has a 'stale' label
+
+            if not is_open:
+                self.set_status(204)
+                return
+
+            if owner != "conda-forge":
+                self.set_status(204)
+                return
+
+            if not (repo_name == "staged-recipes" or repo_name.endswith("-feedstock")):
+                self.set_status(204)
                 return
 
             if event == "pull_request" and (
                 body["action"] not in ["opened", "reopened", "synchronize", "unlocked"]
             ):
-                self.set_status(404)
-                self.write_error(404)
+                self.set_status(204)
                 return
 
-            if event == "pull_request" and repo_name == "staged-recipes":
-                stale = any(
+            if (
+                event == "pull_request"
+                and repo_name == "staged-recipes"
+                and any(
                     label["name"] == "stale" for label in body["pull_request"]["labels"]
                 )
+            ):
+                self.set_status(204)
+                return
+
+            if linting.LINT_VIA_GHA:
+                # for merge groups, we pass the SHA of the merge commit
+                tornado.ioloop.IOLoop.current().spawn_callback(
+                    _run_gha_linting_pure_args,
+                    body["repository"]["full_name"],
+                    pr_id,
+                    None
+                    if event == "pull_request"
+                    else body["merge_group"]["head_sha"],
+                )
+                self.set_status(202)
             else:
-                stale = False
+                log_title_and_message_at_level(
+                    level="info",
+                    title=f"linting: {body['repository']['full_name']}#{pr_id}",
+                )
 
-            # Only do anything if we are working with conda-forge,
-            # and an open PR.
-            if is_open and owner == "conda-forge" and not stale:
-                if linting.LINT_VIA_GHA:
-                    # for merge groups, we pass the SHA of the merge commit
-                    tornado.ioloop.IOLoop.current().spawn_callback(
-                        _run_gha_linting_pure_args,
-                        body["repository"]["full_name"],
-                        pr_id,
-                        None
-                        if event == "pull_request"
-                        else body["merge_group"]["head_sha"],
-                    )
-                else:
-                    log_title_and_message_at_level(
-                        level="info",
-                        title=f"linting: {body['repository']['full_name']}#{pr_id}",
-                    )
-
-                    lint_info = await tornado.ioloop.IOLoop.current().run_in_executor(
-                        _worker_pool("command"),
-                        linting.compute_lint_message,
+                lint_info = await tornado.ioloop.IOLoop.current().run_in_executor(
+                    _worker_pool("command"),
+                    linting.compute_lint_message,
+                    owner,
+                    repo_name,
+                    pr_id,
+                    repo_name == "staged-recipes",
+                )
+                if lint_info:
+                    msg = linting.comment_on_pr(
                         owner,
                         repo_name,
                         pr_id,
-                        repo_name == "staged-recipes",
+                        lint_info["message"],
+                        search="conda-forge-linting service",
                     )
-                    if lint_info:
-                        msg = linting.comment_on_pr(
-                            owner,
-                            repo_name,
-                            pr_id,
-                            lint_info["message"],
-                            search="conda-forge-linting service",
-                        )
-                        linting.set_pr_status(
-                            owner,
-                            repo_name,
-                            lint_info,
-                            target_url=msg.html_url,
-                        )
+                    linting.set_pr_status(
+                        owner,
+                        repo_name,
+                        lint_info,
+                        target_url=msg.html_url,
+                    )
+                self.set_status(200)
         else:
             LOGGER.info(f'Unhandled event "{event}".')
-            self.set_status(404)
-            self.write_error(404)
+            self.set_status(204)
 
 
 def _staged_recipes_label_pure_args(
@@ -385,8 +410,8 @@ class StagedRecipesLabelerHandler(WriteErrorAsJSONRequestHandler):
             self.request.body,
             headers.get("X-Hub-Signature", ""),
         ):
-            self.set_status(403)
-            self.write_error(403)
+            self.set_status(401)
+            self.write_error(401)
             return
 
         if event == "ping":
@@ -434,6 +459,7 @@ class StagedRecipesLabelerHandler(WriteErrorAsJSONRequestHandler):
                 or (not is_pr)
                 or (not is_open)
             ):
+                self.set_status(204)
                 return
 
             log_title_and_message_at_level(
@@ -455,11 +481,10 @@ class StagedRecipesLabelerHandler(WriteErrorAsJSONRequestHandler):
                 comment,
                 label,
             )
-
+            self.set_status(202)
         else:
             LOGGER.info(f'Unhandled event "{event}".')
-            self.set_status(404)
-            self.write_error(404)
+            self.set_status(204)
 
 
 def _complete_future(fut):
@@ -478,13 +503,12 @@ class UpdateFeedstockHookHandler(WriteErrorAsJSONRequestHandler):
             self.request.body,
             headers.get("X-Hub-Signature", ""),
         ):
-            self.set_status(403)
-            self.write_error(403)
+            self.set_status(401)
+            self.write_error(401)
             return
 
         if event == "ping":
             self.write("pong")
-            return
         elif event == "push":
             body = tornado.escape.json_decode(self.request.body)
             repo_name = body["repository"]["name"]
@@ -514,12 +538,12 @@ class UpdateFeedstockHookHandler(WriteErrorAsJSONRequestHandler):
                     repo_name,
                 )
                 tornado.ioloop.IOLoop.current().add_future(handled, _complete_future)
-                return
+                self.set_status(202)
+            else:
+                self.set_status(204)
         else:
             LOGGER.info(f'Unhandled event "{event}".')
-
-        self.set_status(404)
-        self.write_error(404)
+            self.set_status(204)
 
 
 class UpdateTeamHookHandler(WriteErrorAsJSONRequestHandler):
@@ -531,13 +555,12 @@ class UpdateTeamHookHandler(WriteErrorAsJSONRequestHandler):
             self.request.body,
             headers.get("X-Hub-Signature", ""),
         ):
-            self.set_status(403)
-            self.write_error(403)
+            self.set_status(401)
+            self.write_error(401)
             return
 
         if event == "ping":
             self.write("pong")
-            return
         elif event == "push":
             body = tornado.escape.json_decode(self.request.body)
             repo_name = body["repository"]["name"]
@@ -569,12 +592,12 @@ class UpdateTeamHookHandler(WriteErrorAsJSONRequestHandler):
                     commit,
                 )
                 tornado.ioloop.IOLoop.current().add_future(fut, _complete_future)
-                return
+                self.set_status(202)
+            else:
+                self.set_status(204)
         else:
             LOGGER.info(f'Unhandled event "{event}".')
-
-        self.set_status(404)
-        self.write_error(404)
+            self.set_status(204)
 
 
 class CommandHookHandler(WriteErrorAsJSONRequestHandler):
@@ -590,13 +613,12 @@ class CommandHookHandler(WriteErrorAsJSONRequestHandler):
             self.request.body,
             headers.get("X-Hub-Signature", ""),
         ):
-            self.set_status(403)
-            self.write_error(403)
+            self.set_status(401)
+            self.write_error(401)
             return
 
         if event == "ping":
             self.write("pong")
-            return
         elif (
             event == "pull_request_review"
             or event == "pull_request"
@@ -611,8 +633,7 @@ class CommandHookHandler(WriteErrorAsJSONRequestHandler):
                 repo_name in ALLOWED_CMD_NON_FEEDSTOCKS
                 or repo_name.endswith("-feedstock")
             ):
-                self.set_status(404)
-                self.write_error(404)
+                self.set_status(204)
                 return
 
             pr_repo = body["pull_request"]["head"]["repo"]
@@ -653,7 +674,9 @@ class CommandHookHandler(WriteErrorAsJSONRequestHandler):
                     review_id,
                 )
                 tornado.ioloop.IOLoop.current().add_future(fut, _complete_future)
-                return
+                self.set_status(202)
+            else:
+                self.set_status(204)
 
         elif event == "issue_comment" or event == "issues":
             body = tornado.escape.json_decode(self.request.body)
@@ -667,68 +690,72 @@ class CommandHookHandler(WriteErrorAsJSONRequestHandler):
                 repo_name in ALLOWED_CMD_NON_FEEDSTOCKS
                 or repo_name.endswith("-feedstock")
             ):
-                self.set_status(404)
-                self.write_error(404)
+                self.set_status(204)
                 return
+
             pull_request = False
             if "pull_request" in body["issue"]:
                 pull_request = True
-            if pull_request and action != "deleted":
-                comment = body["comment"]["body"]
-                comment_id = body["comment"]["id"]
-                log_title_and_message_at_level(
-                    level="info",
-                    title=f"PR command: {body['repository']['full_name']}",
-                )
 
-                fut = tornado.ioloop.IOLoop.current().run_in_executor(
-                    _worker_pool("command"),
-                    commands.pr_comment,
-                    owner,
-                    repo_name,
-                    issue_num,
-                    comment,
-                    comment_id,
-                )
-                tornado.ioloop.IOLoop.current().add_future(fut, _complete_future)
-                return
-
-            if not pull_request and action in [
-                "opened",
-                "edited",
-                "created",
-                "reopened",
-            ]:
-                title = body["issue"]["title"] if event == "issues" else ""
-                if "comment" in body:
+            if pull_request:
+                if action != "deleted":
                     comment = body["comment"]["body"]
                     comment_id = body["comment"]["id"]
+                    log_title_and_message_at_level(
+                        level="info",
+                        title=f"PR command: {body['repository']['full_name']}",
+                    )
+
+                    fut = tornado.ioloop.IOLoop.current().run_in_executor(
+                        _worker_pool("command"),
+                        commands.pr_comment,
+                        owner,
+                        repo_name,
+                        issue_num,
+                        comment,
+                        comment_id,
+                    )
+                    tornado.ioloop.IOLoop.current().add_future(fut, _complete_future)
+                    self.set_status(202)
                 else:
-                    comment = body["issue"]["body"]
-                    comment_id = -1  # will react to issue/PR description #issue_num
+                    self.set_status(204)
+            else:
+                if action in [
+                    "opened",
+                    "edited",
+                    "created",
+                    "reopened",
+                ]:
+                    title = body["issue"]["title"] if event == "issues" else ""
+                    if "comment" in body:
+                        comment = body["comment"]["body"]
+                        comment_id = body["comment"]["id"]
+                    else:
+                        comment = body["issue"]["body"]
+                        comment_id = -1  # will react to issue/PR description #issue_num
 
-                log_title_and_message_at_level(
-                    level="info",
-                    title=f"issue command: {body['repository']['full_name']}",
-                )
+                    log_title_and_message_at_level(
+                        level="info",
+                        title=f"issue command: {body['repository']['full_name']}",
+                    )
 
-                fut = tornado.ioloop.IOLoop.current().run_in_executor(
-                    _worker_pool("command"),
-                    commands.issue_comment,
-                    owner,
-                    repo_name,
-                    issue_num,
-                    title,
-                    comment,
-                    comment_id,
-                )
-                tornado.ioloop.IOLoop.current().add_future(fut, _complete_future)
-                return
-
+                    fut = tornado.ioloop.IOLoop.current().run_in_executor(
+                        _worker_pool("command"),
+                        commands.issue_comment,
+                        owner,
+                        repo_name,
+                        issue_num,
+                        title,
+                        comment,
+                        comment_id,
+                    )
+                    tornado.ioloop.IOLoop.current().add_future(fut, _complete_future)
+                    self.set_status(202)
+                else:
+                    self.set_status(204)
         else:
             LOGGER.info(f'Unhandled event "{event}".')
-        self.set_status(404)
-        self.write_error(404)
+            self.set_status(204)
 
 
 def _get_current_versions():
@@ -942,7 +969,7 @@ def _run_single_copy_job(
                 {},
             )
 
-        return 403, None
+        return 400, None
     else:
         staging_label = STAGING_LABEL + "-h" + uuid.uuid4().hex
         (
@@ -962,7 +989,7 @@ def _run_single_copy_job(
         )
 
         if not all(v for v in copied.values()):
-            status = 403
+            status = 400
         else:
             status = 200
 
@@ -1124,8 +1151,8 @@ class AutotickBotPayloadHookHandler(WriteErrorAsJSONRequestHandler):
             self.request.body,
             headers.get("X-Hub-Signature", ""),
         ):
-            self.set_status(403)
-            self.write_error(403)
+            self.set_status(401)
+            self.write_error(401)
             return
 
         if event == "ping":
@@ -1147,6 +1174,10 @@ class AutotickBotPayloadHookHandler(WriteErrorAsJSONRequestHandler):
                     "pr",
                     body["pull_request"]["id"],
                 )
+                self.set_status(202)
+            else:
+                self.set_status(204)
+
             return
         elif event == "push":
             repo_name = body["repository"]["name"]
@@ -1171,13 +1202,14 @@ class AutotickBotPayloadHookHandler(WriteErrorAsJSONRequestHandler):
                     "push",
                     repo_name.rsplit("-feedstock", 1)[0],
                 )
+                self.set_status(202)
+            else:
+                self.set_status(204)
 
             return
         else:
             LOGGER.info(f'Unhandled event "{event}".')
-
-        self.set_status(404)
-        self.write_error(404)
+            self.set_status(204)
 
 
 def _dispatch_automerge_job(repo, sha):
@@ -1230,8 +1262,8 @@ class StatusMonitorPayloadHookHandler(WriteErrorAsJSONRequestHandler):
             self.request.body,
             headers.get("X-Hub-Signature", ""),
         ):
-            self.set_status(403)
-            self.write_error(403)
+            self.set_status(401)
+            self.write_error(401)
             return
 
         if event == "ping":
@@ -1267,6 +1299,9 @@ class StatusMonitorPayloadHookHandler(WriteErrorAsJSONRequestHandler):
                     body["repository"]["name"],
                     body["check_suite"]["head_sha"],
                 )
+                self.set_status(202)
+            else:
+                self.set_status(204)
 
             return
         elif event == "status":
@@ -1285,6 +1320,7 @@ class StatusMonitorPayloadHookHandler(WriteErrorAsJSONRequestHandler):
                     body["repository"]["name"],
                     body["sha"],
                 )
+                self.set_status(202)
 
             return
         elif event in ["pull_request", "pull_request_review"]:
@@ -1302,12 +1338,14 @@ class StatusMonitorPayloadHookHandler(WriteErrorAsJSONRequestHandler):
                     body["repository"]["name"],
                     body["pull_request"]["head"]["sha"],
                 )
+                self.set_status(202)
+            else:
+                self.set_status(204)
+
             return
         else:
             LOGGER.info(f'Unhandled event "{event}".')
-
-        self.set_status(404)
-        self.write_error(404)
+            self.set_status(204)
 
 
 class StatusMonitorAzureHandler(WriteErrorAsJSONRequestHandler):
@@ -1370,10 +1408,12 @@ class UpdateTeamsEndpointHandler(WriteErrorAsJSONRequestHandler):
                     None,
                 )
                 tornado.ioloop.IOLoop.current().add_future(fut, _complete_future)
-                return
-
-        self.set_status(404)
-        self.write_error(404)
+                self.set_status(202)
+            else:
+                self.set_status(204)
+        else:
+            self.set_status(401)
+            self.write_error(401)
 
 
 def create_webapp():

--- a/scripts/test_cfep13_endpoints.py
+++ b/scripts/test_cfep13_endpoints.py
@@ -95,7 +95,7 @@ def test_feedstock_outputs_copy_bad_token():
         },
     )
 
-    assert r.status_code == 403, r.status_code
+    assert r.status_code == 400, r.status_code
 
 
 @pytest.mark.skipif(headers is None, reason="No feedstock token for testing!")
@@ -113,7 +113,7 @@ def test_feedstock_outputs_copy_missing_token():
         },
     )
 
-    assert r.status_code == 403, r.status_code
+    assert r.status_code == 400, r.status_code
 
 
 @pytest.mark.skipif(headers is None, reason="No feedstock token for testing!")
@@ -131,7 +131,7 @@ def test_feedstock_outputs_copy_missing_data(key):
         headers=headers,
         json=json_data,
     )
-    assert r.status_code == 403, r.status_code
+    assert r.status_code == 400, r.status_code
 
 
 @pytest.mark.skipif(headers is None, reason="No feedstock token for testing!")
@@ -152,7 +152,7 @@ def test_feedstock_outputs_copy_bad_hash():
             headers=headers,
             json=json_data,
         )
-        assert r.status_code == 403, r.status_code
+        assert r.status_code == 400, r.status_code
     finally:
         _clone_and_remove(OUTPUTS_REPO, f"outputs/b/l/a/{name}.json")
 
@@ -174,6 +174,6 @@ def test_feedstock_outputs_copy_bad_data():
             headers=headers,
             json=json_data,
         )
-        assert r.status_code == 403, r.status_code
+        assert r.status_code == 400, r.status_code
     finally:
         _clone_and_remove(OUTPUTS_REPO, f"outputs/b/l/a/{name}.json")


### PR DESCRIPTION
### Description

This PR changes the HTTP codes so that we only return 4XX codes for failed authentication issues or bad output copies. We were returning 404 for unhandled webhook events, but GitHub does not recommend this. By making this change, we can use GitHub's API endpoints for webhooks to periodically retry failed webhooks.

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
