### PR TITLE
test: ensure build number is updated when updating recipe versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -498,7 +498,7 @@ jobs:
           export CF_FEEDSTOCK_OPS_CONTAINER_TAG="${version}"
 
           cd tests
-          pytest -vvs --branch=${branch} test_live_version_update.py
+          pytest -vvsx --dist no --branch=${branch} test_live_version_update.py
         env:
           GH_TOKEN: ${{ secrets.CF_ADMIN_GITHUB_TOKEN }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -498,7 +498,7 @@ jobs:
           export CF_FEEDSTOCK_OPS_CONTAINER_TAG="${version}"
 
           cd tests
-          pytest -vvsx --dist no --branch=${branch} test_live_version_update.py
+          pytest -vvs --branch=${branch} test_live_version_update.py
         env:
           GH_TOKEN: ${{ secrets.CF_ADMIN_GITHUB_TOKEN }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -442,7 +442,7 @@ jobs:
       - tests
       - docker-build
     concurrency:
-      group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests-version-update' || format('{0}-{1}', github.workflow, github.ref) }}
+      group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests-main-test-feedstock' || format('{0}-{1}', github.workflow, github.ref) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
@@ -508,8 +508,9 @@ jobs:
     needs:
       - check
       - tests
+      - live-tests-version-update
     concurrency:
-      group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests-automerge' || format('{0}-{1}', github.workflow, github.ref) }}
+      group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests-main-test-feedstock' || format('{0}-{1}', github.workflow, github.ref) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -442,7 +442,7 @@ jobs:
       - tests
       - docker-build
     concurrency:
-      group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests-main-test-feedstock' || format('{0}-{1}', github.workflow, github.ref) }}
+      group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests-version-update' || format('{0}-{1}', github.workflow, github.ref) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
@@ -508,9 +508,8 @@ jobs:
     needs:
       - check
       - tests
-      - live-tests-version-update
     concurrency:
-      group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests-main-test-feedstock' || format('{0}-{1}', github.workflow, github.ref) }}
+      group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests-automerge' || format('{0}-{1}', github.workflow, github.ref) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}

--- a/conda_forge_webservices/github_actions_integration/version_updating.py
+++ b/conda_forge_webservices/github_actions_integration/version_updating.py
@@ -107,10 +107,11 @@ def update_version(
             )
             meta_yaml_path.write_text(new_meta_yaml)
         elif recipe_yaml_path.exists():
-            v1_recipe.update_build_number(
+            new_recipe_yaml = v1_recipe.update_build_number(
                 recipe_yaml_path,
                 0,
             )
+            recipe_yaml_path.write_text(new_recipe_yaml)
             schema_version = 1
         else:
             raise FileNotFoundError("Could not find meta.yaml or recipe.yaml!")

--- a/tests/conda-forge-for-recipe.yml
+++ b/tests/conda-forge-for-recipe.yml
@@ -1,0 +1,12 @@
+bot:
+  automerge: true
+conda_forge_output_validation: true
+github:
+  branch_name: main
+  tooling_branch_name: main
+conda_build:
+  pkg_format: 2
+provider:
+  linux_64: github_actions
+  osx_arm64: azure
+conda_build_tool: rattler-build

--- a/tests/recipe.yaml
+++ b/tests/recipe.yaml
@@ -1,0 +1,40 @@
+schema_version: 1
+
+context:
+  version: "0.14"
+
+package:
+  name: cf-autotick-bot-test-package
+  version: ${{ version }}
+
+source:
+  url: https://github.com/regro/cf-autotick-bot-test-package/archive/v${{ version }}.tar.gz
+  sha256: f6c45d5788f51dbe1cc55e1010f3e9ebd18b6c0f21907fc35499468a59827eef
+
+build:
+  number: 0
+  skip:
+    - match(python, "!=3.13") or win or aarch64 or ppc64le or s390x or (osx and x86_64)
+
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools
+  run:
+    - python
+
+tests:
+  - script:
+      - echo "works!"
+
+about:
+  license: BSD-3-Clause
+  license_file: LICENSE
+  summary: testing feedstock for the regro-cf-autotick-bot
+  homepage: https://github.com/conda-forge/conda-forge-bot
+
+extra:
+  recipe-maintainers:
+    - conda-forge-daemon
+

--- a/tests/recipe.yaml
+++ b/tests/recipe.yaml
@@ -37,4 +37,3 @@ about:
 extra:
   recipe-maintainers:
     - conda-forge-daemon
-

--- a/tests/test_live_version_update.py
+++ b/tests/test_live_version_update.py
@@ -154,6 +154,11 @@ def _version_update_is_ok(version, verbose=False):
                     check=True,
                 )
 
+                subprocess.run(
+                    ["git", "pull", BRANCH],
+                    check=True,
+                )
+
                 with open("recipe/meta.yaml") as fp:
                     test_line = None
                     for line in fp.readlines():

--- a/tests/test_live_version_update.py
+++ b/tests/test_live_version_update.py
@@ -106,8 +106,8 @@ def _change_version(schema_version, new_version="0.13", branch="main", build_num
                 new_lines.append(f"  sha256: {new_sha}\n")
             elif line.startswith("  number:"):
                 new_lines.append(f"  number: {build_number}\n")
-            elif line.startswith("  version: "):
-                new_lines.append(f'  version: "{new_version}"')
+            elif line.startswith('  version: "'):
+                new_lines.append(f'  version: "{new_version}"\n')
             else:
                 new_lines.append(line)
     with open(filename, "w") as fp:
@@ -122,6 +122,68 @@ def _change_version(schema_version, new_version="0.13", branch="main", build_num
             "--allow-empty",
             "-m",
             f"[ci skip] moved version to {new_version}",
+        ],
+        check=True,
+    )
+
+    print("push to origin...", flush=True)
+    subprocess.run(["git", "pull"], check=True)
+    subprocess.run(["git", "push"], check=True)
+
+
+def _change_to_schema(schema_version, branch):
+
+    if schema_version == 0:
+        filename = "recipe/meta.yaml"
+        filename_to_remove = "recipe/recipe.yaml"
+        cfy = "conda-forge.yml"
+    else:
+        filename = "recipe/recipe.yaml"
+        filename_to_remove = "recipe/meta.yaml"
+        cfy = "conda-forge-for-recipe.yml"
+
+    subprocess.run(
+        ["git", "checkout", branch],
+        check=True,
+    )
+    subprocess.run(["git", "pull"], check=True)
+
+    if os.path.exists(filename_to_remove):
+        subprocess.run(
+            ["git", "rm", filename_to_remove],
+            check=True,
+        )
+    with open(
+        os.path.join(os.path.dirname(__file__), os.path.basename(filename))
+    ) as fp:
+        new_recipe = fp.read()
+
+    with open(filename, "w") as fp:
+        fp.write(new_recipe)
+
+    subprocess.run(
+        ["git", "add", filename],
+        check=True,
+    )
+
+    with open(os.path.join(os.path.dirname(__file__), os.path.basename(cfy))) as fp:
+        new_cfy = fp.read()
+
+    with open("conda-forge.yml", "w") as fp:
+        fp.write(new_cfy)
+
+    subprocess.run(
+        ["git", "add", "conda-forge.yml"],
+        check=True,
+    )
+
+    subprocess.run(
+        [
+            "git",
+            "commit",
+            "--allow-empty",
+            "-m",
+            f"[ci skip] moved schema to {schema_version}",
         ],
         check=True,
     )
@@ -263,68 +325,6 @@ def _run_test(branch, version, schema_version):
         )
     assert update_is_ok
     print("tests passed!", flush=True)
-
-
-def _change_to_schema(schema_version, branch):
-
-    if schema_version == 0:
-        filename = "recipe/meta.yaml"
-        filename_to_remove = "recipe/recipe.yaml"
-        cfy = "conda-forge.yml"
-    else:
-        filename = "recipe/recipe.yaml"
-        filename_to_remove = "recipe/meta.yaml"
-        cfy = "conda-forge-for-recipe.yml"
-
-    subprocess.run(
-        ["git", "checkout", branch],
-        check=True,
-    )
-    subprocess.run(["git", "pull"], check=True)
-
-    if os.path.exists(filename_to_remove):
-        subprocess.run(
-            ["git", "rm", filename_to_remove],
-            check=True,
-        )
-    with open(
-        os.path.join(os.path.dirname(__file__), os.path.basename(filename))
-    ) as fp:
-        new_recipe = fp.read()
-
-    with open(filename, "w") as fp:
-        fp.write(new_recipe)
-
-    subprocess.run(
-        ["git", "add", filename],
-        check=True,
-    )
-
-    with open(os.path.join(os.path.dirname(__file__), os.path.basename(cfy))) as fp:
-        new_cfy = fp.read()
-
-    with open("conda-forge.yml", "w") as fp:
-        fp.write(new_cfy)
-
-    subprocess.run(
-        ["git", "add", "conda-forge.yml"],
-        check=True,
-    )
-
-    subprocess.run(
-        [
-            "git",
-            "commit",
-            "--allow-empty",
-            "-m",
-            f"[ci skip] moved schema to {schema_version}",
-        ],
-        check=True,
-    )
-
-    print("push to origin...", flush=True)
-    subprocess.run(["git", "pull"], check=True)
-    subprocess.run(["git", "push"], check=True)
 
 
 def _run_test_try_finally(branch, version, schema_version):

--- a/tests/test_live_version_update.py
+++ b/tests/test_live_version_update.py
@@ -277,9 +277,7 @@ def _run_test_try_finally(branch, version):
                 finally:
                     _change_version(new_version="0.14", branch="main", build_number=0)
                     _merge_main_to_branch(BRANCH, verbose=True)
-                    _change_version(
-                        new_version="0.13", branch=BRANCH, build_number=0
-                    )
+                    _change_version(new_version="0.13", branch=BRANCH, build_number=0)
                     _pr_title(new=original_title)
                     _set_pr_not_draft()
 

--- a/tests/test_live_version_update.py
+++ b/tests/test_live_version_update.py
@@ -277,7 +277,7 @@ def _run_test_try_finally(branch, version):
                     _change_version(new_version="0.14", branch="main", build_number=0)
                     _merge_main_to_branch(BRANCH, verbose=True)
                     _change_version(
-                        new_version="0.13", branch=BRANCH, build_number=4312
+                        new_version="0.13", branch=BRANCH, build_number=0
                     )
                     _pr_title(new=original_title)
                     _set_pr_not_draft()

--- a/tests/test_live_version_update.py
+++ b/tests/test_live_version_update.py
@@ -81,6 +81,7 @@ def _set_pr_not_draft():
 def _change_version(new_version="0.13", branch="main", build_number=0):
     import random
 
+    random.seed(new_version)
     new_sha = "".join(random.choices("0123456789abcdef", k=64))
     if new_version == "0.14":
         new_sha = "f6c45d5788f51dbe1cc55e1010f3e9ebd18b6c0f21907fc35499468a59827eef"
@@ -160,7 +161,7 @@ def _version_update_is_ok(version, verbose=False):
                             test_line = line
                             break
                 assert test_line is not None
-                assert test_line.strip() == "  number: 0"
+                assert test_line.strip() == "number: 0"
 
                 if verbose:
                     print("checking the git history", flush=True)

--- a/tests/test_live_version_update.py
+++ b/tests/test_live_version_update.py
@@ -78,7 +78,7 @@ def _set_pr_not_draft():
         raise ValueError(req.json()["errors"])
 
 
-def _change_version(new_version="0.13", branch="main"):
+def _change_version(new_version="0.13", branch="main", build_number=0):
     import random
 
     new_sha = "".join(random.choices("0123456789abcdef", k=64))
@@ -98,7 +98,7 @@ def _change_version(new_version="0.13", branch="main"):
             elif line.startswith("  sha256: "):
                 new_lines.append(f"  sha256: {new_sha}\n")
             elif line.startswith("  number:"):
-                new_lines.append("  number: 4352342\n")
+                new_lines.append(f"  number: {build_number}\n")
             else:
                 new_lines.append(line)
     with open("recipe/meta.yaml", "w") as fp:
@@ -263,16 +263,22 @@ def _run_test_try_finally(branch, version):
 
             with pushd(REPO_NAME):
                 try:
-                    _change_version(new_version="0.13", branch="main")
+                    _change_version(
+                        new_version="0.13", branch="main", build_number=4312
+                    )
                     _merge_main_to_branch(BRANCH, verbose=True)
-                    _change_version(new_version="0.13", branch=BRANCH)
+                    _change_version(
+                        new_version="0.13", branch=BRANCH, build_number=4312
+                    )
                     original_title = _pr_title(new="chore: update package version")
                     _set_pr_draft()
                     _run_test(branch, version)
                 finally:
-                    _change_version(new_version="0.14", branch="main")
+                    _change_version(new_version="0.14", branch="main", build_number=0)
                     _merge_main_to_branch(BRANCH, verbose=True)
-                    _change_version(new_version="0.13", branch=BRANCH)
+                    _change_version(
+                        new_version="0.13", branch=BRANCH, build_number=4312
+                    )
                     _pr_title(new=original_title)
                     _set_pr_not_draft()
 

--- a/tests/test_live_version_update.py
+++ b/tests/test_live_version_update.py
@@ -268,16 +268,12 @@ def _run_test_try_finally(branch, version):
                         new_version="0.13", branch="main", build_number=4312
                     )
                     _merge_main_to_branch(BRANCH, verbose=True)
-                    _change_version(
-                        new_version="0.13", branch=BRANCH, build_number=4312
-                    )
                     original_title = _pr_title(new="chore: update package version")
                     _set_pr_draft()
                     _run_test(branch, version)
                 finally:
                     _change_version(new_version="0.14", branch="main", build_number=0)
                     _merge_main_to_branch(BRANCH, verbose=True)
-                    _change_version(new_version="0.13", branch=BRANCH, build_number=0)
                     _pr_title(new=original_title)
                     _set_pr_not_draft()
 

--- a/tests/test_live_version_update.py
+++ b/tests/test_live_version_update.py
@@ -97,8 +97,8 @@ def _change_version(new_version="0.13", branch="main"):
                 new_lines.append(f'{{% set version = "{new_version}" %}}\n')
             elif line.startswith("  sha256: "):
                 new_lines.append(f"  sha256: {new_sha}\n")
-            elif line.startswith("    number:"):
-                new_lines.append("    number: 4352342\n")
+            elif line.startswith("  number:"):
+                new_lines.append("  number: 4352342\n")
             else:
                 new_lines.append(line)
     with open("recipe/meta.yaml", "w") as fp:
@@ -156,11 +156,11 @@ def _version_update_is_ok(version, verbose=False):
                 with open("recipe/meta.yaml") as fp:
                     test_line = None
                     for line in fp.readlines():
-                        if line.startswith("    number:"):
+                        if line.startswith("  number:"):
                             test_line = line
                             break
                 assert test_line is not None
-                assert test_line.strip() == "    number: 0"
+                assert test_line.strip() == "  number: 0"
 
                 if verbose:
                     print("checking the git history", flush=True)

--- a/tests/test_live_version_update.py
+++ b/tests/test_live_version_update.py
@@ -277,69 +277,57 @@ def _change_to_schema(schema_version, branch):
         filename_to_remove = "recipe/meta.yaml"
         cfy = "conda-forge-for-recipe.yml"
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        with pushd(tmpdir):
-            print("cloning...", flush=True)
-            subprocess.run(
-                [
-                    "git",
-                    "clone",
-                    f"https://x-access-token:{os.environ['GH_TOKEN']}@github.com/{REPO}.git",
-                ],
-                check=True,
-            )
+    subprocess.run(
+        ["git", "checkout", branch],
+        check=True,
+    )
+    subprocess.run(["git", "pull"], check=True)
 
-            with pushd(REPO_NAME):
-                subprocess.run(
-                    ["git", "checkout", branch],
-                    check=True,
-                )
+    if os.path.exists(filename_to_remove):
+        subprocess.run(
+            ["git", "rm", filename_to_remove],
+            check=True,
+        )
+    with open(
+        os.path.join(os.path.dirname(__file__), os.path.basename(filename))
+    ) as fp:
+        new_recipe = fp.read()
 
-                if os.path.exists(filename_to_remove):
-                    subprocess.run(
-                        ["git", "rm", filename_to_remove],
-                        check=True,
-                    )
-                with open(
-                    os.path.join(os.path.dirname(__file__), os.path.basename(filename))
-                ) as fp:
-                    new_recipe = fp.read()
+    with open(filename, "w") as fp:
+        fp.write(new_recipe)
 
-                with open(filename, "w") as fp:
-                    fp.write(new_recipe)
+    subprocess.run(
+        ["git", "add", filename],
+        check=True,
+    )
 
-                subprocess.run(
-                    ["git", "add", filename],
-                    check=True,
-                )
+    with open(
+        os.path.join(os.path.dirname(__file__), os.path.basename(cfy))
+    ) as fp:
+        new_cfy = fp.read()
 
-                with open(
-                    os.path.join(os.path.dirname(__file__), os.path.basename(cfy))
-                ) as fp:
-                    new_cfy = fp.read()
+    with open("conda-forge.yml", "w") as fp:
+        fp.write(new_cfy)
 
-                with open("conda-forge.yml", "w") as fp:
-                    fp.write(new_cfy)
+    subprocess.run(
+        ["git", "add", "conda-forge.yml"],
+        check=True,
+    )
 
-                subprocess.run(
-                    ["git", "add", "conda-forge.yml"],
-                    check=True,
-                )
+    subprocess.run(
+        [
+            "git",
+            "commit",
+            "--allow-empty",
+            "-m",
+            f"[ci skip] moved schema to {schema_version}",
+        ],
+        check=True,
+    )
 
-                subprocess.run(
-                    [
-                        "git",
-                        "commit",
-                        "--allow-empty",
-                        "-m",
-                        f"[ci skip] moved schema to {schema_version}",
-                    ],
-                    check=True,
-                )
-
-                print("push to origin...", flush=True)
-                subprocess.run(["git", "pull"], check=True)
-                subprocess.run(["git", "push"], check=True)
+    print("push to origin...", flush=True)
+    subprocess.run(["git", "pull"], check=True)
+    subprocess.run(["git", "push"], check=True)
 
 
 def _run_test_try_finally(branch, version, schema_version):

--- a/tests/test_live_version_update.py
+++ b/tests/test_live_version_update.py
@@ -7,7 +7,7 @@ import uuid
 import github
 import requests
 
-# from flaky import flaky
+from flaky import flaky
 import pytest
 
 import conda_forge_webservices
@@ -398,7 +398,7 @@ def _run_test_try_finally(branch, version, schema_version):
                     _set_pr_not_draft()
 
 
-# @flaky
+@flaky
 @pytest.mark.parametrize("schema_version", [0, 1])
 def test_live_version_update_with_finding_version(
     pytestconfig, skip_if_no_tokens, schema_version
@@ -409,7 +409,7 @@ def test_live_version_update_with_finding_version(
     _run_test_try_finally(branch, None, schema_version)
 
 
-# @flaky
+@flaky
 @pytest.mark.parametrize("schema_version", [0, 1])
 def test_live_version_update_with_input_version(
     pytestconfig, skip_if_no_tokens, schema_version

--- a/tests/test_live_version_update.py
+++ b/tests/test_live_version_update.py
@@ -97,8 +97,8 @@ def _change_version(new_version="0.13", branch="main"):
                 new_lines.append(f'{{% set version = "{new_version}" %}}\n')
             elif line.startswith("  sha256: "):
                 new_lines.append(f"  sha256: {new_sha}\n")
-            elif line.startswith("  build:"):
-                new_lines.append("  build: 4352342\n")
+            elif line.startswith("    number:"):
+                new_lines.append("    number: 4352342\n")
             else:
                 new_lines.append(line)
     with open("recipe/meta.yaml", "w") as fp:
@@ -156,11 +156,11 @@ def _version_update_is_ok(version, verbose=False):
                 with open("recipe/meta.yaml") as fp:
                     test_line = None
                     for line in fp.readlines():
-                        if line.startswith("  build:"):
+                        if line.startswith("    number:"):
                             test_line = line
                             break
                 assert test_line is not None
-                assert test_line.strip() == "  build: 0"
+                assert test_line.strip() == "    number: 0"
 
                 if verbose:
                     print("checking the git history", flush=True)

--- a/tests/test_live_version_update.py
+++ b/tests/test_live_version_update.py
@@ -12,7 +12,6 @@ import pytest
 
 import conda_forge_webservices
 from conda_forge_webservices.utils import pushd
-from conftest import _merge_main_to_branch
 from conda_forge_webservices.commands import (
     get_workflow_run_from_uid,
     set_version_update_pr_status,
@@ -301,9 +300,7 @@ def _change_to_schema(schema_version, branch):
         check=True,
     )
 
-    with open(
-        os.path.join(os.path.dirname(__file__), os.path.basename(cfy))
-    ) as fp:
+    with open(os.path.join(os.path.dirname(__file__), os.path.basename(cfy))) as fp:
         new_cfy = fp.read()
 
     with open("conda-forge.yml", "w") as fp:
@@ -367,14 +364,14 @@ def _run_test_try_finally(branch, version, schema_version):
                 finally:
                     _change_to_schema(0, "main")
                     _change_version(
-                        schema_version,
+                        0,
                         new_version="0.14",
                         branch="main",
                         build_number=0,
                     )
                     _change_to_schema(0, BRANCH)
                     _change_version(
-                        schema_version,
+                        0,
                         new_version="0.14",
                         branch=BRANCH,
                         build_number=0,

--- a/tests/test_live_version_update.py
+++ b/tests/test_live_version_update.py
@@ -149,9 +149,8 @@ def _version_update_is_ok(version, verbose=False):
             with pushd(REPO_NAME):
                 if verbose:
                     print("checkout branch...", flush=True)
-
                 subprocess.run(
-                    ["git", "pull", BRANCH],
+                    ["git", "checkout", BRANCH],
                     check=True,
                 )
 

--- a/tests/test_live_version_update.py
+++ b/tests/test_live_version_update.py
@@ -337,6 +337,10 @@ def _change_to_schema(schema_version, branch):
                     check=True,
                 )
 
+                print("push to origin...", flush=True)
+                subprocess.run(["git", "pull"], check=True)
+                subprocess.run(["git", "push"], check=True)
+
 
 def _run_test_try_finally(branch, version, schema_version):
     print("making an edit to the head ref...", flush=True)

--- a/tests/test_live_version_update.py
+++ b/tests/test_live_version_update.py
@@ -149,10 +149,6 @@ def _version_update_is_ok(version, verbose=False):
             with pushd(REPO_NAME):
                 if verbose:
                     print("checkout branch...", flush=True)
-                subprocess.run(
-                    ["git", "checkout", BRANCH],
-                    check=True,
-                )
 
                 subprocess.run(
                     ["git", "pull", BRANCH],
@@ -165,8 +161,11 @@ def _version_update_is_ok(version, verbose=False):
                         if line.startswith("  number:"):
                             test_line = line
                             break
-                assert test_line is not None
-                assert test_line.strip() == "number: 0"
+                if test_line is None:
+                    return False
+
+                if test_line.strip() != "number: 0":
+                    return False
 
                 if verbose:
                     print("checking the git history", flush=True)
@@ -277,11 +276,10 @@ def _run_test_try_finally(branch, version):
                     _set_pr_draft()
                     _run_test(branch, version)
                 finally:
-                    pass
-                    # _change_version(new_version="0.14", branch="main", build_number=0)
-                    # _merge_main_to_branch(BRANCH, verbose=True)
-                    # _pr_title(new=original_title)
-                    # _set_pr_not_draft()
+                    _change_version(new_version="0.14", branch="main", build_number=0)
+                    _merge_main_to_branch(BRANCH, verbose=True)
+                    _pr_title(new=original_title)
+                    _set_pr_not_draft()
 
 
 # @flaky

--- a/tests/test_live_version_update.py
+++ b/tests/test_live_version_update.py
@@ -106,7 +106,7 @@ def _change_version(schema_version, new_version="0.13", branch="main", build_num
                 new_lines.append(f"  sha256: {new_sha}\n")
             elif line.startswith("  number:"):
                 new_lines.append(f"  number: {build_number}\n")
-            elif line.startswith('  version: "'):
+            elif line.startswith('  version: "') and "{{" not in line:
                 new_lines.append(f'  version: "{new_version}"\n')
             else:
                 new_lines.append(line)

--- a/tests/test_live_version_update.py
+++ b/tests/test_live_version_update.py
@@ -97,6 +97,8 @@ def _change_version(new_version="0.13", branch="main"):
                 new_lines.append(f'{{% set version = "{new_version}" %}}\n')
             elif line.startswith("  sha256: "):
                 new_lines.append(f"  sha256: {new_sha}\n")
+            elif line.startswith("  build:"):
+                new_lines.append("  build: 4352342\n")
             else:
                 new_lines.append(line)
     with open("recipe/meta.yaml", "w") as fp:
@@ -150,6 +152,15 @@ def _version_update_is_ok(version, verbose=False):
                     ["git", "checkout", BRANCH],
                     check=True,
                 )
+
+                with open("recipe/meta.yaml") as fp:
+                    test_line = None
+                    for line in fp.readlines():
+                        if line.startswith("  build:"):
+                            test_line = line
+                            break
+                assert test_line is not None
+                assert test_line.strip() == "  build: 0"
 
                 if verbose:
                     print("checking the git history", flush=True)

--- a/tests/test_live_version_update.py
+++ b/tests/test_live_version_update.py
@@ -272,10 +272,11 @@ def _run_test_try_finally(branch, version):
                     _set_pr_draft()
                     _run_test(branch, version)
                 finally:
-                    _change_version(new_version="0.14", branch="main", build_number=0)
-                    _merge_main_to_branch(BRANCH, verbose=True)
-                    _pr_title(new=original_title)
-                    _set_pr_not_draft()
+                    pass
+                    # _change_version(new_version="0.14", branch="main", build_number=0)
+                    # _merge_main_to_branch(BRANCH, verbose=True)
+                    # _pr_title(new=original_title)
+                    # _set_pr_not_draft()
 
 
 # @flaky

--- a/tests/test_live_version_update.py
+++ b/tests/test_live_version_update.py
@@ -278,7 +278,7 @@ def _run_test_try_finally(branch, version):
                     _set_pr_not_draft()
 
 
-@flaky
+# @flaky
 def test_live_version_update_with_finding_version(pytestconfig, skip_if_no_tokens):
     global GH
     GH = github.Github(auth=github.Auth.Token(os.environ["GH_TOKEN"]))
@@ -286,7 +286,7 @@ def test_live_version_update_with_finding_version(pytestconfig, skip_if_no_token
     _run_test_try_finally(branch, None)
 
 
-@flaky
+# @flaky
 def test_live_version_update_with_input_version(pytestconfig, skip_if_no_tokens):
     global GH
     GH = github.Github(auth=github.Auth.Token(os.environ["GH_TOKEN"]))

--- a/tests/test_live_version_update.py
+++ b/tests/test_live_version_update.py
@@ -6,7 +6,9 @@ import uuid
 
 import github
 import requests
-from flaky import flaky
+
+# from flaky import flaky
+import pytest
 
 import conda_forge_webservices
 from conda_forge_webservices.utils import pushd
@@ -78,7 +80,7 @@ def _set_pr_not_draft():
         raise ValueError(req.json()["errors"])
 
 
-def _change_version(new_version="0.13", branch="main", build_number=0):
+def _change_version(schema_version, new_version="0.13", branch="main", build_number=0):
     import random
 
     random.seed(new_version)
@@ -91,8 +93,13 @@ def _change_version(new_version="0.13", branch="main", build_number=0):
 
     subprocess.run(["git", "pull"], check=True)
 
+    if schema_version == 0:
+        filename = "recipe/meta.yaml"
+    else:
+        filename = "recipe/recipe.yaml"
+
     new_lines = []
-    with open("recipe/meta.yaml") as fp:
+    with open(filename) as fp:
         for line in fp.readlines():
             if line.startswith("{% set version ="):
                 new_lines.append(f'{{% set version = "{new_version}" %}}\n')
@@ -100,13 +107,15 @@ def _change_version(new_version="0.13", branch="main", build_number=0):
                 new_lines.append(f"  sha256: {new_sha}\n")
             elif line.startswith("  number:"):
                 new_lines.append(f"  number: {build_number}\n")
+            elif line.startswith("  version: "):
+                new_lines.append(f'  version: "{new_version}"')
             else:
                 new_lines.append(line)
-    with open("recipe/meta.yaml", "w") as fp:
+    with open(filename, "w") as fp:
         fp.write("".join(new_lines))
 
     print("committing file...", flush=True)
-    subprocess.run(["git", "add", "recipe/meta.yaml"], check=True)
+    subprocess.run(["git", "add", filename], check=True)
     subprocess.run(
         [
             "git",
@@ -132,7 +141,13 @@ def _pr_title(new=None):
     return old
 
 
-def _version_update_is_ok(version, verbose=False):
+def _version_update_is_ok(version, schema_version, verbose=False):
+
+    if schema_version == 0:
+        filename = "recipe/meta.yaml"
+    else:
+        filename = "recipe/recipe.yaml"
+
     with tempfile.TemporaryDirectory() as tmpdir:
         with pushd(tmpdir):
             if verbose:
@@ -154,7 +169,7 @@ def _version_update_is_ok(version, verbose=False):
                     check=True,
                 )
 
-                with open("recipe/meta.yaml") as fp:
+                with open(filename) as fp:
                     test_line = None
                     for line in fp.readlines():
                         if line.startswith("  number:"):
@@ -195,7 +210,7 @@ def _version_update_is_ok(version, verbose=False):
     return True
 
 
-def _run_test(branch, version):
+def _run_test(branch, version, schema_version):
     print("sending workflow dispatch event to version updater...", flush=True)
     pr_head_sha = GH.get_repo(REPO).get_pull(PR_NUM).head.sha
     uid = uuid.uuid4().hex
@@ -235,11 +250,11 @@ def _run_test(branch, version):
         tot += 10
         print(f"    slept {tot} seconds out of {WAIT_TIME}", flush=True)
         if tot % 30 == 0 and tot > 0:
-            if _version_update_is_ok(version):
+            if _version_update_is_ok(version, schema_version):
                 break
 
     print("checking repo for the version update...", flush=True)
-    update_is_ok = _version_update_is_ok(version, verbose=True)
+    update_is_ok = _version_update_is_ok(version, schema_version, verbose=True)
     if not update_is_ok:
         set_version_update_pr_status(
             GH.get_repo(REPO),
@@ -251,7 +266,79 @@ def _run_test(branch, version):
     print("tests passed!", flush=True)
 
 
-def _run_test_try_finally(branch, version):
+def _change_to_schema(schema_version, branch):
+
+    if schema_version == 0:
+        filename = "recipe/meta.yaml"
+        filename_to_remove = "recipe/recipe.yaml"
+        cfy = "conda-forge.yml"
+    else:
+        filename = "recipe/recipe.yaml"
+        filename_to_remove = "recipe/meta.yaml"
+        cfy = "conda-forge-for-recipe.yml"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with pushd(tmpdir):
+            print("cloning...", flush=True)
+            subprocess.run(
+                [
+                    "git",
+                    "clone",
+                    f"https://x-access-token:{os.environ['GH_TOKEN']}@github.com/{REPO}.git",
+                ],
+                check=True,
+            )
+
+            with pushd(REPO_NAME):
+                subprocess.run(
+                    ["git", "checkout", branch],
+                    check=True,
+                )
+
+                if os.path.exists(filename_to_remove):
+                    subprocess.run(
+                        ["git", "rm", filename_to_remove],
+                        check=True,
+                    )
+                with open(
+                    os.path.join(os.path.dirname(__file__), os.path.basename(filename))
+                ) as fp:
+                    new_recipe = fp.read()
+
+                with open(filename, "w") as fp:
+                    fp.write(new_recipe)
+
+                subprocess.run(
+                    ["git", "add", filename],
+                    check=True,
+                )
+
+                with open(
+                    os.path.join(os.path.dirname(__file__), os.path.basename(cfy))
+                ) as fp:
+                    new_cfy = fp.read()
+
+                with open("conda-forge.yml", "w") as fp:
+                    fp.write(new_cfy)
+
+                subprocess.run(
+                    ["git", "add", "conda-forge.yml"],
+                    check=True,
+                )
+
+                subprocess.run(
+                    [
+                        "git",
+                        "commit",
+                        "--allow-empty",
+                        "-m",
+                        f"[ci skip] moved schema to {schema_version}",
+                    ],
+                    check=True,
+                )
+
+
+def _run_test_try_finally(branch, version, schema_version):
     print("making an edit to the head ref...", flush=True)
     with tempfile.TemporaryDirectory() as tmpdir:
         with pushd(tmpdir):
@@ -267,31 +354,49 @@ def _run_test_try_finally(branch, version):
 
             with pushd(REPO_NAME):
                 try:
+                    _change_to_schema(schema_version, "main")
                     _change_version(
-                        new_version="0.13", branch="main", build_number=4312
+                        schema_version,
+                        new_version="0.13",
+                        branch="main",
+                        build_number=4312,
                     )
+                    _change_to_schema(schema_version, BRANCH)
                     _merge_main_to_branch(BRANCH, verbose=True)
                     original_title = _pr_title(new="chore: update package version")
                     _set_pr_draft()
-                    _run_test(branch, version)
+                    _run_test(branch, version, schema_version)
                 finally:
-                    _change_version(new_version="0.14", branch="main", build_number=0)
+                    _change_to_schema(0, "main")
+                    _change_version(
+                        schema_version,
+                        new_version="0.14",
+                        branch="main",
+                        build_number=0,
+                    )
+                    _change_to_schema(0, BRANCH)
                     _merge_main_to_branch(BRANCH, verbose=True)
                     _pr_title(new=original_title)
                     _set_pr_not_draft()
 
 
 # @flaky
-def test_live_version_update_with_finding_version(pytestconfig, skip_if_no_tokens):
+@pytest.mark.parametrize("schema_version", [0, 1])
+def test_live_version_update_with_finding_version(
+    pytestconfig, skip_if_no_tokens, schema_version
+):
     global GH
     GH = github.Github(auth=github.Auth.Token(os.environ["GH_TOKEN"]))
     branch = pytestconfig.getoption("branch")
-    _run_test_try_finally(branch, None)
+    _run_test_try_finally(branch, None, schema_version)
 
 
 # @flaky
-def test_live_version_update_with_input_version(pytestconfig, skip_if_no_tokens):
+@pytest.mark.parametrize("schema_version", [0, 1])
+def test_live_version_update_with_input_version(
+    pytestconfig, skip_if_no_tokens, schema_version
+):
     global GH
     GH = github.Github(auth=github.Auth.Token(os.environ["GH_TOKEN"]))
     branch = pytestconfig.getoption("branch")
-    _run_test_try_finally(branch, "0.14")
+    _run_test_try_finally(branch, "0.14", schema_version)

--- a/tests/test_live_version_update.py
+++ b/tests/test_live_version_update.py
@@ -354,7 +354,13 @@ def _run_test_try_finally(branch, version, schema_version):
                         build_number=4312,
                     )
                     _change_to_schema(schema_version, BRANCH)
-                    _merge_main_to_branch(BRANCH, verbose=True)
+                    _change_version(
+                        schema_version,
+                        new_version="0.13",
+                        branch=BRANCH,
+                        build_number=4312,
+                    )
+                    # _merge_main_to_branch(BRANCH, verbose=True)
                     original_title = _pr_title(new="chore: update package version")
                     _set_pr_draft()
                     _run_test(branch, version, schema_version)
@@ -367,7 +373,13 @@ def _run_test_try_finally(branch, version, schema_version):
                         build_number=0,
                     )
                     _change_to_schema(0, BRANCH)
-                    _merge_main_to_branch(BRANCH, verbose=True)
+                    _change_version(
+                        schema_version,
+                        new_version="0.14",
+                        branch=BRANCH,
+                        build_number=0,
+                    )
+                    # _merge_main_to_branch(BRANCH, verbose=True)
                     _pr_title(new=original_title)
                     _set_pr_not_draft()
 

--- a/tests/test_live_version_update.py
+++ b/tests/test_live_version_update.py
@@ -177,6 +177,23 @@ def _change_to_schema(schema_version, branch):
         check=True,
     )
 
+    print("rerendering...", flush=True)
+    subprocess.run(
+        [
+            "conda-smithy",
+            "rerender",
+            "-c",
+            "auto",
+            "--no-check-uptodate",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "add", "."],
+        check=True,
+    )
+
+    print("making a commit...", flush=True)
     subprocess.run(
         [
             "git",

--- a/tests/test_live_version_update.py
+++ b/tests/test_live_version_update.py
@@ -337,7 +337,7 @@ def _run_test(branch, version, schema_version):
         set_version_update_pr_status(
             GH.get_repo(REPO),
             PR_NUM,
-            "failed",
+            "failure",
             target_url=target_url,
         )
     assert update_is_ok


### PR DESCRIPTION
### Description

Trying to debug the lack of build number bumps.

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
