### PR TITLE
fix: do nto run mq-ci-skip on forks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,10 @@ jobs:
       skip-check: ${{ steps.should-skip.outputs.should-skip }}
     runs-on: ubuntu-slim
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
       - name: get PR number
         id: pr-number
         # this appears to be busted now so using my own code based on the merge_group

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,13 +24,13 @@ jobs:
     steps:
       - name: check if we can skip the merge queue
         id: merge-queue-ci-skipper
-        if: !github.event.pull_request.head.repo.fork
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: cariad-tech/merge-queue-ci-skipper@cf80db21fc70244e36487acc531b3f1118889b0a
         with:
           secret: ${{ secrets.CF_ADMIN_GITHUB_TOKEN }}
       - name: fall back step for forks
         id: fall-back
-        if: github.event.pull_request.head.repo.fork
+        if: ${{ github.event.pull_request.head.repo.fork }}
         run: |
           "skip-check=false" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,18 +16,32 @@ defaults:
     shell: bash -leo pipefail {0}
 
 jobs:
-  check:
-    name: check if we can skip the merge queue
+  run-merge-queue-ci-skipper:
+    name: run-merge-queue-ci-skipper
     outputs:
-      skip-check: ${{ steps.should-skip.outputs.should-skip }}
+      mq-ci-skip-check: ${{ steps.merge-queue-ci-skipper.outputs.skip-check || steps.fall-back.outputs.skip-check }}
     runs-on: ubuntu-slim
     steps:
       - name: check if we can skip the merge queue
         id: merge-queue-ci-skipper
+        if: !github.event.pull_request.head.repo.fork
         uses: cariad-tech/merge-queue-ci-skipper@cf80db21fc70244e36487acc531b3f1118889b0a
         with:
           secret: ${{ secrets.CF_ADMIN_GITHUB_TOKEN }}
+      - name: fall back step for forks
+        id: fall-back
+        if: github.event.pull_request.head.repo.fork
+        run: |
+          "skip-check=false" >> "$GITHUB_OUTPUT"
 
+  check:
+    name: check if we can skip the merge queue
+    needs:
+      - run-merge-queue-ci-skipper
+    outputs:
+      skip-check: ${{ steps.should-skip.outputs.should-skip }}
+    runs-on: ubuntu-slim
+    steps:
       - name: get PR number
         id: pr-number
         # this appears to be busted now so using my own code based on the merge_group
@@ -77,7 +91,7 @@ jobs:
           echo "merge queue CI needs to run: ${MQ_CI_SKIP}"
           echo "should run: ${final_should_run}"
         env:
-          MQ_CI_SKIP: ${{ steps.merge-queue-ci-skipper.outputs.skip-check != 'true' }}
+          MQ_CI_SKIP: ${{ needs.run-merge-queue-ci-skipper.outputs.mq-ci-skip-check != 'true' }}
           PR_NUMBER: ${{ steps.pr-number.outputs.pr }}
           GH_TOKEN: ${{ secrets.CF_ADMIN_GITHUB_TOKEN }}
 


### PR DESCRIPTION
### Description

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->

As it says above...