### PR TITLE
Reply to invalid bot commands in PR comments

### DIFF
--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -213,14 +213,18 @@ def pr_comment(org_name, repo_name, issue_num, comment, comment_id=None):
 def reply_no_command(
     org_name,
     repo_name,
-    pr_num,
+    issue_num,
     comment_id,
     review_id,
 ):
-    if comment_id is not None:
-        request = f"[request](https://github.com/{org_name}/{repo_name}/pull/{pr_num}#issuecomment-{comment_id})"
+    if comment_id == -1:
+        request = (
+            f"[request](https://github.com/{org_name}/{repo_name}/pull/{issue_num}#)"
+        )
+    elif comment_id is not None:
+        request = f"[request](https://github.com/{org_name}/{repo_name}/pull/{issue_num}#issuecomment-{comment_id})"
     elif review_id is not None:
-        request = f"[request](https://github.com/{org_name}/{repo_name}/pull/{pr_num}#discussion_r{review_id})"
+        request = f"[request](https://github.com/{org_name}/{repo_name}/pull/{issue_num}#discussion_r{review_id})"
     else:
         request = "request"
     no_command_message = textwrap.dedent(f"""
@@ -231,12 +235,13 @@ def reply_no_command(
     gh = get_gh_client()
     repo = gh.get_repo(f"{org_name}/{repo_name}")
     if comment_id is not None or review_id is not None:
-        add_reaction("confused", repo, pr_num, comment_id, review_id)
-    pull = repo.get_pull(int(pr_num))
+        add_reaction("confused", repo, issue_num, comment_id, review_id)
     if review_id is not None:
+        pull = repo.get_pull(int(issue_num))
         pull.create_review_comment_reply(review_id, no_command_message)
     else:
-        pull.create_issue_comment(no_command_message)
+        issue = repo.get_issue(int(issue_num))
+        issue.create_comment(no_command_message)
 
 
 def pr_detailed_comment(
@@ -481,6 +486,7 @@ def issue_comment(org_name, repo_name, issue_num, title, comment, comment_id=Non
     ]
 
     if not any(command.search(text) for command in issue_commands):
+        reply_no_command(org_name, repo_name, issue_num, comment_id, None)
         return
 
     # sometimes the webhook outpaces other bits of the API so we try a bit

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -231,7 +231,10 @@ def reply_no_command(
     if comment_id is not None or review_id is not None:
         add_reaction("confused", repo, pr_num, comment_id, review_id)
     pull = repo.get_pull(int(pr_num))
-    pull.create_issue_comment(no_command_message)
+    if review_id is not None:
+        pull.create_review_comment_reply(review_id, no_command_message)
+    else:
+        pull.create_issue_comment(no_command_message)
 
 
 def pr_detailed_comment(

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -212,6 +212,8 @@ def reply_no_command(
     org_name,
     repo_name,
     pr_num,
+    comment_id,
+    review_id,
 ):
     no_command_message = textwrap.dedent("""
         Hi! This is the friendly automated conda-forge-webservice.
@@ -220,6 +222,8 @@ def reply_no_command(
         """)  # ruff: ignore[line-too-long]
     gh = get_gh_client()
     repo = gh.get_repo(f"{org_name}/{repo_name}")
+    if comment_id is not None or review_id is not None:
+        add_reaction("confused", repo, pr_num, comment_id, review_id)
     pull = repo.get_pull(int(pr_num))
     pull.create_issue_comment(no_command_message)
 
@@ -316,7 +320,7 @@ def pr_detailed_comment(
     is_staged_recipes = repo_name == "staged-recipes"
     if not (repo_name.endswith("-feedstock") or is_staged_recipes):
         if not command_found:
-            reply_no_command(org_name, repo_name, pr_num)
+            reply_no_command(org_name, repo_name, pr_num, comment_id, review_id)
         return
 
     pr_commands = [LINT_MSG]
@@ -325,7 +329,7 @@ def pr_detailed_comment(
 
     if not any(command.search(comment) for command in pr_commands):
         if not command_found:
-            reply_no_command(org_name, repo_name, pr_num)
+            reply_no_command(org_name, repo_name, pr_num, comment_id, review_id)
         return
 
     if comment_id is not None or review_id is not None:

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -215,10 +215,16 @@ def reply_no_command(
     comment_id,
     review_id,
 ):
-    no_command_message = textwrap.dedent("""
+    if comment_id is not None:
+        request = f"[request](https://github.com/{org_name}/{repo_name}/pull/{pr_num}#issuecomment-{comment_id})"
+    elif review_id is not None:
+        request = f"[request](https://github.com/{org_name}/{repo_name}/pull/{pr_num}#discussion_r{review_id})"
+    else:
+        request = "request"
+    no_command_message = textwrap.dedent(f"""
         Hi! This is the friendly automated conda-forge-webservice.
 
-        I couldn't find any valid commands in the request. Please see [Admin web services](https://conda-forge.org/docs/maintainer/infrastructure/#admin-web-services) for the list of valid commands.
+        I couldn't find any valid commands in the {request}. Please see [Admin web services](https://conda-forge.org/docs/maintainer/infrastructure/#admin-web-services) for the list of valid commands.
         """)  # ruff: ignore[line-too-long]
     gh = get_gh_client()
     repo = gh.get_repo(f"{org_name}/{repo_name}")

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -208,6 +208,22 @@ def pr_comment(org_name, repo_name, issue_num, comment, comment_id=None):
     )
 
 
+def reply_no_command(
+    org_name,
+    repo_name,
+    pr_num,
+):
+    no_command_message = textwrap.dedent("""
+        Hi! This is the friendly automated conda-forge-webservice.
+
+        I couldn't find any valid commands in the request. Please see [Admin web services](https://conda-forge.org/docs/maintainer/infrastructure/#admin-web-services) for the list of valid commands.
+        """)  # ruff: ignore[line-too-long]
+    gh = get_gh_client()
+    repo = gh.get_repo(f"{org_name}/{repo_name}")
+    pull = repo.get_pull(int(pr_num))
+    pull.create_issue_comment(no_command_message)
+
+
 def pr_detailed_comment(
     org_name,
     repo_name,
@@ -219,12 +235,6 @@ def pr_detailed_comment(
     comment_id=None,
     review_id=None,
 ):
-    no_command_message = textwrap.dedent("""
-        Hi! This is the friendly automated conda-forge-webservice.
-
-        I couldn't find any valid commands in the request. Please see [Admin web services](https://conda-forge.org/docs/maintainer/infrastructure/#admin-web-services) for the list of valid commands.
-        """)  # ruff: ignore[line-too-long]
-
     is_allowed_cmd = repo_name in ALLOWED_CMD_NON_FEEDSTOCKS
     if not (repo_name.endswith("-feedstock") or is_allowed_cmd):
         return
@@ -306,10 +316,7 @@ def pr_detailed_comment(
     is_staged_recipes = repo_name == "staged-recipes"
     if not (repo_name.endswith("-feedstock") or is_staged_recipes):
         if not command_found:
-            gh = get_gh_client()
-            repo = gh.get_repo(f"{org_name}/{repo_name}")
-            pull = repo.get_pull(int(pr_num))
-            pull.create_issue_comment(no_command_message)
+            reply_no_command(org_name, repo_name, pr_num)
         return
 
     pr_commands = [LINT_MSG]
@@ -318,10 +325,7 @@ def pr_detailed_comment(
 
     if not any(command.search(comment) for command in pr_commands):
         if not command_found:
-            gh = get_gh_client()
-            repo = gh.get_repo(f"{org_name}/{repo_name}")
-            pull = repo.get_pull(int(pr_num))
-            pull.create_issue_comment(no_command_message)
+            reply_no_command(org_name, repo_name, pr_num)
         return
 
     if comment_id is not None or review_id is not None:

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -219,10 +219,17 @@ def pr_detailed_comment(
     comment_id=None,
     review_id=None,
 ):
+    no_command_message = textwrap.dedent("""
+        Hi! This is the friendly automated conda-forge-webservice.
+
+        I couldn't find any valid commands in the request. Please see [Admin web services](https://conda-forge.org/docs/maintainer/infrastructure/#admin-web-services) for the list of valid commands.
+        """)  # ruff: ignore[line-too-long]
+
     is_allowed_cmd = repo_name in ALLOWED_CMD_NON_FEEDSTOCKS
     if not (repo_name.endswith("-feedstock") or is_allowed_cmd):
         return
 
+    command_found = False
     if not is_allowed_cmd:
         gh = get_gh_client()
         repo = gh.get_repo(f"{org_name}/{repo_name}")
@@ -251,6 +258,7 @@ def pr_detailed_comment(
                 return
 
     if RESTART_CI.search(comment):
+        command_found = True
         gh = get_gh_client()
         repo = gh.get_repo(f"{org_name}/{repo_name}")
         if comment_id is not None or review_id is not None:
@@ -258,6 +266,7 @@ def pr_detailed_comment(
         restart_pull_request_ci(repo, int(pr_num))
 
     if PING_TEAM.search(comment):
+        command_found = True
         # get the team
         m = PING_TEAM.search(comment)
         if m.group("team"):
@@ -285,6 +294,7 @@ def pr_detailed_comment(
         pull.create_issue_comment(message)
 
     if not is_allowed_cmd and RERUN_BOT.search(comment):
+        command_found = True
         gh = get_gh_client()
         repo = gh.get_repo(f"{org_name}/{repo_name}")
         if comment_id is not None or review_id is not None:
@@ -295,6 +305,11 @@ def pr_detailed_comment(
     # below here we only allow staged recipes + feedstocks
     is_staged_recipes = repo_name == "staged-recipes"
     if not (repo_name.endswith("-feedstock") or is_staged_recipes):
+        if not command_found:
+            gh = get_gh_client()
+            repo = gh.get_repo(f"{org_name}/{repo_name}")
+            pull = repo.get_pull(int(pr_num))
+            pull.create_issue_comment(no_command_message)
         return
 
     pr_commands = [LINT_MSG]
@@ -302,6 +317,11 @@ def pr_detailed_comment(
         pr_commands += [ADD_NOARCH_MSG, RERENDER_MSG, UPDATE_CB3_MSG]
 
     if not any(command.search(comment) for command in pr_commands):
+        if not command_found:
+            gh = get_gh_client()
+            repo = gh.get_repo(f"{org_name}/{repo_name}")
+            pull = repo.get_pull(int(pr_num))
+            pull.create_issue_comment(no_command_message)
         return
 
     if comment_id is not None or review_id is not None:

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -216,15 +216,17 @@ def reply_no_command(
     issue_num,
     comment_id,
     review_id,
+    kind="pull",
 ):
     if comment_id == -1:
         request = (
-            f"[request](https://github.com/{org_name}/{repo_name}/pull/{issue_num}#)"
+            f"[request](https://github.com/{org_name}/{repo_name}/{kind}/{issue_num}#)"
         )
     elif comment_id is not None:
-        request = f"[request](https://github.com/{org_name}/{repo_name}/pull/{issue_num}#issuecomment-{comment_id})"
+        request = f"[request](https://github.com/{org_name}/{repo_name}/{kind}/{issue_num}#issuecomment-{comment_id})"
     elif review_id is not None:
-        request = f"[request](https://github.com/{org_name}/{repo_name}/pull/{issue_num}#discussion_r{review_id})"
+        assert kind == "pull"
+        request = f"[request](https://github.com/{org_name}/{repo_name}/{kind}/{issue_num}#discussion_r{review_id})"
     else:
         request = "request"
     no_command_message = textwrap.dedent(f"""
@@ -486,7 +488,9 @@ def issue_comment(org_name, repo_name, issue_num, title, comment, comment_id=Non
     ]
 
     if not any(command.search(text) for command in issue_commands):
-        reply_no_command(org_name, repo_name, issue_num, comment_id, None)
+        reply_no_command(
+            org_name, repo_name, issue_num, comment_id, None, kind="issues"
+        )
         return
 
     # sometimes the webhook outpaces other bits of the API so we try a bit

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -191,6 +191,8 @@ def _attempt_git_clone(repo_url, feedstock_dir, pr_branch=None):
 
 
 def pr_comment(org_name, repo_name, issue_num, comment, comment_id=None):
+    """Process a pull request comment"""
+
     if not COMMAND_PREFIX.search(comment):
         return
     gh = get_gh_client()
@@ -248,6 +250,14 @@ def pr_detailed_comment(
     comment_id=None,
     review_id=None,
 ):
+    """
+    Process a pull request, pull request comment or review.
+
+    For a pull request, comment is the body and comment_id is -1.
+    For a comment, comment is the comment and comment_id is its id.
+    For a review, comment is the review comment and review_id is its id.
+    """
+
     is_allowed_cmd = repo_name in ALLOWED_CMD_NON_FEEDSTOCKS
     if not (repo_name.endswith("-feedstock") or is_allowed_cmd):
         return
@@ -433,6 +443,12 @@ def pr_detailed_comment(
 
 
 def issue_comment(org_name, repo_name, issue_num, title, comment, comment_id=None):
+    """
+    Process an issue or an issue comment
+
+    For an issue, title is issue title, comment is its body and comment_id is -1.
+    For a comment, title is empty, comment is the comment and comment_id is its id.
+    """
     if not repo_name.endswith("-feedstock"):
         return
     if comment is None:

--- a/conda_forge_webservices/tests/test_commands.py
+++ b/conda_forge_webservices/tests/test_commands.py
@@ -25,18 +25,33 @@ def pr_detailed_comment(
     pr_owner="some-user",
     pr_branch="master",
     pr_num=1,
+    comment_id=None,
+    review_id=None,
 ):
     if pr_repo is None:
         pr_repo = repo_name
     return _pr_detailed_comment(
-        org_name, repo_name, pr_owner, pr_repo, pr_branch, pr_num, comment
+        org_name,
+        repo_name,
+        pr_owner,
+        pr_repo,
+        pr_branch,
+        pr_num,
+        comment,
+        comment_id,
+        review_id,
     )
 
 
 def issue_comment(
-    title, comment, issue_num=1, org_name="conda-forge", repo_name="python-feedstock"
+    title,
+    comment,
+    issue_num=1,
+    org_name="conda-forge",
+    repo_name="python-feedstock",
+    comment_id=None,
 ):
-    return _issue_comment(org_name, repo_name, issue_num, title, comment)
+    return _issue_comment(org_name, repo_name, issue_num, title, comment, comment_id)
 
 
 @pytest.fixture
@@ -623,6 +638,18 @@ def test_add_and_remove_user(pillow_feedstock):
 @mock.patch("conda_forge_webservices.commands.update_team")
 @mock.patch("conda_forge_webservices.commands.get_gh_client")
 @mock.patch("conda_forge_webservices.commands.Repo")
+@pytest.mark.parametrize(
+    "comment_id,review_id,path",
+    [
+        (None, None, "pull"),
+        (-1, None, "pull"),
+        (12345, None, "pull"),
+        (None, 12345, "pull"),
+        (None, None, "issues"),
+        (-1, None, "issues"),
+        (12345, None, "issues"),
+    ],
+)
 def test_pr_reply_to_invalid_command(
     repo,
     gh,
@@ -632,11 +659,45 @@ def test_pr_reply_to_invalid_command(
     rerender,
     add_bot_rerun_label,
     get_app_token_for_webservices_only,
+    comment_id: int | None,
+    review_id: int | None,
+    path: str,
 ):
-    pr_detailed_comment("@conda-forge-admin, please reply to this invalid command")
+    if path == "pull":
+        pr_detailed_comment(
+            "@conda-forge-admin, please reply to this invalid command",
+            pr_num=999,
+            comment_id=comment_id,
+            review_id=review_id,
+        )
+    elif path == "issues":
+        assert review_id is None
+        issue_comment(
+            "@conda-forge-admin, please reply to this invalid command",
+            "",
+            issue_num=999,
+            comment_id=comment_id,
+        )
+    else:
+        assert False, f"{path}"
+
     for command in (update_team, relint, make_noarch, rerender):
         command.assert_not_called()
-    issue_calls = gh.return_value.get_repo.return_value.get_issue.return_value
-    comment_calls = issue_calls.create_comment.mock_calls
+    if review_id is None:
+        issue_calls = gh.return_value.get_repo.return_value.get_issue.return_value
+        comment_calls = issue_calls.create_comment.mock_calls
+        arg_index = 0
+        if comment_id == -1:
+            expected_url = f"/{path}/999#"
+        elif comment_id is not None:
+            expected_url = f"/{path}/999#issuecomment-{comment_id}"
+        else:
+            expected_url = ""
+    else:
+        pull_calls = gh.return_value.get_repo.return_value.get_pull.return_value
+        comment_calls = pull_calls.create_review_comment_reply.mock_calls
+        arg_index = 1
+        expected_url = f"/{path}/999#discussion_r{review_id}"
     assert len(comment_calls) == 1
-    assert "find any valid commands" in comment_calls[0][1][0]
+    assert "find any valid commands" in comment_calls[0][1][arg_index]
+    assert expected_url in comment_calls[0][1][arg_index]

--- a/conda_forge_webservices/tests/test_commands.py
+++ b/conda_forge_webservices/tests/test_commands.py
@@ -180,8 +180,8 @@ def test_pr_command_triggers(
         print(msg, end=" " * 30 + "\r")
         pr_detailed_comment(msg)
         command.assert_called()
-        pull_calls = gh.return_value.get_repo.return_value.get_pull.return_value
-        comment_calls = pull_calls.create_issue_comment.mock_calls
+        issue_calls = gh.return_value.get_repo.return_value.get_issue.return_value
+        comment_calls = issue_calls.create_comment.mock_calls
         assert not any(
             "find any valid commands" in call[1][0] for call in comment_calls
         )
@@ -193,8 +193,8 @@ def test_pr_command_triggers(
         pr_detailed_comment(msg, repo_name="staged-recipes")
         if on_sr:
             command.assert_called()
-            pull_calls = gh.return_value.get_repo.return_value.get_pull.return_value
-            comment_calls = pull_calls.create_issue_comment.mock_calls
+            issue_calls = gh.return_value.get_repo.return_value.get_issue.return_value
+            comment_calls = issue_calls.create_comment.mock_calls
             assert not any(
                 "find any valid commands" in call[1][0] for call in comment_calls
             )
@@ -636,7 +636,7 @@ def test_pr_reply_to_invalid_command(
     pr_detailed_comment("@conda-forge-admin, please reply to this invalid command")
     for command in (update_team, relint, make_noarch, rerender):
         command.assert_not_called()
-    pull_calls = gh.return_value.get_repo.return_value.get_pull.return_value
-    comment_calls = pull_calls.create_issue_comment.mock_calls
+    issue_calls = gh.return_value.get_repo.return_value.get_issue.return_value
+    comment_calls = issue_calls.create_comment.mock_calls
     assert len(comment_calls) == 1
     assert "find any valid commands" in comment_calls[0][1][0]

--- a/conda_forge_webservices/tests/test_commands.py
+++ b/conda_forge_webservices/tests/test_commands.py
@@ -176,15 +176,28 @@ def test_pr_command_triggers(
 
     for msg in should:
         command.reset_mock()
+        gh.reset_mock()
         print(msg, end=" " * 30 + "\r")
         pr_detailed_comment(msg)
         command.assert_called()
+        pull_calls = gh.return_value.get_repo.return_value.get_pull.return_value
+        comment_calls = pull_calls.create_issue_comment.mock_calls
+        assert not any(
+            "find any valid commands" in call[1][0] for call in comment_calls
+        )
+        gh.reset_mock()
 
         command.reset_mock()
+        gh.reset_mock()
         print(msg, end=" " * 30 + "\r")
         pr_detailed_comment(msg, repo_name="staged-recipes")
         if on_sr:
             command.assert_called()
+            pull_calls = gh.return_value.get_repo.return_value.get_pull.return_value
+            comment_calls = pull_calls.create_issue_comment.mock_calls
+            assert not any(
+                "find any valid commands" in call[1][0] for call in comment_calls
+            )
         else:
             command.assert_not_called()
 
@@ -600,3 +613,30 @@ def test_add_and_remove_user(pillow_feedstock):
     assert remove_user(pillow_feedstock, "doesnotexist") is None
     assert "@doesnotexist" not in _read_codeowners_words(pillow_feedstock)
     assert "- doesnotexist" not in _read_recipe_stripped_lines(pillow_feedstock)
+
+
+@mock.patch("conda_forge_webservices.commands.get_app_token_for_webservices_only")
+@mock.patch("conda_forge_webservices.commands.add_bot_rerun_label")
+@mock.patch("conda_forge_webservices.commands.rerender")
+@mock.patch("conda_forge_webservices.commands.make_noarch")
+@mock.patch("conda_forge_webservices.commands.relint")
+@mock.patch("conda_forge_webservices.commands.update_team")
+@mock.patch("conda_forge_webservices.commands.get_gh_client")
+@mock.patch("conda_forge_webservices.commands.Repo")
+def test_pr_reply_to_invalid_command(
+    repo,
+    gh,
+    update_team,
+    relint,
+    make_noarch,
+    rerender,
+    add_bot_rerun_label,
+    get_app_token_for_webservices_only,
+):
+    pr_detailed_comment("@conda-forge-admin, please reply to this invalid command")
+    for command in (update_team, relint, make_noarch, rerender):
+        command.assert_not_called()
+    pull_calls = gh.return_value.get_repo.return_value.get_pull.return_value
+    comment_calls = pull_calls.create_issue_comment.mock_calls
+    assert len(comment_calls) == 1
+    assert "find any valid commands" in comment_calls[0][1][0]


### PR DESCRIPTION
### Description

Reply with a comment to apparent webservice requests that do not list any valid command. This helps people realize they've mistyped the command rather than having them wonder whether there is a problem with webservices right now.

So far covered just the PR comment branch. I don't exactly love my code, so I'd appreciate your suggestions on how to make this better.

Fixes #1429