### PR TITLE
fix: better exception logging

### DIFF
--- a/conda_forge_webservices/github_actions_integration/__main__.py
+++ b/conda_forge_webservices/github_actions_integration/__main__.py
@@ -5,7 +5,6 @@ import pprint
 import subprocess
 import sys
 import tempfile
-import traceback
 
 import click
 from conda_forge_feedstock_ops import setup_logging
@@ -166,8 +165,7 @@ def main_run_task(
                 lints, hints, errors = res
             lint_error = False
         except Exception as err:
-            LOGGER.warning("LINTING ERROR: %r", err)
-            LOGGER.warning("LINTING ERROR TRACEBACK: %s", traceback.format_exc())
+            LOGGER.exception("LINTING ERROR: %r", err)
             lint_error = True
             lints = None
             hints = None

--- a/conda_forge_webservices/github_actions_integration/rerendering.py
+++ b/conda_forge_webservices/github_actions_integration/rerendering.py
@@ -26,7 +26,7 @@ def rerender(git_repo):
             use_container=True,
         )
     except ContainerRuntimeError as e:
-        LOGGER.error(f"Rerendering failed: {e}")
+        LOGGER.exception("Rerendering failed: %r", e)
         ret = 1
     else:
         ret = 0

--- a/conda_forge_webservices/github_actions_integration/utils.py
+++ b/conda_forge_webservices/github_actions_integration/utils.py
@@ -81,7 +81,7 @@ def comment_and_push_if_changed(
             git_repo.remotes.origin.push()
         except GitCommandError as e:
             push_error = True
-            LOGGER.critical(repr(e))
+            LOGGER.exception("Error pushing to %s/%s: %r", pr_owner, pr_repo, e)
             message = dedent_with_escaped_continue(f"""
                 Hi! This is the friendly automated conda-forge-webservice.
 


### PR DESCRIPTION
### Description

Trying to make it easier to diagnose issues live.

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
