### PR TITLE
testing for PR #1441

### DIFF
--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -190,7 +190,7 @@ def _attempt_git_clone(repo_url, feedstock_dir, pr_branch=None):
     return repo
 
 
-def pr_comment(org_name, repo_name, issue_num, comment, comment_id=None):
+def pr_comment(org_name, repo_name, issue_num, comment, comment_id=None, actor=None):
     """Process a pull request comment"""
 
     if not COMMAND_PREFIX.search(comment):
@@ -206,7 +206,8 @@ def pr_comment(org_name, repo_name, issue_num, comment, comment_id=None):
         pr.head.ref,
         issue_num,
         comment,
-        comment_id,
+        comment_id=comment_id,
+        actor=actor,
     )
 
 
@@ -240,23 +241,10 @@ def reply_no_command(
         add_reaction("confused", repo, issue_num, comment_id, review_id)
     if review_id is not None:
         pull = repo.get_pull(int(issue_num))
-        make_comment = True
-        for possible_comment in pull.get_single_review_comments(int(review_id)):
-            if "I couldn't find any valid commands in the" in possible_comment.body:
-                make_comment = False
-                break
-        if make_comment:
-            pull.create_review_comment_reply(review_id, no_command_message)
+        pull.create_review_comment_reply(review_id, no_command_message)
     else:
         issue = repo.get_issue(int(issue_num))
-        make_comment = True
-        for possible_comment in issue.get_comments():
-            if "I couldn't find any valid commands in the" in possible_comment.body:
-                make_comment = False
-                break
-
-        if make_comment:
-            issue.create_comment(no_command_message)
+        issue.create_comment(no_command_message)
 
 
 def pr_detailed_comment(
@@ -269,6 +257,7 @@ def pr_detailed_comment(
     comment,
     comment_id=None,
     review_id=None,
+    actor=None,
 ):
     """
     Process a pull request, pull request comment or review.
@@ -358,7 +347,10 @@ def pr_detailed_comment(
     # below here we only allow staged recipes + feedstocks
     is_staged_recipes = repo_name == "staged-recipes"
     if not (repo_name.endswith("-feedstock") or is_staged_recipes):
-        if not command_found:
+        if (not command_found) and actor not in [
+            "conda-forge-admin",
+            "conda-forge-bot",
+        ]:
             reply_no_command(org_name, repo_name, pr_num, comment_id, review_id)
         return
 
@@ -367,7 +359,10 @@ def pr_detailed_comment(
         pr_commands += [ADD_NOARCH_MSG, RERENDER_MSG, UPDATE_CB3_MSG]
 
     if not any(command.search(comment) for command in pr_commands):
-        if not command_found:
+        if (not command_found) and actor not in [
+            "conda-forge-admin",
+            "conda-forge-bot",
+        ]:
             reply_no_command(org_name, repo_name, pr_num, comment_id, review_id)
         return
 
@@ -462,7 +457,9 @@ def pr_detailed_comment(
             shutil.rmtree(tmp_dir)
 
 
-def issue_comment(org_name, repo_name, issue_num, title, comment, comment_id=None):
+def issue_comment(
+    org_name, repo_name, issue_num, title, comment, comment_id=None, actor=None
+):
     """
     Process an issue or an issue comment
 
@@ -500,7 +497,10 @@ def issue_comment(org_name, repo_name, issue_num, title, comment, comment_id=Non
         UPDATE_VERSION,
     ]
 
-    if not any(command.search(text) for command in issue_commands):
+    if (not any(command.search(text) for command in issue_commands)) and actor not in [
+        "conda-forge-admin",
+        "conda-forge-bot",
+    ]:
         reply_no_command(
             org_name, repo_name, issue_num, comment_id, None, kind="issues"
         )

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -240,10 +240,23 @@ def reply_no_command(
         add_reaction("confused", repo, issue_num, comment_id, review_id)
     if review_id is not None:
         pull = repo.get_pull(int(issue_num))
-        pull.create_review_comment_reply(review_id, no_command_message)
+        make_comment = False
+        for possible_comment in pull.get_single_review_comments(int(review_id)):
+            if "I couldn't find any valid commands in the" in possible_comment.body:
+                make_comment = False
+                break
+        if make_comment:
+            pull.create_review_comment_reply(review_id, no_command_message)
     else:
         issue = repo.get_issue(int(issue_num))
-        issue.create_comment(no_command_message)
+        make_comment = True
+        for possible_comment in issue.get_comments():
+            if "I couldn't find any valid commands in the" in possible_comment.body:
+                make_comment = False
+                break
+
+        if make_comment:
+            issue.create_comment(no_command_message)
 
 
 def pr_detailed_comment(

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -240,7 +240,7 @@ def reply_no_command(
         add_reaction("confused", repo, issue_num, comment_id, review_id)
     if review_id is not None:
         pull = repo.get_pull(int(issue_num))
-        make_comment = False
+        make_comment = True
         for possible_comment in pull.get_single_review_comments(int(review_id)):
             if "I couldn't find any valid commands in the" in possible_comment.body:
                 make_comment = False

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -191,6 +191,8 @@ def _attempt_git_clone(repo_url, feedstock_dir, pr_branch=None):
 
 
 def pr_comment(org_name, repo_name, issue_num, comment, comment_id=None):
+    """Process a pull request comment"""
+
     if not COMMAND_PREFIX.search(comment):
         return
     gh = get_gh_client()
@@ -208,6 +210,42 @@ def pr_comment(org_name, repo_name, issue_num, comment, comment_id=None):
     )
 
 
+def reply_no_command(
+    org_name,
+    repo_name,
+    issue_num,
+    comment_id,
+    review_id,
+    kind="pull",
+):
+    if comment_id == -1:
+        request = (
+            f"[request](https://github.com/{org_name}/{repo_name}/{kind}/{issue_num}#)"
+        )
+    elif comment_id is not None:
+        request = f"[request](https://github.com/{org_name}/{repo_name}/{kind}/{issue_num}#issuecomment-{comment_id})"
+    elif review_id is not None:
+        assert kind == "pull"
+        request = f"[request](https://github.com/{org_name}/{repo_name}/{kind}/{issue_num}#discussion_r{review_id})"
+    else:
+        request = "request"
+    no_command_message = textwrap.dedent(f"""
+        Hi! This is the friendly automated conda-forge-webservice.
+
+        I couldn't find any valid commands in the {request}. Please see [Admin web services](https://conda-forge.org/docs/maintainer/infrastructure/#admin-web-services) for the list of valid commands.
+        """)  # ruff: ignore[line-too-long]
+    gh = get_gh_client()
+    repo = gh.get_repo(f"{org_name}/{repo_name}")
+    if comment_id is not None or review_id is not None:
+        add_reaction("confused", repo, issue_num, comment_id, review_id)
+    if review_id is not None:
+        pull = repo.get_pull(int(issue_num))
+        pull.create_review_comment_reply(review_id, no_command_message)
+    else:
+        issue = repo.get_issue(int(issue_num))
+        issue.create_comment(no_command_message)
+
+
 def pr_detailed_comment(
     org_name,
     repo_name,
@@ -219,10 +257,19 @@ def pr_detailed_comment(
     comment_id=None,
     review_id=None,
 ):
+    """
+    Process a pull request, pull request comment or review.
+
+    For a pull request, comment is the body and comment_id is -1.
+    For a comment, comment is the comment and comment_id is its id.
+    For a review, comment is the review comment and review_id is its id.
+    """
+
     is_allowed_cmd = repo_name in ALLOWED_CMD_NON_FEEDSTOCKS
     if not (repo_name.endswith("-feedstock") or is_allowed_cmd):
         return
 
+    command_found = False
     if not is_allowed_cmd:
         gh = get_gh_client()
         repo = gh.get_repo(f"{org_name}/{repo_name}")
@@ -251,6 +298,7 @@ def pr_detailed_comment(
                 return
 
     if RESTART_CI.search(comment):
+        command_found = True
         gh = get_gh_client()
         repo = gh.get_repo(f"{org_name}/{repo_name}")
         if comment_id is not None or review_id is not None:
@@ -258,6 +306,7 @@ def pr_detailed_comment(
         restart_pull_request_ci(repo, int(pr_num))
 
     if PING_TEAM.search(comment):
+        command_found = True
         # get the team
         m = PING_TEAM.search(comment)
         if m.group("team"):
@@ -285,6 +334,7 @@ def pr_detailed_comment(
         pull.create_issue_comment(message)
 
     if not is_allowed_cmd and RERUN_BOT.search(comment):
+        command_found = True
         gh = get_gh_client()
         repo = gh.get_repo(f"{org_name}/{repo_name}")
         if comment_id is not None or review_id is not None:
@@ -295,6 +345,8 @@ def pr_detailed_comment(
     # below here we only allow staged recipes + feedstocks
     is_staged_recipes = repo_name == "staged-recipes"
     if not (repo_name.endswith("-feedstock") or is_staged_recipes):
+        if not command_found:
+            reply_no_command(org_name, repo_name, pr_num, comment_id, review_id)
         return
 
     pr_commands = [LINT_MSG]
@@ -302,6 +354,8 @@ def pr_detailed_comment(
         pr_commands += [ADD_NOARCH_MSG, RERENDER_MSG, UPDATE_CB3_MSG]
 
     if not any(command.search(comment) for command in pr_commands):
+        if not command_found:
+            reply_no_command(org_name, repo_name, pr_num, comment_id, review_id)
         return
 
     if comment_id is not None or review_id is not None:
@@ -396,6 +450,12 @@ def pr_detailed_comment(
 
 
 def issue_comment(org_name, repo_name, issue_num, title, comment, comment_id=None):
+    """
+    Process an issue or an issue comment
+
+    For an issue, title is issue title, comment is its body and comment_id is -1.
+    For a comment, title is empty, comment is the comment and comment_id is its id.
+    """
     if not repo_name.endswith("-feedstock"):
         return
     if comment is None:
@@ -428,6 +488,9 @@ def issue_comment(org_name, repo_name, issue_num, title, comment, comment_id=Non
     ]
 
     if not any(command.search(text) for command in issue_commands):
+        reply_no_command(
+            org_name, repo_name, issue_num, comment_id, None, kind="issues"
+        )
         return
 
     # sometimes the webhook outpaces other bits of the API so we try a bit

--- a/conda_forge_webservices/tests/test_commands.py
+++ b/conda_forge_webservices/tests/test_commands.py
@@ -664,10 +664,6 @@ def test_pr_reply_to_invalid_command(
     path: str,
 ):
     if path == "pull":
-        issue_calls = gh.return_value.get_repo.return_value.get_issue.return_value
-        issue_calls.get_comments.return_value = []
-        pull_calls = gh.return_value.get_repo.return_value.get_pull.return_value
-        pull_calls.get_single_review_comments.return_value = []
         pr_detailed_comment(
             "@conda-forge-admin, please reply to this invalid command",
             pr_num=999,
@@ -676,8 +672,6 @@ def test_pr_reply_to_invalid_command(
         )
     elif path == "issues":
         assert review_id is None
-        issue_calls = gh.return_value.get_repo.return_value.get_issue.return_value
-        issue_calls.get_comments.return_value = []
         issue_comment(
             "@conda-forge-admin, please reply to this invalid command",
             "",

--- a/conda_forge_webservices/tests/test_commands.py
+++ b/conda_forge_webservices/tests/test_commands.py
@@ -664,6 +664,8 @@ def test_pr_reply_to_invalid_command(
     path: str,
 ):
     if path == "pull":
+        issue_calls = gh.return_value.get_repo.return_value.get_issue.return_value
+        issue_calls.get_comments.return_value = []
         pull_calls = gh.return_value.get_repo.return_value.get_pull.return_value
         pull_calls.get_single_review_comments.return_value = []
         pr_detailed_comment(

--- a/conda_forge_webservices/tests/test_commands.py
+++ b/conda_forge_webservices/tests/test_commands.py
@@ -25,18 +25,33 @@ def pr_detailed_comment(
     pr_owner="some-user",
     pr_branch="master",
     pr_num=1,
+    comment_id=None,
+    review_id=None,
 ):
     if pr_repo is None:
         pr_repo = repo_name
     return _pr_detailed_comment(
-        org_name, repo_name, pr_owner, pr_repo, pr_branch, pr_num, comment
+        org_name,
+        repo_name,
+        pr_owner,
+        pr_repo,
+        pr_branch,
+        pr_num,
+        comment,
+        comment_id,
+        review_id,
     )
 
 
 def issue_comment(
-    title, comment, issue_num=1, org_name="conda-forge", repo_name="python-feedstock"
+    title,
+    comment,
+    issue_num=1,
+    org_name="conda-forge",
+    repo_name="python-feedstock",
+    comment_id=None,
 ):
-    return _issue_comment(org_name, repo_name, issue_num, title, comment)
+    return _issue_comment(org_name, repo_name, issue_num, title, comment, comment_id)
 
 
 @pytest.fixture
@@ -176,15 +191,28 @@ def test_pr_command_triggers(
 
     for msg in should:
         command.reset_mock()
+        gh.reset_mock()
         print(msg, end=" " * 30 + "\r")
         pr_detailed_comment(msg)
         command.assert_called()
+        issue_calls = gh.return_value.get_repo.return_value.get_issue.return_value
+        comment_calls = issue_calls.create_comment.mock_calls
+        assert not any(
+            "find any valid commands" in call[1][0] for call in comment_calls
+        )
+        gh.reset_mock()
 
         command.reset_mock()
+        gh.reset_mock()
         print(msg, end=" " * 30 + "\r")
         pr_detailed_comment(msg, repo_name="staged-recipes")
         if on_sr:
             command.assert_called()
+            issue_calls = gh.return_value.get_repo.return_value.get_issue.return_value
+            comment_calls = issue_calls.create_comment.mock_calls
+            assert not any(
+                "find any valid commands" in call[1][0] for call in comment_calls
+            )
         else:
             command.assert_not_called()
 
@@ -600,3 +628,76 @@ def test_add_and_remove_user(pillow_feedstock):
     assert remove_user(pillow_feedstock, "doesnotexist") is None
     assert "@doesnotexist" not in _read_codeowners_words(pillow_feedstock)
     assert "- doesnotexist" not in _read_recipe_stripped_lines(pillow_feedstock)
+
+
+@mock.patch("conda_forge_webservices.commands.get_app_token_for_webservices_only")
+@mock.patch("conda_forge_webservices.commands.add_bot_rerun_label")
+@mock.patch("conda_forge_webservices.commands.rerender")
+@mock.patch("conda_forge_webservices.commands.make_noarch")
+@mock.patch("conda_forge_webservices.commands.relint")
+@mock.patch("conda_forge_webservices.commands.update_team")
+@mock.patch("conda_forge_webservices.commands.get_gh_client")
+@mock.patch("conda_forge_webservices.commands.Repo")
+@pytest.mark.parametrize(
+    "comment_id,review_id,path",
+    [
+        (None, None, "pull"),
+        (-1, None, "pull"),
+        (12345, None, "pull"),
+        (None, 12345, "pull"),
+        (None, None, "issues"),
+        (-1, None, "issues"),
+        (12345, None, "issues"),
+    ],
+)
+def test_pr_reply_to_invalid_command(
+    repo,
+    gh,
+    update_team,
+    relint,
+    make_noarch,
+    rerender,
+    add_bot_rerun_label,
+    get_app_token_for_webservices_only,
+    comment_id: int | None,
+    review_id: int | None,
+    path: str,
+):
+    if path == "pull":
+        pr_detailed_comment(
+            "@conda-forge-admin, please reply to this invalid command",
+            pr_num=999,
+            comment_id=comment_id,
+            review_id=review_id,
+        )
+    elif path == "issues":
+        assert review_id is None
+        issue_comment(
+            "@conda-forge-admin, please reply to this invalid command",
+            "",
+            issue_num=999,
+            comment_id=comment_id,
+        )
+    else:
+        assert False, f"{path}"
+
+    for command in (update_team, relint, make_noarch, rerender):
+        command.assert_not_called()
+    if review_id is None:
+        issue_calls = gh.return_value.get_repo.return_value.get_issue.return_value
+        comment_calls = issue_calls.create_comment.mock_calls
+        arg_index = 0
+        if comment_id == -1:
+            expected_url = f"/{path}/999#"
+        elif comment_id is not None:
+            expected_url = f"/{path}/999#issuecomment-{comment_id}"
+        else:
+            expected_url = ""
+    else:
+        pull_calls = gh.return_value.get_repo.return_value.get_pull.return_value
+        comment_calls = pull_calls.create_review_comment_reply.mock_calls
+        arg_index = 1
+        expected_url = f"/{path}/999#discussion_r{review_id}"
+    assert len(comment_calls) == 1
+    assert "find any valid commands" in comment_calls[0][1][arg_index]
+    assert expected_url in comment_calls[0][1][arg_index]

--- a/conda_forge_webservices/tests/test_commands.py
+++ b/conda_forge_webservices/tests/test_commands.py
@@ -664,6 +664,8 @@ def test_pr_reply_to_invalid_command(
     path: str,
 ):
     if path == "pull":
+        pull_calls = gh.return_value.get_repo.return_value.get_pull.return_value
+        pull_calls.get_single_review_comments.return_value = []
         pr_detailed_comment(
             "@conda-forge-admin, please reply to this invalid command",
             pr_num=999,
@@ -672,6 +674,8 @@ def test_pr_reply_to_invalid_command(
         )
     elif path == "issues":
         assert review_id is None
+        issue_calls = gh.return_value.get_repo.return_value.get_issue.return_value
+        issue_calls.get_comments.return_value = []
         issue_comment(
             "@conda-forge-admin, please reply to this invalid command",
             "",

--- a/conda_forge_webservices/tests/test_webapp.py
+++ b/conda_forge_webservices/tests/test_webapp.py
@@ -172,6 +172,7 @@ class TestBucketHandler(TestHandlerBase):
                 for main_or_master_branch in ["main", "master"]:
                     body = {
                         "after": "324234fdf",
+                        "actor": {"login": "conda-forge-bot"},
                         "repository": {
                             "name": name,
                             "full_name": f"{owner}/{name}",

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -622,6 +622,7 @@ class CommandHookHandler(WriteErrorAsJSONRequestHandler):
             or event == "pull_request_review_comment"
         ):
             body = tornado.escape.json_decode(self.request.body)
+            actor = body["actor"]["login"]
             action = body["action"]
             repo_name = body["repository"]["name"]
             owner = body["repository"]["owner"]["login"]
@@ -669,6 +670,7 @@ class CommandHookHandler(WriteErrorAsJSONRequestHandler):
                     comment,
                     comment_id,
                     review_id,
+                    actor,
                 )
                 tornado.ioloop.IOLoop.current().add_future(fut, _complete_future)
                 self.set_status(202)
@@ -677,6 +679,7 @@ class CommandHookHandler(WriteErrorAsJSONRequestHandler):
 
         elif event == "issue_comment" or event == "issues":
             body = tornado.escape.json_decode(self.request.body)
+            actor = body["actor"]["login"]
             action = body["action"]
             repo_name = body["repository"]["name"]
             owner = body["repository"]["owner"]["login"]
@@ -711,6 +714,7 @@ class CommandHookHandler(WriteErrorAsJSONRequestHandler):
                         issue_num,
                         comment,
                         comment_id,
+                        actor,
                     )
                     tornado.ioloop.IOLoop.current().add_future(fut, _complete_future)
                     self.set_status(202)
@@ -745,6 +749,7 @@ class CommandHookHandler(WriteErrorAsJSONRequestHandler):
                         title,
                         comment,
                         comment_id,
+                        actor,
                     )
                     tornado.ioloop.IOLoop.current().add_future(fut, _complete_future)
                     self.set_status(202)


### PR DESCRIPTION
@mgorny when running live invalid commands cause an infinite loop since the bot comment triggers another webhook event which causes another bot comment etc.

This happens when the invalid command is in the title.

The code needs to be adjusted to search for previous invalid command comments and not make one if one already exists.