### PR TITLE
feat: set status and job url for version updates; change PR title to chore...

### DIFF
--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -1159,6 +1159,7 @@ def update_version(full_name, pr_num, input_ver):
             "container_tag": ref,
             "requested_version": str(input_ver) or "null",
             "uuid": uid,
+            "sha": sha,
         },
     )
 

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -555,7 +555,7 @@ def issue_comment(org_name, repo_name, issue_num, title, comment, comment_id=Non
                     m = UPDATE_VERSION.search(comment)
                     input_ver = m.group("ver")
 
-                pr_title = "ENH: update package version"
+                pr_title = "chore: update package version"
                 comment_msg = "started a version update"
                 to_close = UPDATE_VERSION.search(title)
                 check_bump_build = False
@@ -1109,9 +1109,37 @@ def rerender(full_name, pr_num):
     return not running
 
 
+def set_version_update_pr_status(repo, pr_num, status, target_url=None, sha=None):
+    if target_url is not None:
+        kwargs = {"target_url": target_url}
+    else:
+        kwargs = {}
+
+    if sha is None:
+        pull = repo.get_pull(int(pr_num))
+        sha = pull.head.sha
+    commit = repo.get_commit(sha)
+
+    if status == "success":
+        msg = "Version update successful."
+    elif status == "failure" or status == "error":
+        msg = "Version update failed."
+    else:
+        msg = "Version update in progress..."
+
+    commit.create_status(
+        status,
+        description=msg,
+        context="conda-forge-version-update-service",
+        **kwargs,
+    )
+
+
 def update_version(full_name, pr_num, input_ver):
     gh = get_gh_client()
     repo = gh.get_repo(full_name)
+    pull = repo.get_pull(int(pr_num))
+    sha = pull.head.sha
 
     inject_app_token_into_feedstock(full_name, repo=repo)
     inject_app_token_into_feedstock_readonly(full_name, repo=repo)
@@ -1133,6 +1161,18 @@ def update_version(full_name, pr_num, input_ver):
             "uuid": uid,
         },
     )
+
+    if running:
+        run = get_workflow_run_from_uid(workflow, uid, ref)
+        if run:
+            target_url = run.html_url
+        else:
+            target_url = None
+
+        set_version_update_pr_status(
+            repo, pr_num, "pending", target_url=target_url, sha=sha
+        )
+
     return not running
 
 

--- a/conda_forge_webservices/github_actions_integration/__main__.py
+++ b/conda_forge_webservices/github_actions_integration/__main__.py
@@ -30,7 +30,10 @@ from .linting import (
     get_recipes_for_linting,
 )
 from .version_updating import update_version, update_pr_title
-from conda_forge_webservices.commands import set_rerender_pr_status
+from conda_forge_webservices.commands import (
+    set_rerender_pr_status,
+    set_version_update_pr_status,
+)
 
 
 LOGGER = logging.getLogger(__name__)
@@ -130,7 +133,7 @@ def main_run_task(
 
         if version_changed:
             task_data["task_results"]["commit_message"] = (
-                f"ENH: updated version to {new_version}"
+                f"chore: update version to {new_version}"
             )
 
             rerender_changed, rerender_error, info_message, commit_message = rerender(
@@ -422,6 +425,18 @@ def main_finalize_task(task_data_dir):
                 pr_repo=pr_repo,
                 repo_name=full_repo_name,
                 close_pr_if_no_changes_or_errors=True,
+            )
+            status = "success" if not comment_push_error else "failure"
+            target_url = (
+                f"https://github.com/conda-forge/conda-forge-webservices/"
+                f"actions/runs/{os.environ['GITHUB_RUN_ID']}"
+            )
+            set_version_update_pr_status(
+                gh_repo,
+                int(pr_number),
+                status,
+                target_url=target_url,
+                sha=sha_for_status,
             )
 
             # we always do this for versions

--- a/conda_forge_webservices/github_actions_integration/version_updating.py
+++ b/conda_forge_webservices/github_actions_integration/version_updating.py
@@ -161,7 +161,7 @@ def update_pr_title(
         )
         return False, True
 
-    if pr.title == "ENH: update package version":  # user didn't change the default
+    if pr.title == "chore: update package version":  # user didn't change the default
         try:
             pr.edit(title=f"{pr.title} to {found_version}")
             return True, False

--- a/tests/test_live_version_update.py
+++ b/tests/test_live_version_update.py
@@ -11,6 +11,11 @@ from flaky import flaky
 import conda_forge_webservices
 from conda_forge_webservices.utils import pushd
 from conftest import _merge_main_to_branch
+from conda_forge_webservices.commands import (
+    get_workflow_run_from_uid,
+    set_version_update_pr_status,
+)
+from conda_forge_webservices import __version__
 
 REPO_OWNER = "conda-forge"
 REPO_NAME = "cf-autotick-bot-test-package-feedstock"
@@ -177,10 +182,11 @@ def _version_update_is_ok(version, verbose=False):
 
 def _run_test(branch, version):
     print("sending workflow dispatch event to version updater...", flush=True)
+    pr_head_sha = GH.get_repo(REPO).get_pull(PR_NUM).head.sha
     uid = uuid.uuid4().hex
     repo = GH.get_repo("conda-forge/conda-forge-webservices")
     workflow = repo.get_workflow("webservices-workflow-dispatch.yml")
-    workflow.create_dispatch(
+    running = workflow.create_dispatch(
         ref=branch,
         inputs={
             "task": "version_update",
@@ -189,9 +195,20 @@ def _run_test(branch, version):
             "container_tag": conda_forge_webservices.__version__.replace("+", "."),
             "requested_version": version or "null",
             "uuid": uid,
-            "sha": GH.get_repo(REPO).get_pull(PR_NUM).head.sha,
+            "sha": pr_head_sha,
         },
     )
+
+    if running:
+        run = get_workflow_run_from_uid(workflow, uid, __version__.replace("+", "."))
+        if run:
+            target_url = run.html_url
+        else:
+            target_url = None
+
+        set_version_update_pr_status(
+            GH.get_repo(REPO), PR_NUM, "pending", target_url=target_url, sha=pr_head_sha
+        )
 
     print(
         f"sleeping for {WAIT_TIME} seconds to let the version update happen...",

--- a/tests/test_live_version_update.py
+++ b/tests/test_live_version_update.py
@@ -156,14 +156,14 @@ def _version_update_is_ok(version, verbose=False):
                 output = c.stdout.decode("utf-8")
                 if verbose:
                     print("    last commit:", output.strip(), flush=True)
-                if not ("Re-" in output or "ENH:" in output):
+                if not ("Re-" in output or "chore:" in output):
                     return False
 
     if version:
-        if _pr_title() != f"ENH: update package version to {version}":
+        if _pr_title() != f"chore: update package version to {version}":
             return False
     else:
-        if "ENH: update package version to " not in _pr_title():
+        if "chore: update package version to " not in _pr_title():
             return False
 
     repo = GH.get_repo(REPO)
@@ -229,7 +229,7 @@ def _run_test_try_finally(branch, version):
                     _change_version(new_version="0.13", branch="main")
                     _merge_main_to_branch(BRANCH, verbose=True)
                     _change_version(new_version="0.13", branch=BRANCH)
-                    original_title = _pr_title(new="ENH: update package version")
+                    original_title = _pr_title(new="chore: update package version")
                     _set_pr_draft()
                     _run_test(branch, version)
                 finally:

--- a/tests/test_live_version_update.py
+++ b/tests/test_live_version_update.py
@@ -224,7 +224,15 @@ def _run_test(branch, version):
                 break
 
     print("checking repo for the version update...", flush=True)
-    assert _version_update_is_ok(version, verbose=True)
+    update_is_ok = _version_update_is_ok(version, verbose=True)
+    if not update_is_ok:
+        set_version_update_pr_status(
+            GH.get_repo(REPO),
+            PR_NUM,
+            "failed",
+            target_url=target_url,
+        )
+    assert update_is_ok
     print("tests passed!", flush=True)
 
 

--- a/tests/test_live_version_update.py
+++ b/tests/test_live_version_update.py
@@ -189,6 +189,7 @@ def _run_test(branch, version):
             "container_tag": conda_forge_webservices.__version__.replace("+", "."),
             "requested_version": version or "null",
             "uuid": uid,
+            "sha": GH.get_repo(REPO).get_pull(PR_NUM).head.sha,
         },
     )
 

--- a/tests/test_live_version_update.py
+++ b/tests/test_live_version_update.py
@@ -16,7 +16,7 @@ REPO_OWNER = "conda-forge"
 REPO_NAME = "cf-autotick-bot-test-package-feedstock"
 REPO = f"{REPO_OWNER}/{REPO_NAME}"
 BRANCH = "version-update-live-test"
-PR_NUM = 483
+PR_NUM = 1844
 GH = None
 WAIT_TIME = 300  # seconds
 


### PR DESCRIPTION
### Description

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->


This PR is a small quality-of-life fix that exposes the version update command job for users and changes the PR title to be less loud.