### PR TITLE
feat: add v1 conversion command

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -234,332 +234,332 @@ jobs:
           username: conda_forge_daemon
           password: ${{ secrets.CF_DAEMON_QUAY_PASSWORD }}
 
-  # live-tests-upload:
-  #   name: live-tests-upload
-  #   runs-on: "ubuntu-latest"
-  #   needs:
-  #     - check
-  #     - tests
-  #   concurrency:
-  #     group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests-upload' || format('{0}-{1}', github.workflow, github.ref) }}
-  #   steps:
-  #     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-  #       with:
-  #         fetch-depth: 0
+  live-tests-upload:
+    name: live-tests-upload
+    runs-on: "ubuntu-latest"
+    needs:
+      - check
+      - tests
+    concurrency:
+      group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests-upload' || format('{0}-{1}', github.workflow, github.ref) }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+        with:
+          fetch-depth: 0
 
-  #     - name: setup conda
-  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-  #       uses: mamba-org/setup-micromamba@ce51e99f4bb8a82ab7158c4dc59ef4634c59c4f9 # v3.1.0
-  #       with:
-  #         micromamba-version: "2.7.0-0"
-  #         environment-file: conda-lock.yml
-  #         environment-name: webservices
-  #         condarc: |
-  #           show_channel_urls: true
-  #           channel_priority: strict
-  #           channels:
-  #             - conda-forge
+      - name: setup conda
+        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+        uses: mamba-org/setup-micromamba@ce51e99f4bb8a82ab7158c4dc59ef4634c59c4f9 # v3.1.0
+        with:
+          micromamba-version: "2.7.0-0"
+          environment-file: conda-lock.yml
+          environment-name: webservices
+          condarc: |
+            show_channel_urls: true
+            channel_priority: strict
+            channels:
+              - conda-forge
 
-  #     - name: generate token
-  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-  #       id: generate_token
-  #       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-  #       with:
-  #         client-id: ${{ secrets.CF_CURATOR_APP_ID }}
-  #         private-key: ${{ secrets.CF_CURATOR_PRIVATE_KEY }}
-  #         owner: ${{ github.repository_owner }}
+      - name: generate token
+        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+        id: generate_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.CF_CURATOR_APP_ID }}
+          private-key: ${{ secrets.CF_CURATOR_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
-  #     - name: install code
-  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-  #       run: |
-  #         git config --global user.email "79913779+conda-forge-curator[bot]@users.noreply.github.com"
-  #         git config --global user.name "conda-forge-curator[bot]"
-  #         git config --global pull.rebase false
-  #         mkdir -p ~/.conda-smithy/
-  #         echo $GH_TOKEN > ~/.conda-smithy/github.token
-  #         chmod 600 ~/.conda-smithy/github.token
-  #         pip install --no-deps --no-build-isolation -e .
-  #       env:
-  #         GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+      - name: install code
+        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+        run: |
+          git config --global user.email "79913779+conda-forge-curator[bot]@users.noreply.github.com"
+          git config --global user.name "conda-forge-curator[bot]"
+          git config --global pull.rebase false
+          mkdir -p ~/.conda-smithy/
+          echo $GH_TOKEN > ~/.conda-smithy/github.token
+          chmod 600 ~/.conda-smithy/github.token
+          pip install --no-deps --no-build-isolation -e .
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
 
-  #     - name: run package upload tests
-  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-  #       run: |
-  #         export CF_WEBSERVICES_TEST=1
-  #         ./scripts/run_cfep13_tests.sh
-  #       env:
-  #         GH_TOKEN: ${{ steps.generate_token.outputs.token }}
-  #         PROD_BINSTAR_TOKEN: ${{ secrets.PROD_BINSTAR_TOKEN }}
-  #         STAGING_BINSTAR_TOKEN: ${{ secrets.HEROKU_ONLY_STAGING_BINSTAR_TOKEN }}
-  #         POST_STAGING_BINSTAR_TOKEN: ${{ secrets.POST_STAGING_BINSTAR_TOKEN }}
-  #         CF_WEBSERVICES_TOKEN: ${{ secrets.CF_WEBSERVICES_TOKEN }}
-  #         CF_WEBSERVICES_APP_ID: ${{ secrets.CF_CURATOR_APP_ID }}
-  #         CF_WEBSERVICES_PRIVATE_KEY: ${{ secrets.CF_CURATOR_PRIVATE_KEY }}
-  #         ACTION_URL: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
+      - name: run package upload tests
+        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+        run: |
+          export CF_WEBSERVICES_TEST=1
+          ./scripts/run_cfep13_tests.sh
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+          PROD_BINSTAR_TOKEN: ${{ secrets.PROD_BINSTAR_TOKEN }}
+          STAGING_BINSTAR_TOKEN: ${{ secrets.HEROKU_ONLY_STAGING_BINSTAR_TOKEN }}
+          POST_STAGING_BINSTAR_TOKEN: ${{ secrets.POST_STAGING_BINSTAR_TOKEN }}
+          CF_WEBSERVICES_TOKEN: ${{ secrets.CF_WEBSERVICES_TOKEN }}
+          CF_WEBSERVICES_APP_ID: ${{ secrets.CF_CURATOR_APP_ID }}
+          CF_WEBSERVICES_PRIVATE_KEY: ${{ secrets.CF_CURATOR_PRIVATE_KEY }}
+          ACTION_URL: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
 
-  # live-tests-rerender:
-  #   name: live-tests-rerender
-  #   runs-on: "ubuntu-latest"
-  #   needs:
-  #     - check
-  #     - tests
-  #     - docker-build
-  #   concurrency:
-  #     group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests-rerender' || format('{0}-{1}', github.workflow, github.ref) }}
-  #   steps:
-  #     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-  #       with:
-  #         fetch-depth: 0
+  live-tests-rerender:
+    name: live-tests-rerender
+    runs-on: "ubuntu-latest"
+    needs:
+      - check
+      - tests
+      - docker-build
+    concurrency:
+      group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests-rerender' || format('{0}-{1}', github.workflow, github.ref) }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+        with:
+          fetch-depth: 0
 
-  #     - name: setup conda
-  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-  #       uses: mamba-org/setup-micromamba@ce51e99f4bb8a82ab7158c4dc59ef4634c59c4f9 # v3.1.0
-  #       with:
-  #         micromamba-version: "2.7.0-0"
-  #         environment-file: conda-lock.yml
-  #         environment-name: webservices
-  #         condarc: |
-  #           show_channel_urls: true
-  #           channel_priority: strict
-  #           channels:
-  #             - conda-forge
+      - name: setup conda
+        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+        uses: mamba-org/setup-micromamba@ce51e99f4bb8a82ab7158c4dc59ef4634c59c4f9 # v3.1.0
+        with:
+          micromamba-version: "2.7.0-0"
+          environment-file: conda-lock.yml
+          environment-name: webservices
+          condarc: |
+            show_channel_urls: true
+            channel_priority: strict
+            channels:
+              - conda-forge
 
-  #     - name: generate token
-  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-  #       id: generate_token
-  #       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-  #       with:
-  #         client-id: ${{ secrets.CF_CURATOR_APP_ID }}
-  #         private-key: ${{ secrets.CF_CURATOR_PRIVATE_KEY }}
-  #         owner: ${{ github.repository_owner }}
+      - name: generate token
+        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+        id: generate_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.CF_CURATOR_APP_ID }}
+          private-key: ${{ secrets.CF_CURATOR_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
-  #     - name: install code
-  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-  #       run: |
-  #         git config --global user.email "79913779+conda-forge-curator[bot]@users.noreply.github.com"
-  #         git config --global user.name "conda-forge-curator[bot]"
-  #         git config --global pull.rebase false
-  #         mkdir -p ~/.conda-smithy/
-  #         echo $GH_TOKEN > ~/.conda-smithy/github.token
-  #         chmod 600 ~/.conda-smithy/github.token
-  #         pip install --no-deps --no-build-isolation -e .
-  #       env:
-  #         GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+      - name: install code
+        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+        run: |
+          git config --global user.email "79913779+conda-forge-curator[bot]@users.noreply.github.com"
+          git config --global user.name "conda-forge-curator[bot]"
+          git config --global pull.rebase false
+          mkdir -p ~/.conda-smithy/
+          echo $GH_TOKEN > ~/.conda-smithy/github.token
+          chmod 600 ~/.conda-smithy/github.token
+          pip install --no-deps --no-build-isolation -e .
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
 
-  #     - name: run rerender tests
-  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-  #       run: |
-  #         if [[ "${GITHUB_HEAD_REF}" != "" ]]; then
-  #           branch="${GITHUB_HEAD_REF}"
-  #         else
-  #           branch="${GITHUB_REF_NAME}"
-  #         fi
+      - name: run rerender tests
+        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+        run: |
+          if [[ "${GITHUB_HEAD_REF}" != "" ]]; then
+            branch="${GITHUB_HEAD_REF}"
+          else
+            branch="${GITHUB_REF_NAME}"
+          fi
 
-  #         version=$(python -c "import conda_forge_webservices; print(conda_forge_webservices.__version__.replace('+', '.'))")
-  #         export CF_FEEDSTOCK_OPS_CONTAINER_NAME=quay.io/condaforge/webservices-dispatch-action
-  #         export CF_FEEDSTOCK_OPS_CONTAINER_TAG="${version}"
+          version=$(python -c "import conda_forge_webservices; print(conda_forge_webservices.__version__.replace('+', '.'))")
+          export CF_FEEDSTOCK_OPS_CONTAINER_NAME=quay.io/condaforge/webservices-dispatch-action
+          export CF_FEEDSTOCK_OPS_CONTAINER_TAG="${version}"
 
-  #         cd tests
-  #         pytest -vvs --branch=${branch} test_live_rerender.py
-  #       env:
-  #         GH_TOKEN: ${{ secrets.CF_ADMIN_GITHUB_TOKEN }}
+          cd tests
+          pytest -vvs --branch=${branch} test_live_rerender.py
+        env:
+          GH_TOKEN: ${{ secrets.CF_ADMIN_GITHUB_TOKEN }}
 
-  # live-tests-linter:
-  #   name: live-tests-linter
-  #   runs-on: "ubuntu-latest"
-  #   needs:
-  #     - check
-  #     - tests
-  #     - docker-build
-  #   concurrency:
-  #     group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests-linter' || format('{0}-{1}', github.workflow, github.ref) }}
-  #   steps:
-  #     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-  #       with:
-  #         fetch-depth: 0
+  live-tests-linter:
+    name: live-tests-linter
+    runs-on: "ubuntu-latest"
+    needs:
+      - check
+      - tests
+      - docker-build
+    concurrency:
+      group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests-linter' || format('{0}-{1}', github.workflow, github.ref) }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+        with:
+          fetch-depth: 0
 
-  #     - name: setup conda
-  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-  #       uses: mamba-org/setup-micromamba@ce51e99f4bb8a82ab7158c4dc59ef4634c59c4f9 # v3.1.0
-  #       with:
-  #         micromamba-version: "2.7.0-0"
-  #         environment-file: conda-lock.yml
-  #         environment-name: webservices
-  #         condarc: |
-  #           show_channel_urls: true
-  #           channel_priority: strict
-  #           channels:
-  #             - conda-forge
+      - name: setup conda
+        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+        uses: mamba-org/setup-micromamba@ce51e99f4bb8a82ab7158c4dc59ef4634c59c4f9 # v3.1.0
+        with:
+          micromamba-version: "2.7.0-0"
+          environment-file: conda-lock.yml
+          environment-name: webservices
+          condarc: |
+            show_channel_urls: true
+            channel_priority: strict
+            channels:
+              - conda-forge
 
-  #     - name: generate token
-  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-  #       id: generate_token
-  #       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-  #       with:
-  #         client-id: ${{ secrets.CF_CURATOR_APP_ID }}
-  #         private-key: ${{ secrets.CF_CURATOR_PRIVATE_KEY }}
-  #         owner: ${{ github.repository_owner }}
+      - name: generate token
+        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+        id: generate_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.CF_CURATOR_APP_ID }}
+          private-key: ${{ secrets.CF_CURATOR_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
-  #     - name: install code
-  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-  #       run: |
-  #         git config --global user.email "79913779+conda-forge-curator[bot]@users.noreply.github.com"
-  #         git config --global user.name "conda-forge-curator[bot]"
-  #         git config --global pull.rebase false
-  #         mkdir -p ~/.conda-smithy/
-  #         echo $GH_TOKEN > ~/.conda-smithy/github.token
-  #         chmod 600 ~/.conda-smithy/github.token
-  #         pip install --no-deps --no-build-isolation -e .
-  #       env:
-  #         GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+      - name: install code
+        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+        run: |
+          git config --global user.email "79913779+conda-forge-curator[bot]@users.noreply.github.com"
+          git config --global user.name "conda-forge-curator[bot]"
+          git config --global pull.rebase false
+          mkdir -p ~/.conda-smithy/
+          echo $GH_TOKEN > ~/.conda-smithy/github.token
+          chmod 600 ~/.conda-smithy/github.token
+          pip install --no-deps --no-build-isolation -e .
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
 
-  #     - name: run linter tests
-  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-  #       run: |
-  #         if [[ "${GITHUB_HEAD_REF}" != "" ]]; then
-  #           branch="${GITHUB_HEAD_REF}"
-  #         else
-  #           branch="${GITHUB_REF_NAME}"
-  #         fi
+      - name: run linter tests
+        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+        run: |
+          if [[ "${GITHUB_HEAD_REF}" != "" ]]; then
+            branch="${GITHUB_HEAD_REF}"
+          else
+            branch="${GITHUB_REF_NAME}"
+          fi
 
-  #         version=$(python -c "import conda_forge_webservices; print(conda_forge_webservices.__version__.replace('+', '.'))")
-  #         export CF_FEEDSTOCK_OPS_CONTAINER_NAME=quay.io/condaforge/webservices-dispatch-action
-  #         export CF_FEEDSTOCK_OPS_CONTAINER_TAG="${version}"
+          version=$(python -c "import conda_forge_webservices; print(conda_forge_webservices.__version__.replace('+', '.'))")
+          export CF_FEEDSTOCK_OPS_CONTAINER_NAME=quay.io/condaforge/webservices-dispatch-action
+          export CF_FEEDSTOCK_OPS_CONTAINER_TAG="${version}"
 
-  #         cd tests
-  #         pytest -n 4 -vvs --branch=${branch} test_live_linter.py
-  #       env:
-  #         GH_TOKEN: ${{ secrets.CF_ADMIN_GITHUB_TOKEN }}
+          cd tests
+          pytest -n 4 -vvs --branch=${branch} test_live_linter.py
+        env:
+          GH_TOKEN: ${{ secrets.CF_ADMIN_GITHUB_TOKEN }}
 
-  # live-tests-version-update:
-  #   name: live-tests-version-update
-  #   runs-on: "ubuntu-latest"
-  #   needs:
-  #     - check
-  #     - tests
-  #     - docker-build
-  #   concurrency:
-  #     group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests-version-update' || format('{0}-{1}', github.workflow, github.ref) }}
-  #   steps:
-  #     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-  #       with:
-  #         fetch-depth: 0
+  live-tests-version-update:
+    name: live-tests-version-update
+    runs-on: "ubuntu-latest"
+    needs:
+      - check
+      - tests
+      - docker-build
+    concurrency:
+      group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests-version-update' || format('{0}-{1}', github.workflow, github.ref) }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+        with:
+          fetch-depth: 0
 
-  #     - name: setup conda
-  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-  #       uses: mamba-org/setup-micromamba@ce51e99f4bb8a82ab7158c4dc59ef4634c59c4f9 # v3.1.0
-  #       with:
-  #         micromamba-version: "2.7.0-0"
-  #         environment-file: conda-lock.yml
-  #         environment-name: webservices
-  #         condarc: |
-  #           show_channel_urls: true
-  #           channel_priority: strict
-  #           channels:
-  #             - conda-forge
+      - name: setup conda
+        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+        uses: mamba-org/setup-micromamba@ce51e99f4bb8a82ab7158c4dc59ef4634c59c4f9 # v3.1.0
+        with:
+          micromamba-version: "2.7.0-0"
+          environment-file: conda-lock.yml
+          environment-name: webservices
+          condarc: |
+            show_channel_urls: true
+            channel_priority: strict
+            channels:
+              - conda-forge
 
-  #     - name: generate token
-  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-  #       id: generate_token
-  #       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-  #       with:
-  #         client-id: ${{ secrets.CF_CURATOR_APP_ID }}
-  #         private-key: ${{ secrets.CF_CURATOR_PRIVATE_KEY }}
-  #         owner: ${{ github.repository_owner }}
+      - name: generate token
+        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+        id: generate_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.CF_CURATOR_APP_ID }}
+          private-key: ${{ secrets.CF_CURATOR_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
-  #     - name: install code
-  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-  #       run: |
-  #         git config --global user.email "79913779+conda-forge-curator[bot]@users.noreply.github.com"
-  #         git config --global user.name "conda-forge-curator[bot]"
-  #         git config --global pull.rebase false
-  #         mkdir -p ~/.conda-smithy/
-  #         echo $GH_TOKEN > ~/.conda-smithy/github.token
-  #         chmod 600 ~/.conda-smithy/github.token
-  #         pip install --no-deps --no-build-isolation -e .
-  #       env:
-  #         GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+      - name: install code
+        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+        run: |
+          git config --global user.email "79913779+conda-forge-curator[bot]@users.noreply.github.com"
+          git config --global user.name "conda-forge-curator[bot]"
+          git config --global pull.rebase false
+          mkdir -p ~/.conda-smithy/
+          echo $GH_TOKEN > ~/.conda-smithy/github.token
+          chmod 600 ~/.conda-smithy/github.token
+          pip install --no-deps --no-build-isolation -e .
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
 
-  #     - name: run version tests
-  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-  #       run: |
-  #         if [[ "${GITHUB_HEAD_REF}" != "" ]]; then
-  #           branch="${GITHUB_HEAD_REF}"
-  #         else
-  #           branch="${GITHUB_REF_NAME}"
-  #         fi
+      - name: run version tests
+        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+        run: |
+          if [[ "${GITHUB_HEAD_REF}" != "" ]]; then
+            branch="${GITHUB_HEAD_REF}"
+          else
+            branch="${GITHUB_REF_NAME}"
+          fi
 
-  #         version=$(python -c "import conda_forge_webservices; print(conda_forge_webservices.__version__.replace('+', '.'))")
-  #         export CF_FEEDSTOCK_OPS_CONTAINER_NAME=quay.io/condaforge/webservices-dispatch-action
-  #         export CF_FEEDSTOCK_OPS_CONTAINER_TAG="${version}"
+          version=$(python -c "import conda_forge_webservices; print(conda_forge_webservices.__version__.replace('+', '.'))")
+          export CF_FEEDSTOCK_OPS_CONTAINER_NAME=quay.io/condaforge/webservices-dispatch-action
+          export CF_FEEDSTOCK_OPS_CONTAINER_TAG="${version}"
 
-  #         cd tests
-  #         pytest -vvs --branch=${branch} test_live_version_update.py
-  #       env:
-  #         GH_TOKEN: ${{ secrets.CF_ADMIN_GITHUB_TOKEN }}
+          cd tests
+          pytest -vvs --branch=${branch} test_live_version_update.py
+        env:
+          GH_TOKEN: ${{ secrets.CF_ADMIN_GITHUB_TOKEN }}
 
-  # live-tests-automerge:
-  #   name: live-tests-automerge
-  #   runs-on: "ubuntu-latest"
-  #   needs:
-  #     - check
-  #     - tests
-  #   concurrency:
-  #     group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests-automerge' || format('{0}-{1}', github.workflow, github.ref) }}
-  #   steps:
-  #     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-  #       with:
-  #         fetch-depth: 0
+  live-tests-automerge:
+    name: live-tests-automerge
+    runs-on: "ubuntu-latest"
+    needs:
+      - check
+      - tests
+    concurrency:
+      group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests-automerge' || format('{0}-{1}', github.workflow, github.ref) }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+        with:
+          fetch-depth: 0
 
-  #     - name: setup conda
-  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-  #       uses: mamba-org/setup-micromamba@ce51e99f4bb8a82ab7158c4dc59ef4634c59c4f9 # v3.1.0
-  #       with:
-  #         micromamba-version: "2.7.0-0"
-  #         environment-file: conda-lock.yml
-  #         environment-name: webservices
-  #         condarc: |
-  #           show_channel_urls: true
-  #           channel_priority: strict
-  #           channels:
-  #             - conda-forge
+      - name: setup conda
+        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+        uses: mamba-org/setup-micromamba@ce51e99f4bb8a82ab7158c4dc59ef4634c59c4f9 # v3.1.0
+        with:
+          micromamba-version: "2.7.0-0"
+          environment-file: conda-lock.yml
+          environment-name: webservices
+          condarc: |
+            show_channel_urls: true
+            channel_priority: strict
+            channels:
+              - conda-forge
 
-  #     - name: generate token
-  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-  #       id: generate_token
-  #       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-  #       with:
-  #         client-id: ${{ secrets.CF_CURATOR_APP_ID }}
-  #         private-key: ${{ secrets.CF_CURATOR_PRIVATE_KEY }}
-  #         owner: ${{ github.repository_owner }}
+      - name: generate token
+        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+        id: generate_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.CF_CURATOR_APP_ID }}
+          private-key: ${{ secrets.CF_CURATOR_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
-  #     - name: install code
-  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-  #       run: |
-  #         git config --global user.email "79913779+conda-forge-curator[bot]@users.noreply.github.com"
-  #         git config --global user.name "conda-forge-curator[bot]"
-  #         git config --global pull.rebase false
-  #         pip install --no-deps --no-build-isolation -e .
+      - name: install code
+        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+        run: |
+          git config --global user.email "79913779+conda-forge-curator[bot]@users.noreply.github.com"
+          git config --global user.name "conda-forge-curator[bot]"
+          git config --global pull.rebase false
+          pip install --no-deps --no-build-isolation -e .
 
-  #     - name: run automerge tests
-  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-  #       run: |
-  #         if [[ "${GITHUB_HEAD_REF}" != "" ]]; then
-  #           branch="${GITHUB_HEAD_REF}"
-  #         else
-  #           branch="${GITHUB_REF_NAME}"
-  #         fi
+      - name: run automerge tests
+        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+        run: |
+          if [[ "${GITHUB_HEAD_REF}" != "" ]]; then
+            branch="${GITHUB_HEAD_REF}"
+          else
+            branch="${GITHUB_REF_NAME}"
+          fi
 
-  #         cd tests
-  #         pytest -vvs --branch=${branch} test_live_automerge.py
-  #       env:
-  #         GHA_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-  #         GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+          cd tests
+          pytest -vvs --branch=${branch} test_live_automerge.py
+        env:
+          GHA_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
 
   live-tests-convert-recipe-to-v1:
     name: live-tests-convert-recipe-to-v1
@@ -568,7 +568,7 @@ jobs:
       - check
       - tests
       - docker-build
-      # - live-tests-version-update
+      - live-tests-version-update
     concurrency:
       group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests-convert-recipe-to-v1' || format('{0}-{1}', github.workflow, github.ref) }}
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -568,6 +568,7 @@ jobs:
       - check
       - tests
       - docker-build
+      # - live-tests-version-update
     concurrency:
       group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests-convert-recipe-to-v1' || format('{0}-{1}', github.workflow, github.ref) }}
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -131,7 +131,7 @@ jobs:
         if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.CF_CURATOR_APP_ID }}
+          client-id: ${{ secrets.CF_CURATOR_APP_ID }}
           private-key: ${{ secrets.CF_CURATOR_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
@@ -234,79 +234,342 @@ jobs:
           username: conda_forge_daemon
           password: ${{ secrets.CF_DAEMON_QUAY_PASSWORD }}
 
-  live-tests-upload:
-    name: live-tests-upload
-    runs-on: "ubuntu-latest"
-    needs:
-      - check
-      - tests
-    concurrency:
-      group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests-upload' || format('{0}-{1}', github.workflow, github.ref) }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-        with:
-          fetch-depth: 0
+  # live-tests-upload:
+  #   name: live-tests-upload
+  #   runs-on: "ubuntu-latest"
+  #   needs:
+  #     - check
+  #     - tests
+  #   concurrency:
+  #     group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests-upload' || format('{0}-{1}', github.workflow, github.ref) }}
+  #   steps:
+  #     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+  #       with:
+  #         fetch-depth: 0
 
-      - name: setup conda
-        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-        uses: mamba-org/setup-micromamba@ce51e99f4bb8a82ab7158c4dc59ef4634c59c4f9 # v3.1.0
-        with:
-          micromamba-version: "2.7.0-0"
-          environment-file: conda-lock.yml
-          environment-name: webservices
-          condarc: |
-            show_channel_urls: true
-            channel_priority: strict
-            channels:
-              - conda-forge
+  #     - name: setup conda
+  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+  #       uses: mamba-org/setup-micromamba@ce51e99f4bb8a82ab7158c4dc59ef4634c59c4f9 # v3.1.0
+  #       with:
+  #         micromamba-version: "2.7.0-0"
+  #         environment-file: conda-lock.yml
+  #         environment-name: webservices
+  #         condarc: |
+  #           show_channel_urls: true
+  #           channel_priority: strict
+  #           channels:
+  #             - conda-forge
 
-      - name: generate token
-        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-        id: generate_token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ secrets.CF_CURATOR_APP_ID }}
-          private-key: ${{ secrets.CF_CURATOR_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
+  #     - name: generate token
+  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+  #       id: generate_token
+  #       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+  #       with:
+  #         client-id: ${{ secrets.CF_CURATOR_APP_ID }}
+  #         private-key: ${{ secrets.CF_CURATOR_PRIVATE_KEY }}
+  #         owner: ${{ github.repository_owner }}
 
-      - name: install code
-        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-        run: |
-          git config --global user.email "79913779+conda-forge-curator[bot]@users.noreply.github.com"
-          git config --global user.name "conda-forge-curator[bot]"
-          git config --global pull.rebase false
-          mkdir -p ~/.conda-smithy/
-          echo $GH_TOKEN > ~/.conda-smithy/github.token
-          chmod 600 ~/.conda-smithy/github.token
-          pip install --no-deps --no-build-isolation -e .
-        env:
-          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+  #     - name: install code
+  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+  #       run: |
+  #         git config --global user.email "79913779+conda-forge-curator[bot]@users.noreply.github.com"
+  #         git config --global user.name "conda-forge-curator[bot]"
+  #         git config --global pull.rebase false
+  #         mkdir -p ~/.conda-smithy/
+  #         echo $GH_TOKEN > ~/.conda-smithy/github.token
+  #         chmod 600 ~/.conda-smithy/github.token
+  #         pip install --no-deps --no-build-isolation -e .
+  #       env:
+  #         GH_TOKEN: ${{ steps.generate_token.outputs.token }}
 
-      - name: run package upload tests
-        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-        run: |
-          export CF_WEBSERVICES_TEST=1
-          ./scripts/run_cfep13_tests.sh
-        env:
-          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
-          PROD_BINSTAR_TOKEN: ${{ secrets.PROD_BINSTAR_TOKEN }}
-          STAGING_BINSTAR_TOKEN: ${{ secrets.HEROKU_ONLY_STAGING_BINSTAR_TOKEN }}
-          POST_STAGING_BINSTAR_TOKEN: ${{ secrets.POST_STAGING_BINSTAR_TOKEN }}
-          CF_WEBSERVICES_TOKEN: ${{ secrets.CF_WEBSERVICES_TOKEN }}
-          CF_WEBSERVICES_APP_ID: ${{ secrets.CF_CURATOR_APP_ID }}
-          CF_WEBSERVICES_PRIVATE_KEY: ${{ secrets.CF_CURATOR_PRIVATE_KEY }}
-          ACTION_URL: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
+  #     - name: run package upload tests
+  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+  #       run: |
+  #         export CF_WEBSERVICES_TEST=1
+  #         ./scripts/run_cfep13_tests.sh
+  #       env:
+  #         GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+  #         PROD_BINSTAR_TOKEN: ${{ secrets.PROD_BINSTAR_TOKEN }}
+  #         STAGING_BINSTAR_TOKEN: ${{ secrets.HEROKU_ONLY_STAGING_BINSTAR_TOKEN }}
+  #         POST_STAGING_BINSTAR_TOKEN: ${{ secrets.POST_STAGING_BINSTAR_TOKEN }}
+  #         CF_WEBSERVICES_TOKEN: ${{ secrets.CF_WEBSERVICES_TOKEN }}
+  #         CF_WEBSERVICES_APP_ID: ${{ secrets.CF_CURATOR_APP_ID }}
+  #         CF_WEBSERVICES_PRIVATE_KEY: ${{ secrets.CF_CURATOR_PRIVATE_KEY }}
+  #         ACTION_URL: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
 
-  live-tests-rerender:
-    name: live-tests-rerender
+  # live-tests-rerender:
+  #   name: live-tests-rerender
+  #   runs-on: "ubuntu-latest"
+  #   needs:
+  #     - check
+  #     - tests
+  #     - docker-build
+  #   concurrency:
+  #     group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests-rerender' || format('{0}-{1}', github.workflow, github.ref) }}
+  #   steps:
+  #     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+  #       with:
+  #         fetch-depth: 0
+
+  #     - name: setup conda
+  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+  #       uses: mamba-org/setup-micromamba@ce51e99f4bb8a82ab7158c4dc59ef4634c59c4f9 # v3.1.0
+  #       with:
+  #         micromamba-version: "2.7.0-0"
+  #         environment-file: conda-lock.yml
+  #         environment-name: webservices
+  #         condarc: |
+  #           show_channel_urls: true
+  #           channel_priority: strict
+  #           channels:
+  #             - conda-forge
+
+  #     - name: generate token
+  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+  #       id: generate_token
+  #       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+  #       with:
+  #         client-id: ${{ secrets.CF_CURATOR_APP_ID }}
+  #         private-key: ${{ secrets.CF_CURATOR_PRIVATE_KEY }}
+  #         owner: ${{ github.repository_owner }}
+
+  #     - name: install code
+  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+  #       run: |
+  #         git config --global user.email "79913779+conda-forge-curator[bot]@users.noreply.github.com"
+  #         git config --global user.name "conda-forge-curator[bot]"
+  #         git config --global pull.rebase false
+  #         mkdir -p ~/.conda-smithy/
+  #         echo $GH_TOKEN > ~/.conda-smithy/github.token
+  #         chmod 600 ~/.conda-smithy/github.token
+  #         pip install --no-deps --no-build-isolation -e .
+  #       env:
+  #         GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+
+  #     - name: run rerender tests
+  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+  #       run: |
+  #         if [[ "${GITHUB_HEAD_REF}" != "" ]]; then
+  #           branch="${GITHUB_HEAD_REF}"
+  #         else
+  #           branch="${GITHUB_REF_NAME}"
+  #         fi
+
+  #         version=$(python -c "import conda_forge_webservices; print(conda_forge_webservices.__version__.replace('+', '.'))")
+  #         export CF_FEEDSTOCK_OPS_CONTAINER_NAME=quay.io/condaforge/webservices-dispatch-action
+  #         export CF_FEEDSTOCK_OPS_CONTAINER_TAG="${version}"
+
+  #         cd tests
+  #         pytest -vvs --branch=${branch} test_live_rerender.py
+  #       env:
+  #         GH_TOKEN: ${{ secrets.CF_ADMIN_GITHUB_TOKEN }}
+
+  # live-tests-linter:
+  #   name: live-tests-linter
+  #   runs-on: "ubuntu-latest"
+  #   needs:
+  #     - check
+  #     - tests
+  #     - docker-build
+  #   concurrency:
+  #     group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests-linter' || format('{0}-{1}', github.workflow, github.ref) }}
+  #   steps:
+  #     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+  #       with:
+  #         fetch-depth: 0
+
+  #     - name: setup conda
+  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+  #       uses: mamba-org/setup-micromamba@ce51e99f4bb8a82ab7158c4dc59ef4634c59c4f9 # v3.1.0
+  #       with:
+  #         micromamba-version: "2.7.0-0"
+  #         environment-file: conda-lock.yml
+  #         environment-name: webservices
+  #         condarc: |
+  #           show_channel_urls: true
+  #           channel_priority: strict
+  #           channels:
+  #             - conda-forge
+
+  #     - name: generate token
+  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+  #       id: generate_token
+  #       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+  #       with:
+  #         client-id: ${{ secrets.CF_CURATOR_APP_ID }}
+  #         private-key: ${{ secrets.CF_CURATOR_PRIVATE_KEY }}
+  #         owner: ${{ github.repository_owner }}
+
+  #     - name: install code
+  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+  #       run: |
+  #         git config --global user.email "79913779+conda-forge-curator[bot]@users.noreply.github.com"
+  #         git config --global user.name "conda-forge-curator[bot]"
+  #         git config --global pull.rebase false
+  #         mkdir -p ~/.conda-smithy/
+  #         echo $GH_TOKEN > ~/.conda-smithy/github.token
+  #         chmod 600 ~/.conda-smithy/github.token
+  #         pip install --no-deps --no-build-isolation -e .
+  #       env:
+  #         GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+
+  #     - name: run linter tests
+  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+  #       run: |
+  #         if [[ "${GITHUB_HEAD_REF}" != "" ]]; then
+  #           branch="${GITHUB_HEAD_REF}"
+  #         else
+  #           branch="${GITHUB_REF_NAME}"
+  #         fi
+
+  #         version=$(python -c "import conda_forge_webservices; print(conda_forge_webservices.__version__.replace('+', '.'))")
+  #         export CF_FEEDSTOCK_OPS_CONTAINER_NAME=quay.io/condaforge/webservices-dispatch-action
+  #         export CF_FEEDSTOCK_OPS_CONTAINER_TAG="${version}"
+
+  #         cd tests
+  #         pytest -n 4 -vvs --branch=${branch} test_live_linter.py
+  #       env:
+  #         GH_TOKEN: ${{ secrets.CF_ADMIN_GITHUB_TOKEN }}
+
+  # live-tests-version-update:
+  #   name: live-tests-version-update
+  #   runs-on: "ubuntu-latest"
+  #   needs:
+  #     - check
+  #     - tests
+  #     - docker-build
+  #   concurrency:
+  #     group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests-version-update' || format('{0}-{1}', github.workflow, github.ref) }}
+  #   steps:
+  #     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+  #       with:
+  #         fetch-depth: 0
+
+  #     - name: setup conda
+  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+  #       uses: mamba-org/setup-micromamba@ce51e99f4bb8a82ab7158c4dc59ef4634c59c4f9 # v3.1.0
+  #       with:
+  #         micromamba-version: "2.7.0-0"
+  #         environment-file: conda-lock.yml
+  #         environment-name: webservices
+  #         condarc: |
+  #           show_channel_urls: true
+  #           channel_priority: strict
+  #           channels:
+  #             - conda-forge
+
+  #     - name: generate token
+  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+  #       id: generate_token
+  #       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+  #       with:
+  #         client-id: ${{ secrets.CF_CURATOR_APP_ID }}
+  #         private-key: ${{ secrets.CF_CURATOR_PRIVATE_KEY }}
+  #         owner: ${{ github.repository_owner }}
+
+  #     - name: install code
+  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+  #       run: |
+  #         git config --global user.email "79913779+conda-forge-curator[bot]@users.noreply.github.com"
+  #         git config --global user.name "conda-forge-curator[bot]"
+  #         git config --global pull.rebase false
+  #         mkdir -p ~/.conda-smithy/
+  #         echo $GH_TOKEN > ~/.conda-smithy/github.token
+  #         chmod 600 ~/.conda-smithy/github.token
+  #         pip install --no-deps --no-build-isolation -e .
+  #       env:
+  #         GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+
+  #     - name: run version tests
+  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+  #       run: |
+  #         if [[ "${GITHUB_HEAD_REF}" != "" ]]; then
+  #           branch="${GITHUB_HEAD_REF}"
+  #         else
+  #           branch="${GITHUB_REF_NAME}"
+  #         fi
+
+  #         version=$(python -c "import conda_forge_webservices; print(conda_forge_webservices.__version__.replace('+', '.'))")
+  #         export CF_FEEDSTOCK_OPS_CONTAINER_NAME=quay.io/condaforge/webservices-dispatch-action
+  #         export CF_FEEDSTOCK_OPS_CONTAINER_TAG="${version}"
+
+  #         cd tests
+  #         pytest -vvs --branch=${branch} test_live_version_update.py
+  #       env:
+  #         GH_TOKEN: ${{ secrets.CF_ADMIN_GITHUB_TOKEN }}
+
+  # live-tests-automerge:
+  #   name: live-tests-automerge
+  #   runs-on: "ubuntu-latest"
+  #   needs:
+  #     - check
+  #     - tests
+  #   concurrency:
+  #     group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests-automerge' || format('{0}-{1}', github.workflow, github.ref) }}
+  #   steps:
+  #     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+  #       with:
+  #         fetch-depth: 0
+
+  #     - name: setup conda
+  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+  #       uses: mamba-org/setup-micromamba@ce51e99f4bb8a82ab7158c4dc59ef4634c59c4f9 # v3.1.0
+  #       with:
+  #         micromamba-version: "2.7.0-0"
+  #         environment-file: conda-lock.yml
+  #         environment-name: webservices
+  #         condarc: |
+  #           show_channel_urls: true
+  #           channel_priority: strict
+  #           channels:
+  #             - conda-forge
+
+  #     - name: generate token
+  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+  #       id: generate_token
+  #       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+  #       with:
+  #         client-id: ${{ secrets.CF_CURATOR_APP_ID }}
+  #         private-key: ${{ secrets.CF_CURATOR_PRIVATE_KEY }}
+  #         owner: ${{ github.repository_owner }}
+
+  #     - name: install code
+  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+  #       run: |
+  #         git config --global user.email "79913779+conda-forge-curator[bot]@users.noreply.github.com"
+  #         git config --global user.name "conda-forge-curator[bot]"
+  #         git config --global pull.rebase false
+  #         pip install --no-deps --no-build-isolation -e .
+
+  #     - name: run automerge tests
+  #       if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
+  #       run: |
+  #         if [[ "${GITHUB_HEAD_REF}" != "" ]]; then
+  #           branch="${GITHUB_HEAD_REF}"
+  #         else
+  #           branch="${GITHUB_REF_NAME}"
+  #         fi
+
+  #         cd tests
+  #         pytest -vvs --branch=${branch} test_live_automerge.py
+  #       env:
+  #         GHA_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  #         GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+
+  live-tests-convert-recipe-to-v1:
+    name: live-tests-convert-recipe-to-v1
     runs-on: "ubuntu-latest"
     needs:
       - check
       - tests
       - docker-build
     concurrency:
-      group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests-rerender' || format('{0}-{1}', github.workflow, github.ref) }}
+      group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests-convert-recipe-to-v1' || format('{0}-{1}', github.workflow, github.ref) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
@@ -331,7 +594,7 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.CF_CURATOR_APP_ID }}
+          client-id: ${{ secrets.CF_CURATOR_APP_ID }}
           private-key: ${{ secrets.CF_CURATOR_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
@@ -348,7 +611,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
 
-      - name: run rerender tests
+      - name: run recipe conversion tests
         if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
         run: |
           if [[ "${GITHUB_HEAD_REF}" != "" ]]; then
@@ -362,201 +625,6 @@ jobs:
           export CF_FEEDSTOCK_OPS_CONTAINER_TAG="${version}"
 
           cd tests
-          pytest -vvs --branch=${branch} test_live_rerender.py
+          pytest -vvs --branch=${branch} test_live_convert_recipe_to_v1.py
         env:
           GH_TOKEN: ${{ secrets.CF_ADMIN_GITHUB_TOKEN }}
-
-  live-tests-linter:
-    name: live-tests-linter
-    runs-on: "ubuntu-latest"
-    needs:
-      - check
-      - tests
-      - docker-build
-    concurrency:
-      group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests-linter' || format('{0}-{1}', github.workflow, github.ref) }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-        with:
-          fetch-depth: 0
-
-      - name: setup conda
-        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-        uses: mamba-org/setup-micromamba@ce51e99f4bb8a82ab7158c4dc59ef4634c59c4f9 # v3.1.0
-        with:
-          micromamba-version: "2.7.0-0"
-          environment-file: conda-lock.yml
-          environment-name: webservices
-          condarc: |
-            show_channel_urls: true
-            channel_priority: strict
-            channels:
-              - conda-forge
-
-      - name: generate token
-        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-        id: generate_token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ secrets.CF_CURATOR_APP_ID }}
-          private-key: ${{ secrets.CF_CURATOR_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
-      - name: install code
-        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-        run: |
-          git config --global user.email "79913779+conda-forge-curator[bot]@users.noreply.github.com"
-          git config --global user.name "conda-forge-curator[bot]"
-          git config --global pull.rebase false
-          mkdir -p ~/.conda-smithy/
-          echo $GH_TOKEN > ~/.conda-smithy/github.token
-          chmod 600 ~/.conda-smithy/github.token
-          pip install --no-deps --no-build-isolation -e .
-        env:
-          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
-
-      - name: run linter tests
-        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-        run: |
-          if [[ "${GITHUB_HEAD_REF}" != "" ]]; then
-            branch="${GITHUB_HEAD_REF}"
-          else
-            branch="${GITHUB_REF_NAME}"
-          fi
-
-          version=$(python -c "import conda_forge_webservices; print(conda_forge_webservices.__version__.replace('+', '.'))")
-          export CF_FEEDSTOCK_OPS_CONTAINER_NAME=quay.io/condaforge/webservices-dispatch-action
-          export CF_FEEDSTOCK_OPS_CONTAINER_TAG="${version}"
-
-          cd tests
-          pytest -n 4 -vvs --branch=${branch} test_live_linter.py
-        env:
-          GH_TOKEN: ${{ secrets.CF_ADMIN_GITHUB_TOKEN }}
-
-  live-tests-version-update:
-    name: live-tests-version-update
-    runs-on: "ubuntu-latest"
-    needs:
-      - check
-      - tests
-      - docker-build
-    concurrency:
-      group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests-version-update' || format('{0}-{1}', github.workflow, github.ref) }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-        with:
-          fetch-depth: 0
-
-      - name: setup conda
-        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-        uses: mamba-org/setup-micromamba@ce51e99f4bb8a82ab7158c4dc59ef4634c59c4f9 # v3.1.0
-        with:
-          micromamba-version: "2.7.0-0"
-          environment-file: conda-lock.yml
-          environment-name: webservices
-          condarc: |
-            show_channel_urls: true
-            channel_priority: strict
-            channels:
-              - conda-forge
-
-      - name: generate token
-        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-        id: generate_token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ secrets.CF_CURATOR_APP_ID }}
-          private-key: ${{ secrets.CF_CURATOR_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
-      - name: install code
-        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-        run: |
-          git config --global user.email "79913779+conda-forge-curator[bot]@users.noreply.github.com"
-          git config --global user.name "conda-forge-curator[bot]"
-          git config --global pull.rebase false
-          mkdir -p ~/.conda-smithy/
-          echo $GH_TOKEN > ~/.conda-smithy/github.token
-          chmod 600 ~/.conda-smithy/github.token
-          pip install --no-deps --no-build-isolation -e .
-        env:
-          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
-
-      - name: run version tests
-        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-        run: |
-          if [[ "${GITHUB_HEAD_REF}" != "" ]]; then
-            branch="${GITHUB_HEAD_REF}"
-          else
-            branch="${GITHUB_REF_NAME}"
-          fi
-
-          version=$(python -c "import conda_forge_webservices; print(conda_forge_webservices.__version__.replace('+', '.'))")
-          export CF_FEEDSTOCK_OPS_CONTAINER_NAME=quay.io/condaforge/webservices-dispatch-action
-          export CF_FEEDSTOCK_OPS_CONTAINER_TAG="${version}"
-
-          cd tests
-          pytest -vvs --branch=${branch} test_live_version_update.py
-        env:
-          GH_TOKEN: ${{ secrets.CF_ADMIN_GITHUB_TOKEN }}
-
-  live-tests-automerge:
-    name: live-tests-automerge
-    runs-on: "ubuntu-latest"
-    needs:
-      - check
-      - tests
-    concurrency:
-      group: ${{ github.event.pull_request.head.repo.fork != 'true' && 'live-tests-automerge' || format('{0}-{1}', github.workflow, github.ref) }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-        with:
-          fetch-depth: 0
-
-      - name: setup conda
-        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-        uses: mamba-org/setup-micromamba@ce51e99f4bb8a82ab7158c4dc59ef4634c59c4f9 # v3.1.0
-        with:
-          micromamba-version: "2.7.0-0"
-          environment-file: conda-lock.yml
-          environment-name: webservices
-          condarc: |
-            show_channel_urls: true
-            channel_priority: strict
-            channels:
-              - conda-forge
-
-      - name: generate token
-        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-        id: generate_token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ secrets.CF_CURATOR_APP_ID }}
-          private-key: ${{ secrets.CF_CURATOR_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
-      - name: install code
-        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-        run: |
-          git config --global user.email "79913779+conda-forge-curator[bot]@users.noreply.github.com"
-          git config --global user.name "conda-forge-curator[bot]"
-          git config --global pull.rebase false
-          pip install --no-deps --no-build-isolation -e .
-
-      - name: run automerge tests
-        if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
-        run: |
-          if [[ "${GITHUB_HEAD_REF}" != "" ]]; then
-            branch="${GITHUB_HEAD_REF}"
-          else
-            branch="${GITHUB_REF_NAME}"
-          fi
-
-          cd tests
-          pytest -vvs --branch=${branch} test_live_automerge.py
-        env:
-          GHA_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          GH_TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -13,7 +13,7 @@
 version: 1
 metadata:
   content_hash:
-    linux-64: a59cb45417da23ad5cd098ca72529e836372d4cfb6b918af7029966295d6c09c
+    linux-64: c47cd955a98aeda7d3a9fee6cac209233c3f0f2bab0df05d06f617400aec717d
   channels:
   - url: conda-forge
     used_env_vars: []
@@ -388,7 +388,7 @@ package:
   category: main
   optional: false
 - name: botocore
-  version: 1.43.81
+  version: 1.43.82
   manager: conda
   platform: linux-64
   dependencies:
@@ -396,10 +396,10 @@ package:
     python: '>=3.10'
     python-dateutil: '>=2.1,<3.0.0'
     urllib3: '>=1.25.4,!=2.2.0,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.43.81-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.43.82-pyhd8ed1ab_0.conda
   hash:
-    md5: bfa2cc0aea841900547d896e2b4a121f
-    sha256: 6c2313153639052358c67e9f3c13086ea568f4e45c207ea332955977d629b80a
+    md5: 6030b5a42ea92add4fa545baba0154d8
+    sha256: b56a2616e335b83f1ee310f7c049649875c8854abedb92d64ede531b85059a37
   category: main
   optional: false
 - name: brotli-python
@@ -746,7 +746,7 @@ package:
   category: main
   optional: false
 - name: conda-forge-feedstock-ops
-  version: 0.18.0
+  version: 0.18.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -768,10 +768,10 @@ package:
     ruamel.yaml.jinja2: ''
     wurlitzer: ''
     zstandard: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/conda-forge-feedstock-ops-0.18.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/conda-forge-feedstock-ops-0.18.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 9ebf9a2ee3195888584c7898b94c4ab2
-    sha256: 95f3e1ea22b3c2ff5737f786e159c590af421e93225bb67403bf13819050f97f
+    md5: 2c088e21eac46ca90905afd5578e772a
+    sha256: c1b294d8dea665b41e8f8a6789a41b12e9170cb8ff8ddec615bfd522e73da6c7
   category: main
   optional: false
 - name: conda-forge-metadata
@@ -793,14 +793,14 @@ package:
   category: main
   optional: false
 - name: conda-forge-pinning
-  version: 2026.08.26.23.15.14
+  version: 2026.08.28.08.21.25
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/conda-forge-pinning-2026.08.26.23.15.14-hd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/conda-forge-pinning-2026.08.28.08.21.25-hd8ed1ab_0.conda
   hash:
-    md5: 1faec9061b38d54a9364ef8c8b3bb5b0
-    sha256: e29c10058ec3e7489dd0a1c04adbb870f8c32ac063d10c1de2138a0cd9e302b5
+    md5: 589d6cf82e253a996ac80a3380ed904d
+    sha256: 0ae696f6ed2c03018aa54c9583c6ba776bed878c7ca68a0620a5aa257394c630
   category: main
   optional: false
 - name: conda-forge-tick
@@ -1778,12 +1778,12 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libffi: ''
-    libgcc: '>=14'
+    libgcc: '>=15'
     libglib: ==2.88.3
-  url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.88.3-h4916ab3_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.88.3-h67ed8a3_2.conda
   hash:
-    md5: 246c12ff18139b126586eb2d0e906c7e
-    sha256: ffa59cd7b517ed0a5905cc83643d08117f073502b0bdb1cab1835805ecc8da4e
+    md5: 5c35ace78b7d630e77efcb37dacb62ae
+    sha256: 966f78753d7f044df52a0b32876580ee15f006e8ec960afa5360c50e66be0fc5
   category: main
   optional: false
 - name: gmp
@@ -2726,14 +2726,14 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libffi: '>=3.7.0,<3.8.0a0'
-    libgcc: '>=14'
+    libgcc: '>=15'
     libiconv: '>=1.18,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
     pcre2: '>=10.47,<10.48.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.3-h45c3219_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.3-he503a2a_2.conda
   hash:
-    md5: 533cb021c1bfeba9f720e669cd863fdf
-    sha256: 4499458124bcf0bd45e8bd17576f9f007cb1373cb3b01659105443f522bab45c
+    md5: 533d342dedadf134c67760ce6fc5b748
+    sha256: af6c14f387f810c5df491b328ae955329596d3bc73b1e2e091ab5adb46a10759
   category: main
   optional: false
 - name: libglvnd
@@ -2937,10 +2937,10 @@ package:
     spdlog: '>=1.17.0,<1.18.0a0'
     yaml-cpp: '>=0.8.0,<0.9.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libmamba-2.9.0-py314h3b59866_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libmamba-2.9.0-py312h2d0c9bb_0.conda
   hash:
-    md5: 444e55c79d67040779af3a0167963bea
-    sha256: 1b9ca94f36f6072ff71550dfaa8dd4106a118bf01f352ed639aef134b462bab6
+    md5: 51ba582481cea91b5bdcbf91bfa4cff1
+    sha256: 1c9ab757ba4c1148771cbd0fa1a1f3e3b38ea492ee92ba3fcee3e3b1cd3b1384
   category: main
   optional: false
 - name: libmamba-spdlog
@@ -2952,10 +2952,10 @@ package:
     libgcc: '>=14'
     libmamba: '>=2.9.0,<2.10.0a0'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libmamba-spdlog-2.9.0-hf1e253f_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libmamba-spdlog-2.9.0-habb885a_0.conda
   hash:
-    md5: 1066c66681f6a1d6e36d13dc3eecbd50
-    sha256: ddae16548197cf30cf72d700733427cb314ce6fa2921fea7e2922566288de42e
+    md5: bb6b4507713ead7f390486169179c686
+    sha256: 8b8333496589d829c9dcca4403122f1341a680bc735ec4b85e354747387114c8
   category: main
   optional: false
 - name: libmambapy
@@ -2971,16 +2971,16 @@ package:
     libstdcxx: '>=14'
     nlohmann_json-abi: 3.12.0
     openssl: '>=3.5.7,<4.0a0'
-    pybind11-abi: '11'
+    pybind11-abi: '4'
     python: ''
     python_abi: 3.12.*
     spdlog: '>=1.17.0,<1.18.0a0'
     yaml-cpp: '>=0.8.0,<0.9.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libmambapy-2.9.0-py312h9266df1_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libmambapy-2.9.0-py312h4a71922_0.conda
   hash:
-    md5: df622382b1873ff09421d4276da78de8
-    sha256: 4fe6ebcf06564927d372dd8f76eb8a8e68d5f9e8f99ae0e8581ca82844c8a07f
+    md5: 2cbc32d24ea456217a689998f5a46091
+    sha256: a5bdc79bf6cb00380fc01d4f6c04610d3cf9d237f7884871a108a9b93621a003
   category: main
   optional: false
 - name: libmsgpack-c
@@ -3258,10 +3258,10 @@ package:
     pthread-stubs: ''
     xorg-libxau: '>=1.0.12,<2.0a0'
     xorg-libxdmcp: '>=1.1.5,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-hb83e432_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-hb83e432_2.conda
   hash:
-    md5: 64e856c420205b009da26471d3ac161d
-    sha256: ce25a1efa85a78a3ce3b16721d9c36153814adbf2fb004a15f72ec69894b4cb1
+    md5: 61f0ffba9161cbb3a77722869b21e4bb
+    sha256: 7b49e6fd2a584b7f072943e6adf4149677af5121246975278804782d37752837
   category: main
   optional: false
 - name: libxcrypt
@@ -3451,10 +3451,10 @@ package:
     reproc: '>=14.2.7.post0,<14.3.0a0'
     reproc-cpp: '>=14.2.7.post0,<14.3.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/mamba-2.9.0-h1a727f0_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/mamba-2.9.0-h11589d2_0.conda
   hash:
-    md5: a67598b3c6befa1aefa4212b3d4c6b73
-    sha256: 0e56d283337d9a95ba4b8821a1a64434199cde6094443d4f10b743701fd20dde
+    md5: 53613301e1d6449798ccac2bbb2d14e2
+    sha256: 5dd41bf88618f3bf600a0cbdf3dcc18aa0988ab7dac971643d2263f5aa3db79c
   category: main
   optional: false
 - name: markdown-it-py
@@ -3962,15 +3962,15 @@ package:
   category: main
   optional: false
 - name: platformdirs
-  version: 4.11.4
+  version: 4.11.5
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.11.4-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.11.5-pyhcf101f3_0.conda
   hash:
-    md5: 840f27e0254bcdc8382ac2ca32782a22
-    sha256: 36596d60d6bc49c4c27f009ab3128c63ea50ac5d67dffc44df05ab3d78bc4669
+    md5: 152ec36401f710145a7db03475594410
+    sha256: 4496a7e0b584a388b3580ab594a4f384696ab7d702282588fd33a7ee38af983c
   category: main
   optional: false
 - name: pluggy
@@ -4066,10 +4066,10 @@ package:
     libgcc: '>=15'
     openssl: '>=3.5.8,<4.0a0'
     python: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/py-rattler-0.25.0-py310hefeb9ab_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/py-rattler-0.25.0-py310hefeb9ab_3.conda
   hash:
-    md5: 04a00061f404b1420ea34f39030a9aef
-    sha256: 71735e1900ebdaca911a4a3b39ae08d2653f209ebb88b7a1ea710213affbaac3
+    md5: 2a75e016bb35e33e2acb65ee2aa4f0af
+    sha256: 673052cec285da1db0198313277b077103b8f235b12b9564cce8af5222b4af70
   category: main
   optional: false
 - name: py-rattler-build
@@ -4090,14 +4090,14 @@ package:
   category: main
   optional: false
 - name: pybind11-abi
-  version: '11'
+  version: '4'
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
   hash:
-    md5: f0599959a2447c1e544e216bddf393fa
-    sha256: 9e7fe12f727acd2787fb5816b2049cef4604b7a00ad3e408c5e709c298ce8bf1
+    md5: 878f923dd6acc8aeb47a75da6c4098be
+    sha256: d4fb485b79b11042a16dc6abfb0c44c4f557707c2653ac47c81e5d32b24a3bb0
   category: main
   optional: false
 - name: pycosat
@@ -4403,7 +4403,7 @@ package:
   category: main
   optional: false
 - name: python-build
-  version: 1.5.0
+  version: 1.6.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -4413,10 +4413,10 @@ package:
     pyproject_hooks: ''
     python: '>=3.10'
     tomli: '>=1.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-build-1.5.0-pyhc364b38_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-build-1.6.0-pyhc364b38_0.conda
   hash:
-    md5: fa587158c0d768127faa1a3b4df01e5d
-    sha256: eb8d5e44fddee9033eb7cfdd5ea584b7594b50e31c7602bef553af0fd4ee9266
+    md5: 1e696c762d003f8f4af971b6dccb8c1e
+    sha256: d5bad775346fbd21cce7922b29cab2587fe599517654de65c3d2fe50a7126279
   category: main
   optional: false
 - name: python-dateutil
@@ -5387,17 +5387,17 @@ package:
   category: main
   optional: false
 - name: uv
-  version: 0.12.6
+  version: 0.12.7
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=15'
     libstdcxx: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/uv-0.12.6-h86a270d_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/uv-0.12.7-h86a270d_0.conda
   hash:
-    md5: 84cbc7778da4fff389cc7b94312e0e6b
-    sha256: 9cd22c40e07e22d7f5de6c8c604dc25e1c428c34c380ee0ae88519742703ebfb
+    md5: 14a917c8e21f3faa2fabb8a761b793dc
+    sha256: fdd3fc7b02dfcf0a357cd5596910e6f2696d27873f8bcac2f83d2c4db365b6e9
   category: main
   optional: false
 - name: vcs_versioning
@@ -5873,10 +5873,10 @@ package:
     python: ''
     python_abi: 3.12.*
     zstd: '>=1.5.7,<1.5.8.0a0,>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.25.0-py312h1b36aeb_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.25.0-py312h1b36aeb_3.conda
   hash:
-    md5: 703b4411975b98e49aa05f953e5de743
-    sha256: b0e01b9ed3a584de9012c94d3a4081a760e58cf7c41f74111e61245fba273aa3
+    md5: b71258304496a49e77c66650459089d1
+    sha256: 7c2b7d721ae03896f4ac7d0d806567ba92786de94efc79e14512f355552bcdca
   category: main
   optional: false
 - name: zstd

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -474,7 +474,7 @@ def pr_detailed_comment(
 
                 I tried to convert the recipe to v1 for you but ran into an issue with kicking GitHub Actions.
                 Please ping conda-forge/core for further assistance.
-                """).format(doc_url)  # ruff: ignore[line-too-long]
+                """)  # ruff: ignore[line-too-long]
 
         if message is not None:
             gh = get_gh_client()

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -48,9 +48,7 @@ RERENDER_MSG = re.compile(pre + "(please )?re-?render", re.I)
 RESTART_CI = re.compile(pre + "(please )?restart (build|builds|ci)", re.I)
 LINT_MSG = re.compile(pre + "(please )?(re-?)?lint", re.I)
 UPDATE_TEAM_MSG = re.compile(pre + "(please )?(update|refresh) (the )?team", re.I)
-UPDATE_CB3_MSG = re.compile(
-    pre + "(please )?update (for )?(cb|conda[- ]build)[- ]?3", re.I
-)
+CONVERT_V1_MSG = re.compile(pre + "(please )?convert (feedstock |recipe )?to v1", re.I)
 PING_TEAM = re.compile(pre + r"(please )?ping (?P<team>\S+)", re.I)
 RERUN_BOT = re.compile(pre + "(please )?rerun (the )?bot", re.I)
 ADD_BOT_AUTOMERGE = re.compile(pre + "(please )?(add|enable) bot auto-?merge", re.I)
@@ -363,7 +361,7 @@ def pr_detailed_comment(
 
     pr_commands = [LINT_MSG]
     if not is_staged_recipes:
-        pr_commands += [ADD_NOARCH_MSG, RERENDER_MSG, UPDATE_CB3_MSG]
+        pr_commands += [ADD_NOARCH_MSG, RERENDER_MSG, CONVERT_V1_MSG]
 
     if not any(command.search(comment) for command in pr_commands):
         if (not command_found) and actor not in [
@@ -399,12 +397,14 @@ def pr_detailed_comment(
         changed_anything = False
         expected_changes = []
         if not is_staged_recipes:
-            do_noarch = do_rerender = False
+            do_noarch = do_rerender = do_convert_v1 = False
             if ADD_NOARCH_MSG.search(comment):
                 do_noarch = do_rerender = True
                 expected_changes.append("add noarch")
             if RERENDER_MSG.search(comment):
                 do_rerender = True
+            if CONVERT_V1_MSG.search(comment):
+                do_convert_v1 = True
 
             if do_noarch:
                 changed_anything |= make_noarch(repo)
@@ -457,6 +457,25 @@ def pr_detailed_comment(
                 Please ping conda-forge/core for further assistance. You can also try [re-rendering locally]({}).
                 """).format(doc_url)  # ruff: ignore[line-too-long]
 
+        convert_v1_error = False
+        if not is_staged_recipes and do_convert_v1:
+            try:
+                convert_v1_error = convert_v1(org_name + "/" + repo_name, int(pr_num))
+            except RequestException:
+                convert_v1_error = True
+
+        if convert_v1_error:
+            if message is None:
+                message = textwrap.dedent("""
+                    Hi! This is the friendly automated conda-forge-webservice.
+                    """)
+
+            message += textwrap.dedent("""
+
+                I tried to convert the recipe to v1 for you but ran into an issue with kicking GitHub Actions.
+                Please ping conda-forge/core for further assistance.
+                """).format(doc_url)  # ruff: ignore[line-too-long]
+
         if message is not None:
             gh = get_gh_client()
             gh_repo = gh.get_repo(f"{org_name}/{repo_name}")
@@ -493,7 +512,7 @@ def issue_comment(
         UPDATE_TEAM_MSG,
         ADD_NOARCH_MSG,
         RERENDER_MSG,
-        UPDATE_CB3_MSG,
+        CONVERT_V1_MSG,
         ADD_BOT_AUTOMERGE,
         ADD_USER,
         REMOVE_USER,
@@ -503,7 +522,7 @@ def issue_comment(
     send_pr_commands = [
         ADD_NOARCH_MSG,
         RERENDER_MSG,
-        UPDATE_CB3_MSG,
+        CONVERT_V1_MSG,
         ADD_BOT_AUTOMERGE,
         ADD_USER,
         REMOVE_USER,
@@ -619,10 +638,11 @@ def issue_comment(
             check_bump_build = True
             do_rerender = False
             do_version_update = False
+            do_convert_v1 = False
             extra_msg = ""
             input_ver = None
             if ADD_NOARCH_MSG.search(text):
-                pr_title = "MNT: Add noarch: python"
+                pr_title = "chore: Add noarch: python"
                 comment_msg = "made the recipe `noarch: python`"
                 to_close = ADD_NOARCH_MSG.search(title)
 
@@ -630,7 +650,7 @@ def issue_comment(
                 do_rerender = True
                 changed_anything |= make_rerender_dummy_commit(git_repo)
             elif RERENDER_MSG.search(text):
-                pr_title = "MNT: rerender"
+                pr_title = "chore: rerender"
                 comment_msg = "started rerendering the recipe"
                 to_close = RERENDER_MSG.search(title)
                 extra_msg = (
@@ -640,6 +660,18 @@ def issue_comment(
                 )
 
                 do_rerender = True
+                changed_anything |= make_rerender_dummy_commit(git_repo)
+            elif CONVERT_V1_MSG.search(text):
+                pr_title = "chore: convert recipe to v1"
+                comment_msg = "started converting the recipe to v1"
+                to_close = CONVERT_V1_MSG.search(title)
+                extra_msg = (
+                    "\n\nIf I find any needed changes to the recipe, "
+                    "I'll push them to this PR shortly. Thank you for "
+                    "waiting!\n"
+                )
+
+                do_convert_v1 = True
                 changed_anything |= make_rerender_dummy_commit(git_repo)
             elif UPDATE_VERSION.search(text):
                 if UPDATE_VERSION.search(title):
@@ -788,6 +820,26 @@ def issue_comment(
                             I tried to rerender for you but ran into an issue with kicking GitHub Actions to do the rerender.
                             Please ping conda-forge/core for further assistance. You can also try [re-rendering locally]({}).
                             """).format(doc_url)  # ruff: ignore[line-too-long]
+
+                        pr.create_issue_comment(message)
+
+                if do_convert_v1:
+                    convert_v1_error = False
+                    try:
+                        convert_v1_error = convert_v1(
+                            org_name + "/" + repo_name,
+                            pr.number,
+                        )
+                    except RequestException:
+                        convert_v1_error = True
+
+                    if convert_v1_error:
+                        message = textwrap.dedent("""
+                            Hi! This is the friendly automated conda-forge-webservice.
+
+                            I tried to convert the recipe to v1 for you but ran into an issue with kicking GitHub Actions.
+                            Please ping conda-forge/core for further assistance.
+                            """)  # ruff: ignore[line-too-long]
 
                         pr.create_issue_comment(message)
 
@@ -1199,6 +1251,72 @@ def rerender(full_name, pr_num):
             target_url = None
 
         set_rerender_pr_status(repo, pr_num, "pending", target_url=target_url, sha=sha)
+
+    return not running
+
+
+def set_convert_v1_pr_status(repo, pr_num, status, target_url=None, sha=None):
+    if target_url is not None:
+        kwargs = {"target_url": target_url}
+    else:
+        kwargs = {}
+
+    if sha is None:
+        pull = repo.get_pull(int(pr_num))
+        sha = pull.head.sha
+    commit = repo.get_commit(sha)
+
+    if status == "success":
+        msg = "Converting recipe to v1 successful."
+    elif status == "failure" or status == "error":
+        msg = "Converting recipe to v1 failed."
+    else:
+        msg = "Converting recipe to v1 in progress..."
+
+    commit.create_status(
+        status,
+        description=msg,
+        context="conda-forge-v1-conversion-service",
+        **kwargs,
+    )
+
+
+def convert_v1(full_name, pr_num):
+    gh = get_gh_client()
+    repo = gh.get_repo(full_name)
+    pull = repo.get_pull(int(pr_num))
+    sha = pull.head.sha
+
+    inject_app_token_into_feedstock(full_name, repo=repo)
+    inject_app_token_into_feedstock_readonly(full_name, repo=repo)
+
+    _, repo_name = full_name.split("/")
+    uid = uuid.uuid4().hex
+    ref = __version__.replace("+", ".")
+    workflow = gh.get_repo("conda-forge/conda-forge-webservices").get_workflow(
+        "webservices-workflow-dispatch.yml"
+    )
+    running = workflow.create_dispatch(
+        ref=ref,
+        inputs={
+            "task": "convert_v1",
+            "repo": repo_name,
+            "pr_number": str(pr_num),
+            "container_tag": ref,
+            "uuid": uid,
+            "sha": sha,
+        },
+    )
+    if running:
+        run = get_workflow_run_from_uid(workflow, uid, ref)
+        if run:
+            target_url = run.html_url
+        else:
+            target_url = None
+
+        set_convert_v1_pr_status(
+            repo, pr_num, "pending", target_url=target_url, sha=sha
+        )
 
     return not running
 

--- a/conda_forge_webservices/github_actions_integration/__main__.py
+++ b/conda_forge_webservices/github_actions_integration/__main__.py
@@ -116,7 +116,7 @@ def main_run_task(
         if convert_info_message is not None:
             task_data["task_results"]["info_message"] = (
                 "Recipe conversion error:\n"
-                f"<details/>\n{convert_info_message}\n<details/>\n"
+                f"<details/>\n```\n{convert_info_message}```\n\n<details/>\n"
             )
         else:
             task_data["task_results"]["info_message"] = ""
@@ -275,7 +275,8 @@ def _push_changes(
         repo_name=repo_name,
         close_pr_if_no_changes_or_errors=close_pr_if_no_changes_or_errors,
         help_message=(
-            " or you can try [rerendering locally]"
+            " or, if there was a rerendering error, "
+            "you can try [rerendering locally]"
             "(https://conda-forge.org/docs/maintainer/updating_pkgs.html"
             "#rerendering-with-conda-smithy-locally)"
         ),

--- a/conda_forge_webservices/github_actions_integration/__main__.py
+++ b/conda_forge_webservices/github_actions_integration/__main__.py
@@ -19,6 +19,7 @@ from .utils import (
     get_gha_run_link,
     get_git_patch_relative_to_commit,
     mark_pr_as_ready_for_review,
+    run_git_command,
 )
 from .api_sessions import create_api_sessions, create_api_sessions_for_admin
 from .rerendering import rerender
@@ -355,21 +356,20 @@ def main_finalize_task(task_data_dir):
                 patch_file = os.path.join(tmpdir, "rerender-diff.patch")
                 with open(patch_file, "w") as fp:
                     fp.write(task_results["patch"])
-                subprocess.run(
-                    ["git", "apply", "--allow-empty", patch_file],
-                    check=True,
+                run_git_command(
+                    ["apply", "--allow-empty", patch_file],
                     cwd=feedstock_dir,
+                    check=True,
                 )
-                subprocess.run(
-                    ["git", "add", "-f", "."],
+                run_git_command(
+                    ["add", "-f", "."],
                     cwd=feedstock_dir,
                     check=True,
                 )
 
             if task_results["commit_message"] is not None:
-                subprocess.run(
+                run_git_command(
                     [
-                        "git",
                         "commit",
                         "-m",
                         task_results["commit_message"],

--- a/conda_forge_webservices/github_actions_integration/__main__.py
+++ b/conda_forge_webservices/github_actions_integration/__main__.py
@@ -111,12 +111,16 @@ def main_run_task(
     elif task == "convert_v1":
         _pull_docker_image()
         convert_changed, convert_error, convert_info_message = convert_to_v1(git_repo)
+        if convert_info_message is not None:
+            convert_info_message = convert_info_message.encode("utf-8").decode(
+                "unicode_escape"
+            )
         task_data["task_results"]["convert_changed"] = convert_changed
         task_data["task_results"]["convert_error"] = convert_error
         if convert_info_message is not None:
             task_data["task_results"]["info_message"] = (
                 "Recipe conversion error:\n"
-                f"<details/>\n```\n{convert_info_message}```\n\n<details/>\n"
+                f"<details/>\n\n```\n{convert_info_message}\n```\n\n</details>\n"
             )
         else:
             task_data["task_results"]["info_message"] = ""

--- a/conda_forge_webservices/github_actions_integration/__main__.py
+++ b/conda_forge_webservices/github_actions_integration/__main__.py
@@ -29,7 +29,9 @@ from .linting import (
     get_recipes_for_linting,
 )
 from .version_updating import update_version, update_pr_title
+from .converting import convert_to_v1
 from conda_forge_webservices.commands import (
+    set_convert_v1_pr_status,
     set_rerender_pr_status,
     set_version_update_pr_status,
 )
@@ -106,6 +108,37 @@ def main_run_task(
         task_data["task_results"]["info_message"] = info_message
         task_data["task_results"]["commit_message"] = commit_message
         task_data["task_results"]["patch"] = patch
+    elif task == "convert_v1":
+        _pull_docker_image()
+        convert_changed, convert_error, convert_info_message = convert_to_v1(git_repo)
+        task_data["task_results"]["convert_changed"] = convert_changed
+        task_data["task_results"]["convert_error"] = convert_error
+        if convert_info_message is not None:
+            task_data["task_results"]["info_message"] = convert_info_message
+        else:
+            task_data["task_results"]["info_message"] = ""
+        task_data["task_results"]["patch"] = None
+
+        if convert_changed and not convert_error:
+            task_data["task_results"]["commit_message"] = "chore: convert recipe to v1"
+
+            rerender_changed, rerender_error, info_message, commit_message = rerender(
+                git_repo
+            )
+            task_data["task_results"]["rerender_changed"] = rerender_changed
+            task_data["task_results"]["rerender_error"] = rerender_error
+            if info_message is not None:
+                task_data["task_results"]["info_message"] += "\n" + info_message
+            if rerender_changed:
+                task_data["task_results"]["commit_message"] += (
+                    " & " + commit_message[len("chore: ") :]
+                )
+            patch = get_git_patch_relative_to_commit(git_repo, prev_head)
+            task_data["task_results"]["patch"] = patch
+        else:
+            task_data["task_results"]["rerender_changed"] = False
+            task_data["task_results"]["rerender_error"] = False
+            task_data["task_results"]["commit_message"] = None
     elif task == "version_update":
         if (
             requested_version.lower() == "null"
@@ -143,7 +176,7 @@ def main_run_task(
             task_data["task_results"]["info_message"] = info_message
             if rerender_changed:
                 task_data["task_results"]["commit_message"] += (
-                    " & " + commit_message[len("MNT: ") :]
+                    " & " + commit_message[len("chore: ") :]
                 )
             patch = get_git_patch_relative_to_commit(git_repo, prev_head)
             task_data["task_results"]["patch"] = patch
@@ -285,7 +318,7 @@ def main_finalize_task(task_data_dir):
                 return
 
         # commit the changes if needed
-        if task in ["rerender", "version_update"]:
+        if task in ["rerender", "version_update", "convert_v1"]:
             pr_branch = pr.head.ref
             pr_owner = pr.head.repo.owner.login
             pr_repo = pr.head.repo.name
@@ -369,7 +402,7 @@ def main_finalize_task(task_data_dir):
             # if the pr was made by the bot, mark it as ready for review
             if (
                 (not comment_push_error)
-                and pr.title == "MNT: rerender"
+                and pr.title == "chore: rerender"
                 and pr.user.login == "conda-forge-admin"
             ):
                 mark_pr_as_ready_for_review(pr)
@@ -380,7 +413,60 @@ def main_finalize_task(task_data_dir):
                     "Check the workflow logs of the `run task` job for more details!",
                 )
                 sys.exit(1)
+        elif task == "convert_v1":
+            if task_results["convert_error"]:
+                action_error = True
+            else:
+                if task_results["convert_changed"]:
+                    # if there is no convert error and the conversion happened
+                    # then we can report if rerendering failed
+                    action_error = task_results["rerender_error"]
+                else:
+                    # if the conversion did not happen, we can ignore the rerendering
+                    # error if any
+                    action_error = False
 
+            comment_push_error = _push_changes(
+                action="convert recipe to v1 and rerender",
+                action_error=action_error,
+                info_message=task_results["info_message"],
+                changed=task_results["convert_changed"],
+                git_repo=git_repo,
+                pr=pr,
+                pr_branch=pr_branch,
+                pr_owner=pr_owner,
+                pr_repo=pr_repo,
+                repo_name=full_repo_name,
+                close_pr_if_no_changes_or_errors=False,
+            )
+            status = "success" if not comment_push_error else "failure"
+            target_url = (
+                f"https://github.com/conda-forge/conda-forge-webservices/"
+                f"actions/runs/{os.environ['GITHUB_RUN_ID']}"
+            )
+            set_convert_v1_pr_status(
+                gh_repo,
+                int(pr_number),
+                status,
+                target_url=target_url,
+                sha=sha_for_status,
+            )
+
+            # if the pr was made by the bot, mark it as ready for review
+            if (
+                (not comment_push_error)
+                and pr.title == "chore: convert recipe to v1"
+                and pr.user.login == "conda-forge-admin"
+            ):
+                mark_pr_as_ready_for_review(pr)
+
+            if comment_push_error:
+                LOGGER.error(
+                    "Error in converting recipe to v1 "
+                    f"for {full_repo_name}#{pr_number}! "
+                    "Check the workflow logs of the `run task` job for more details!",
+                )
+                sys.exit(1)
         elif task == "version_update":
             if (
                 (not task_results["version_error"])

--- a/conda_forge_webservices/github_actions_integration/__main__.py
+++ b/conda_forge_webservices/github_actions_integration/__main__.py
@@ -357,24 +357,26 @@ def main_finalize_task(task_data_dir):
                 with open(patch_file, "w") as fp:
                     fp.write(task_results["patch"])
                 run_git_command(
-                    ["apply", "--allow-empty", patch_file],
+                    "apply",
+                    "--allow-empty",
+                    patch_file,
                     cwd=feedstock_dir,
                     check=True,
                 )
                 run_git_command(
-                    ["add", "-f", "."],
+                    "add",
+                    "-f",
+                    ".",
                     cwd=feedstock_dir,
                     check=True,
                 )
 
             if task_results["commit_message"] is not None:
                 run_git_command(
-                    [
-                        "commit",
-                        "-m",
-                        task_results["commit_message"],
-                        "--allow-empty",
-                    ],
+                    "commit",
+                    "-m",
+                    task_results["commit_message"],
+                    "--allow-empty",
                     cwd=feedstock_dir,
                     check=True,
                 )

--- a/conda_forge_webservices/github_actions_integration/__main__.py
+++ b/conda_forge_webservices/github_actions_integration/__main__.py
@@ -114,7 +114,10 @@ def main_run_task(
         task_data["task_results"]["convert_changed"] = convert_changed
         task_data["task_results"]["convert_error"] = convert_error
         if convert_info_message is not None:
-            task_data["task_results"]["info_message"] = convert_info_message
+            task_data["task_results"]["info_message"] = (
+                "Recipe conversion error:\n"
+                f"<details/>\n{convert_info_message}\n<details/>\n"
+            )
         else:
             task_data["task_results"]["info_message"] = ""
         task_data["task_results"]["patch"] = None

--- a/conda_forge_webservices/github_actions_integration/automerge.py
+++ b/conda_forge_webservices/github_actions_integration/automerge.py
@@ -5,13 +5,14 @@ import datetime
 import logging
 import os
 import random
-import subprocess
 import tempfile
 import time
 from typing import TYPE_CHECKING
 
 from github import GithubException
 from ruamel.yaml import YAML
+
+from .utils import run_git_command
 
 if TYPE_CHECKING:
     from github.PullRequest import PullRequest
@@ -49,19 +50,6 @@ def pushd(new_dir):
         os.chdir(previous_dir)
 
 
-def _run_git_command(*args):
-    try:
-        c = subprocess.run(
-            ["git", *list(args)],
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-        )
-    except subprocess.CalledProcessError as e:
-        print(c.stdout)
-        raise e
-
-
 def _get_conda_forge_config(pr):
     """get the conda-forge.yml from upstream master
 
@@ -69,9 +57,9 @@ def _get_conda_forge_config(pr):
     any from a fork.
     """
     with tempfile.TemporaryDirectory() as tmpdir:
-        _run_git_command("clone", pr.base.repo.clone_url, tmpdir)
+        run_git_command("clone", pr.base.repo.clone_url, tmpdir)
         with pushd(tmpdir):
-            _run_git_command("checkout", pr.base.ref)
+            run_git_command("checkout", pr.base.ref)
             with open("conda-forge.yml") as fp:
                 cfg = YAML().load(fp)
     return cfg
@@ -255,9 +243,9 @@ def _get_required_checks_and_statuses(pr, cfg):
     required = ["linter"]
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        _run_git_command("clone", pr.head.repo.clone_url, tmpdir)
+        run_git_command("clone", pr.head.repo.clone_url, tmpdir)
         with pushd(tmpdir):
-            _run_git_command("checkout", pr.head.sha)
+            run_git_command("checkout", pr.head.sha)
 
             if os.path.exists("appveyor.yml") or os.path.exists(".appveyor.yml"):
                 required.append("appveyor")

--- a/conda_forge_webservices/github_actions_integration/converting.py
+++ b/conda_forge_webservices/github_actions_integration/converting.py
@@ -1,0 +1,47 @@
+import logging
+import subprocess
+
+from conda_forge_feedstock_ops.container_utils import ContainerRuntimeError
+from conda_forge_feedstock_ops.convert import convert_feedstock_to_v1
+
+LOGGER = logging.getLogger(__name__)
+
+
+def convert_to_v1(git_repo):
+    LOGGER.info("converting feedstock to v1")
+
+    info_message = None
+
+    curr_head = git_repo.active_branch.commit
+
+    try:
+        changed = convert_feedstock_to_v1(
+            git_repo.working_dir,
+            use_container=True,
+        )
+    except ContainerRuntimeError as e:
+        LOGGER.exception("Converting feedstock to v1 failed: %r", e)
+        info_message = repr(e)
+        ret = 1
+    else:
+        ret = 0
+        if changed:
+            subprocess.call(
+                ["git", "add", "-f", "."],
+                cwd=git_repo.working_dir,
+                check=False,
+            )
+            subprocess.call(
+                ["git", "commit", "--all", "-m", "chore: converted feedstock to v1"],
+                cwd=git_repo.working_dir,
+                check=False,
+            )
+
+    if ret:
+        changed, convert_error = False, True
+    elif git_repo.active_branch.commit == curr_head:
+        changed, convert_error = False, False
+    else:
+        changed, convert_error = True, False
+
+    return changed, convert_error, info_message

--- a/conda_forge_webservices/github_actions_integration/converting.py
+++ b/conda_forge_webservices/github_actions_integration/converting.py
@@ -27,12 +27,17 @@ def convert_to_v1(git_repo):
         ret = 0
         if changed:
             run_git_command(
-                ["add", "-f", "."],
+                "add",
+                "-f",
+                ".",
                 cwd=git_repo.working_dir,
                 check=False,
             )
             run_git_command(
-                ["commit", "--all", "-m", "chore: converted feedstock to v1"],
+                "commit",
+                "--all",
+                "-m",
+                "chore: converted feedstock to v1",
                 cwd=git_repo.working_dir,
                 check=False,
             )

--- a/conda_forge_webservices/github_actions_integration/converting.py
+++ b/conda_forge_webservices/github_actions_integration/converting.py
@@ -1,8 +1,8 @@
 import logging
-import subprocess
 
 from conda_forge_feedstock_ops.container_utils import ContainerRuntimeError
 from conda_forge_feedstock_ops.convert import convert_feedstock_to_v1
+from .utils import run_git_command
 
 LOGGER = logging.getLogger(__name__)
 
@@ -26,13 +26,13 @@ def convert_to_v1(git_repo):
     else:
         ret = 0
         if changed:
-            subprocess.call(
-                ["git", "add", "-f", "."],
+            run_git_command(
+                ["add", "-f", "."],
                 cwd=git_repo.working_dir,
                 check=False,
             )
-            subprocess.call(
-                ["git", "commit", "--all", "-m", "chore: converted feedstock to v1"],
+            run_git_command(
+                ["commit", "--all", "-m", "chore: converted feedstock to v1"],
                 cwd=git_repo.working_dir,
                 check=False,
             )

--- a/conda_forge_webservices/github_actions_integration/rerendering.py
+++ b/conda_forge_webservices/github_actions_integration/rerendering.py
@@ -32,12 +32,17 @@ def rerender(git_repo):
         ret = 0
         if msg is not None:
             run_git_command(
-                ["add", "-f", "."],
+                "add",
+                "-f",
+                ".",
                 cwd=git_repo.working_dir,
                 check=False,
             )
             run_git_command(
-                ["commit", "--all", "-m", msg],
+                "commit",
+                "--all",
+                "-m",
+                msg,
                 cwd=git_repo.working_dir,
                 check=False,
             )
@@ -67,7 +72,8 @@ def _ensure_output_validation_is_on(git_repo):
             fp.write(yaml.dump(cfg, default_flow_style=False))
 
         run_git_command(
-            ["add", "conda-forge.yml"],
+            "add",
+            "conda-forge.yml",
             cwd=git_repo.working_dir,
             env=os.environ,
             check=True,

--- a/conda_forge_webservices/github_actions_integration/rerendering.py
+++ b/conda_forge_webservices/github_actions_integration/rerendering.py
@@ -1,10 +1,10 @@
 import logging
 import os
-import subprocess
 
 import yaml
 from conda_forge_feedstock_ops.container_utils import ContainerRuntimeError
 from conda_forge_feedstock_ops.rerender import rerender as cf_feedstock_ops_rerender
+from .utils import run_git_command
 
 LOGGER = logging.getLogger(__name__)
 
@@ -31,13 +31,15 @@ def rerender(git_repo):
     else:
         ret = 0
         if msg is not None:
-            subprocess.call(
-                ["git", "add", "-f", "."],
+            run_git_command(
+                ["add", "-f", "."],
                 cwd=git_repo.working_dir,
+                check=False,
             )
-            subprocess.call(
-                ["git", "commit", "--all", "-m", msg],
+            run_git_command(
+                ["commit", "--all", "-m", msg],
                 cwd=git_repo.working_dir,
+                check=False,
             )
 
     if ret:
@@ -64,10 +66,11 @@ def _ensure_output_validation_is_on(git_repo):
         with open(pth, "w") as fp:
             fp.write(yaml.dump(cfg, default_flow_style=False))
 
-        subprocess.run(
-            ["git", "add", "conda-forge.yml"],
+        run_git_command(
+            ["add", "conda-forge.yml"],
             cwd=git_repo.working_dir,
             env=os.environ,
+            check=True,
         )
         return True
     else:

--- a/conda_forge_webservices/github_actions_integration/tests/test_required_checks.py
+++ b/conda_forge_webservices/github_actions_integration/tests/test_required_checks.py
@@ -49,7 +49,7 @@ def test_all_statuses_and_checks_ok(val):
 )
 @pytest.mark.parametrize("ignore_linter", ["conda-forge-linter", "linter", None])
 @mock.patch(
-    "conda_forge_webservices.github_actions_integration.automerge._run_git_command"
+    "conda_forge_webservices.github_actions_integration.automerge.run_git_command"
 )
 @mock.patch("conda_forge_webservices.github_actions_integration.automerge.tempfile")
 def test_get_required_checks_and_statuses(

--- a/conda_forge_webservices/github_actions_integration/utils.py
+++ b/conda_forge_webservices/github_actions_integration/utils.py
@@ -200,3 +200,21 @@ def get_git_patch_relative_to_commit(git_repo, prev_head):
     )
     LOGGER.info("git patch for diff %s: %s", git_sha_diff, ret.stdout)
     return ret.stdout
+
+
+def run_git_command(*args, **kwargs):
+    do_check = kwargs.pop("check", False)
+    try:
+        c = subprocess.run(
+            ["git", *list(args)],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            **kwargs,
+        )
+    except subprocess.CalledProcessError as e:
+        print(c.stdout)
+        if do_check:
+            raise e
+        else:
+            return c

--- a/conda_forge_webservices/github_actions_integration/version_updating.py
+++ b/conda_forge_webservices/github_actions_integration/version_updating.py
@@ -134,7 +134,7 @@ def update_version(
         run_git_command(
             "commit",
             "-m",
-            f"ENH updated version to {new_version}",
+            f"chore: updated version to {new_version}",
             cwd=git_repo.working_dir,
             check=True,
             env=os.environ,

--- a/conda_forge_webservices/github_actions_integration/version_updating.py
+++ b/conda_forge_webservices/github_actions_integration/version_updating.py
@@ -124,14 +124,17 @@ def update_version(
             "recipe/meta.yaml" if schema_version == 0 else "recipe/recipe.yaml"
         )
         run_git_command(
-            ["add", recipe_path],
+            "add",
+            recipe_path,
             cwd=git_repo.working_dir,
             check=True,
             env=os.environ,
         )
 
         run_git_command(
-            ["commit", "-m", f"ENH updated version to {new_version}"],
+            "commit",
+            "-m",
+            f"ENH updated version to {new_version}",
             cwd=git_repo.working_dir,
             check=True,
             env=os.environ,

--- a/conda_forge_webservices/github_actions_integration/version_updating.py
+++ b/conda_forge_webservices/github_actions_integration/version_updating.py
@@ -1,13 +1,12 @@
 import logging
 import os
 import pprint
-import subprocess
 from pathlib import Path
 
 from conda.models.version import VersionOrder
 
 from .api_sessions import create_api_sessions
-
+from .utils import run_git_command
 
 LOGGER = logging.getLogger(__name__)
 
@@ -124,15 +123,15 @@ def update_version(
         recipe_path = (
             "recipe/meta.yaml" if schema_version == 0 else "recipe/recipe.yaml"
         )
-        subprocess.run(
-            ["git", "add", recipe_path],
+        run_git_command(
+            ["add", recipe_path],
             cwd=git_repo.working_dir,
             check=True,
             env=os.environ,
         )
 
-        subprocess.run(
-            ["git", "commit", "-m", f"ENH updated version to {new_version}"],
+        run_git_command(
+            ["commit", "-m", f"ENH updated version to {new_version}"],
             cwd=git_repo.working_dir,
             check=True,
             env=os.environ,

--- a/conda_forge_webservices/tests/test_commands.py
+++ b/conda_forge_webservices/tests/test_commands.py
@@ -154,11 +154,33 @@ def set_dummy_gh_token():
                 "rerun bot, @conda-forge-admin",
             ],
         ),
+        (
+            "convert_v1",
+            False,
+            [
+                "@conda-forge-admin, please convert to v1",
+                "@conda-forge-admin, please convert recipe to v1"
+                "@conda-forge-admin, please convert feedstock to v1"
+                "@conda-forge-admin, convert to v1",
+                "@conda-forge-admin, convert recipe to v1"
+                "@conda-forge-admin, convert feedstock to v1"
+                "@conda-forge-admin: CONVERT TO V1",
+                "something something. @conda-forge-admin: please convert to v1",
+            ],
+            [
+                "@conda-forge admin is pretty cool. please convert to v1 for me?",
+                "@conda-forge admin is pretty cool. convert to v1 for me?",
+                "@conda-forge-admin, go ahead and convert to v1 for me",
+                "please convert to v1, @conda-forge-admin",
+                "convert to v1, @conda-forge-admin",
+            ],
+        ),
     ],
 )
 @mock.patch("conda_forge_webservices.commands.get_app_token_for_webservices_only")
 @mock.patch("conda_forge_webservices.commands.add_bot_rerun_label")
 @mock.patch("conda_forge_webservices.commands.rerender")
+@mock.patch("conda_forge_webservices.commands.convert_v1")
 @mock.patch("conda_forge_webservices.commands.make_noarch")
 @mock.patch("conda_forge_webservices.commands.relint")
 @mock.patch("conda_forge_webservices.commands.update_team")
@@ -170,6 +192,7 @@ def test_pr_command_triggers(
     update_team,
     relint,
     make_noarch,
+    convert_v1,
     rerender,
     add_bot_rerun_label,
     get_app_token_for_webservices_only,
@@ -186,6 +209,8 @@ def test_pr_command_triggers(
         command = make_noarch
     elif command == "relint":
         command = relint
+    elif command == "convert_v1":
+        command = convert_v1
     else:
         raise ValueError(f"Unknown command: {command}")
 
@@ -352,6 +377,26 @@ def test_pr_command_triggers(
                 "remove user @blah, @conda-forge-admin",
             ],
         ),
+        (
+            "convert_v1",
+            [
+                "@conda-forge-admin, please convert to v1",
+                "@conda-forge-admin, please convert recipe to v1"
+                "@conda-forge-admin, please convert feedstock to v1"
+                "@conda-forge-admin, convert to v1",
+                "@conda-forge-admin, convert recipe to v1"
+                "@conda-forge-admin, convert feedstock to v1"
+                "@conda-forge-admin: CONVERT TO V1",
+                "something something. @conda-forge-admin: please convert to v1",
+            ],
+            [
+                "@conda-forge admin is pretty cool. please convert to v1 for me?",
+                "@conda-forge admin is pretty cool. convert to v1 for me?",
+                "@conda-forge-admin, go ahead and convert to v1 for me",
+                "please convert to v1, @conda-forge-admin",
+                "convert to v1, @conda-forge-admin",
+            ],
+        ),
     ],
 )
 @mock.patch("conda_forge_webservices.commands.get_app_token_for_webservices_only")
@@ -361,6 +406,7 @@ def test_pr_command_triggers(
 @mock.patch("conda_forge_webservices.commands.make_rerender_dummy_commit")
 @mock.patch("conda_forge_webservices.commands.add_bot_automerge")
 @mock.patch("conda_forge_webservices.commands.rerender")
+@mock.patch("conda_forge_webservices.commands.convert_v1")
 @mock.patch("conda_forge_webservices.commands.make_noarch")
 @mock.patch("conda_forge_webservices.commands.relint")
 @mock.patch("conda_forge_webservices.commands.update_team")
@@ -374,6 +420,7 @@ def test_issue_command_triggers(
     update_team,
     relint,
     make_noarch,
+    convert_v1,
     rerender,
     add_bot_automerge,
     rerender_dummy_commit,
@@ -402,6 +449,8 @@ def test_issue_command_triggers(
         command = add_user
     elif command == "remove_user":
         command = remove_user
+    elif command == "convert_v1":
+        command = convert_v1
     else:
         raise ValueError(f"Unknown command: {command}")
 
@@ -418,7 +467,7 @@ def test_issue_command_triggers(
         issue_comment(title="hi", comment=msg)
         command.assert_called()
         issue.edit.assert_not_called()
-        if command in (rerender, make_noarch, update_version):
+        if command in (rerender, make_noarch, update_version, convert_v1):
             rerender_dummy_commit.assert_called()
         else:
             rerender_dummy_commit.assert_not_called()
@@ -438,11 +487,12 @@ def test_issue_command_triggers(
             add_user,
             remove_user,
             update_version,
+            convert_v1,
         ):
             assert "Fixes #" in repo.create_pull.call_args.kwargs["body"]
         else:
             issue.edit.assert_called_with(state="closed")
-        if command in (rerender, make_noarch, update_version):
+        if command in (rerender, make_noarch, update_version, convert_v1):
             rerender_dummy_commit.assert_called()
         else:
             rerender_dummy_commit.assert_not_called()
@@ -543,6 +593,49 @@ def test_update_version_failure(
     )
 
 
+@mock.patch("conda_forge_webservices.commands._sync_default_branch")
+@mock.patch("conda_forge_webservices.commands.get_app_token_for_webservices_only")
+@mock.patch("conda_forge_webservices.commands.make_rerender_dummy_commit")
+@mock.patch("conda_forge_webservices.commands.convert_v1")
+@mock.patch("conda_forge_webservices.commands.make_noarch")
+@mock.patch("conda_forge_webservices.commands.relint")
+@mock.patch("conda_forge_webservices.commands.update_team")
+@mock.patch("conda_forge_webservices.commands.get_gh_client")
+@mock.patch("github.Github")
+@mock.patch("conda_forge_webservices.commands.Repo")
+def test_convert_to_v1_failure(
+    repo,
+    gh,
+    gh_app,
+    update_team,
+    relint,
+    make_noarch,
+    convert_v1,
+    rrdc,
+    gatfwo,
+    sdb,
+    set_dummy_gh_token,
+):
+    convert_v1.side_effect = RequestException
+
+    repos = [mock.MagicMock(), mock.MagicMock(), mock.MagicMock()]
+    for repo in repos:
+        repo.default_branch = "main"
+    gh.return_value.get_repo.side_effect = repos
+    pull_create_issue = repos[0].create_pull.return_value.create_issue_comment
+
+    msg = "@conda-forge-admin, please convert to v1"
+
+    issue_comment(title=msg, comment=None)
+
+    convert_v1.assert_called()
+
+    assert "ran into an issue with" in pull_create_issue.call_args[0][0]
+    assert (
+        "conda-forge/core for further assistance" in pull_create_issue.call_args[0][0]
+    )
+
+
 @pytest.mark.parametrize(
     "number,comment_id,review_id",
     [
@@ -633,6 +726,7 @@ def test_add_and_remove_user(pillow_feedstock):
 @mock.patch("conda_forge_webservices.commands.get_app_token_for_webservices_only")
 @mock.patch("conda_forge_webservices.commands.add_bot_rerun_label")
 @mock.patch("conda_forge_webservices.commands.rerender")
+@mock.patch("conda_forge_webservices.commands.convert_v1")
 @mock.patch("conda_forge_webservices.commands.make_noarch")
 @mock.patch("conda_forge_webservices.commands.relint")
 @mock.patch("conda_forge_webservices.commands.update_team")
@@ -656,6 +750,7 @@ def test_pr_reply_to_invalid_command(
     update_team,
     relint,
     make_noarch,
+    convert_v1,
     rerender,
     add_bot_rerun_label,
     get_app_token_for_webservices_only,
@@ -681,7 +776,7 @@ def test_pr_reply_to_invalid_command(
     else:
         assert False, f"{path}"
 
-    for command in (update_team, relint, make_noarch, rerender):
+    for command in (update_team, relint, make_noarch, rerender, convert_v1):
         command.assert_not_called()
     if review_id is None:
         issue_calls = gh.return_value.get_repo.return_value.get_issue.return_value

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - conda-forge-metadata >=0.12.0
   - conda-forge-pinning
   - conda-forge-tick >=2025.1.51
-  - conda-forge-feedstock-ops >=0.18.0
+  - conda-forge-feedstock-ops >=0.18.1
   - conda-recipe-manager >=0.9.0
   - conda-smithy >=3.61.2  # this pin is for username-userid & team security fixes
   - conda-souschef

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - conda-forge-metadata >=0.12.0
   - conda-forge-pinning
   - conda-forge-tick >=2025.1.51
-  - conda-forge-feedstock-ops >=0.16.0
+  - conda-forge-feedstock-ops >=0.18.0
   - conda-recipe-manager >=0.9.0
   - conda-smithy >=3.61.2  # this pin is for username-userid & team security fixes
   - conda-souschef

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - conda-forge-metadata >=0.12.0
   - conda-forge-pinning
   - conda-forge-tick >=2025.1.51
-  - conda-forge-feedstock-ops >=0.18.1
+  - conda-forge-feedstock-ops >=0.18.2
   - conda-recipe-manager >=0.9.0
   - conda-smithy >=3.61.2  # this pin is for username-userid & team security fixes
   - conda-souschef

--- a/tests/test_live_convert_recipe_to_v1.py
+++ b/tests/test_live_convert_recipe_to_v1.py
@@ -1,0 +1,309 @@
+import os
+import subprocess
+import tempfile
+import time
+import uuid
+
+import github
+import requests
+
+import conda_forge_webservices
+from conda_forge_webservices.utils import pushd
+from conda_forge_webservices.commands import (
+    get_workflow_run_from_uid,
+    set_version_update_pr_status,
+)
+from conda_forge_webservices import __version__
+
+REPO_OWNER = "conda-forge"
+REPO_NAME = "cf-autotick-bot-test-package-feedstock"
+REPO = f"{REPO_OWNER}/{REPO_NAME}"
+BRANCH = "version-update-live-test"
+PR_NUM = 1844
+GH = None
+WAIT_TIME = 300  # seconds
+
+
+def _set_pr_draft():
+    repo = GH.get_repo(REPO)
+    pr = repo.get_pull(PR_NUM)
+
+    if pr.draft:
+        return
+
+    # based on this post: https://github.com/orgs/community/discussions/70061
+    mutation = f"""
+        mutation {{
+            convertPullRequestToDraft(input:{{pullRequestId: "{pr.node_id:s}"}}) {{
+                pullRequest{{id, isDraft}}
+            }}
+        }}
+        """
+
+    headers = {"Authorization": f"Bearer {os.environ['GH_TOKEN']}"}
+    req = requests.post(
+        "https://api.github.com/graphql",
+        json={"query": mutation},
+        headers=headers,
+    )
+    if "errors" in req.json():
+        raise ValueError(req.json()["errors"])
+
+
+def _set_pr_not_draft():
+    # based on this post: https://github.com/orgs/community/discussions/70061
+    repo = GH.get_repo(REPO)
+    pr = repo.get_pull(PR_NUM)
+
+    if not pr.draft:
+        return
+
+    mutation = f"""
+        mutation {{
+            markPullRequestReadyForReview(input:{{pullRequestId: "{pr.node_id:s}"}}) {{
+                pullRequest{{id, isDraft}}
+            }}
+        }}
+        """
+
+    headers = {"Authorization": f"Bearer {os.environ['GH_TOKEN']}"}
+    req = requests.post(
+        "https://api.github.com/graphql",
+        json={"query": mutation},
+        headers=headers,
+    )
+    if "errors" in req.json():
+        raise ValueError(req.json()["errors"])
+
+
+def _change_to_schema(schema_version, branch):
+
+    if schema_version == 0:
+        filename = "recipe/meta.yaml"
+        filename_to_remove = "recipe/recipe.yaml"
+        cfy = "conda-forge.yml"
+    else:
+        filename = "recipe/recipe.yaml"
+        filename_to_remove = "recipe/meta.yaml"
+        cfy = "conda-forge-for-recipe.yml"
+
+    subprocess.run(
+        ["git", "checkout", branch],
+        check=True,
+    )
+    subprocess.run(["git", "pull"], check=True)
+
+    if os.path.exists(filename_to_remove):
+        subprocess.run(
+            ["git", "rm", filename_to_remove],
+            check=True,
+        )
+    with open(
+        os.path.join(os.path.dirname(__file__), os.path.basename(filename))
+    ) as fp:
+        new_recipe = fp.read()
+
+    with open(filename, "w") as fp:
+        fp.write(new_recipe)
+
+    subprocess.run(
+        ["git", "add", filename],
+        check=True,
+    )
+
+    with open(os.path.join(os.path.dirname(__file__), os.path.basename(cfy))) as fp:
+        new_cfy = fp.read()
+
+    with open("conda-forge.yml", "w") as fp:
+        fp.write(new_cfy)
+
+    subprocess.run(
+        ["git", "add", "conda-forge.yml"],
+        check=True,
+    )
+
+    print("rerendering...", flush=True)
+    subprocess.run(
+        [
+            "conda-smithy",
+            "rerender",
+            "-c",
+            "auto",
+            "--no-check-uptodate",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "add", "."],
+        check=True,
+    )
+
+    print("making a commit...", flush=True)
+    subprocess.run(
+        [
+            "git",
+            "commit",
+            "--allow-empty",
+            "-m",
+            f"[ci skip] moved schema to {schema_version}",
+        ],
+        check=True,
+    )
+
+    print("push to origin...", flush=True)
+    subprocess.run(["git", "pull"], check=True)
+    subprocess.run(["git", "push"], check=True)
+
+
+def _pr_title(new=None):
+    repo = GH.get_repo(REPO)
+    pr = repo.get_pull(PR_NUM)
+    old = pr.title
+    if new:
+        pr.edit(title=new)
+    return old
+
+
+def _conversion_is_ok(verbose=False):
+
+    filename = "recipe/recipe.yaml"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with pushd(tmpdir):
+            if verbose:
+                print("cloning...", flush=True)
+            subprocess.run(
+                [
+                    "git",
+                    "clone",
+                    f"https://github.com/{REPO}.git",
+                ],
+                check=True,
+            )
+
+            with pushd(REPO_NAME):
+                if verbose:
+                    print("checkout branch...", flush=True)
+                subprocess.run(
+                    ["git", "checkout", BRANCH],
+                    check=True,
+                )
+
+                if not os.path.exists(filename):
+                    return False
+
+                if verbose:
+                    print("checking the git history", flush=True)
+                c = subprocess.run(
+                    ["git", "log", "--pretty=oneline", "-n", "1"],
+                    capture_output=True,
+                    check=True,
+                )
+                output = c.stdout.decode("utf-8")
+                if verbose:
+                    print("    last commit:", output.strip(), flush=True)
+                if not ("Re-" in output or "chore:" in output):
+                    return False
+
+    if "chore: convert recipe to v1" not in _pr_title():
+        return False
+
+    repo = GH.get_repo(REPO)
+    pr = repo.get_pull(PR_NUM)
+
+    if pr.draft:
+        return False
+
+    return True
+
+
+def _run_test(branch):
+    print("sending workflow dispatch event to recipe converter...", flush=True)
+    pr_head_sha = GH.get_repo(REPO).get_pull(PR_NUM).head.sha
+    uid = uuid.uuid4().hex
+    repo = GH.get_repo("conda-forge/conda-forge-webservices")
+    workflow = repo.get_workflow("webservices-workflow-dispatch.yml")
+    running = workflow.create_dispatch(
+        ref=branch,
+        inputs={
+            "task": "convert_v1",
+            "repo": REPO_NAME,
+            "pr_number": str(PR_NUM),
+            "container_tag": conda_forge_webservices.__version__.replace("+", "."),
+            "requested_version": "null",
+            "uuid": uid,
+            "sha": pr_head_sha,
+        },
+    )
+
+    if running:
+        run = get_workflow_run_from_uid(workflow, uid, __version__.replace("+", "."))
+        if run:
+            target_url = run.html_url
+        else:
+            target_url = None
+
+        set_version_update_pr_status(
+            GH.get_repo(REPO), PR_NUM, "pending", target_url=target_url, sha=pr_head_sha
+        )
+
+    print(
+        f"sleeping for {WAIT_TIME} seconds to let the conversion happen...",
+        flush=True,
+    )
+    tot = 0
+    while tot < WAIT_TIME:
+        time.sleep(10)
+        tot += 10
+        print(f"    slept {tot} seconds out of {WAIT_TIME}", flush=True)
+        if tot % 30 == 0 and tot > 0:
+            if _conversion_is_ok():
+                break
+
+    print("checking repo for the conversion...", flush=True)
+    update_is_ok = _conversion_is_ok(verbose=True)
+    if not update_is_ok:
+        set_version_update_pr_status(
+            GH.get_repo(REPO),
+            PR_NUM,
+            "failure",
+            target_url=target_url,
+        )
+    assert update_is_ok
+    print("tests passed!", flush=True)
+
+
+def _run_test_try_finally(branch):
+    print("making an edit to the head ref...", flush=True)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with pushd(tmpdir):
+            print("cloning...", flush=True)
+            subprocess.run(
+                [
+                    "git",
+                    "clone",
+                    f"https://x-access-token:{os.environ['GH_TOKEN']}@github.com/{REPO}.git",
+                ],
+                check=True,
+            )
+
+            with pushd(REPO_NAME):
+                try:
+                    _change_to_schema(0, "main")
+                    _change_to_schema(0, BRANCH)
+                    original_title = _pr_title(new="chore: update package version")
+                    _set_pr_draft()
+                    _run_test(branch)
+                finally:
+                    _change_to_schema(0, "main")
+                    _change_to_schema(0, BRANCH)
+                    _pr_title(new=original_title)
+                    _set_pr_not_draft()
+
+
+# @flaky
+def test_live_convert_recipe_to_vi(pytestconfig, skip_if_no_tokens):
+    global GH
+    GH = github.Github(auth=github.Auth.Token(os.environ["GH_TOKEN"]))
+    branch = pytestconfig.getoption("branch")
+    _run_test_try_finally(branch)

--- a/tests/test_live_convert_recipe_to_v1.py
+++ b/tests/test_live_convert_recipe_to_v1.py
@@ -11,7 +11,7 @@ import conda_forge_webservices
 from conda_forge_webservices.utils import pushd
 from conda_forge_webservices.commands import (
     get_workflow_run_from_uid,
-    set_version_update_pr_status,
+    set_convert_v1_pr_status,
 )
 from conda_forge_webservices import __version__
 
@@ -243,7 +243,7 @@ def _run_test(branch):
         else:
             target_url = None
 
-        set_version_update_pr_status(
+        set_convert_v1_pr_status(
             GH.get_repo(REPO), PR_NUM, "pending", target_url=target_url, sha=pr_head_sha
         )
 
@@ -263,7 +263,7 @@ def _run_test(branch):
     print("checking repo for the conversion...", flush=True)
     update_is_ok = _conversion_is_ok(verbose=True)
     if not update_is_ok:
-        set_version_update_pr_status(
+        set_convert_v1_pr_status(
             GH.get_repo(REPO),
             PR_NUM,
             "failure",

--- a/tests/test_live_convert_recipe_to_v1.py
+++ b/tests/test_live_convert_recipe_to_v1.py
@@ -205,15 +205,6 @@ def _conversion_is_ok(verbose=False):
                 if not ("Re-" in output or "chore:" in output):
                     return False
 
-    if "chore: convert recipe to v1" not in _pr_title():
-        return False
-
-    repo = GH.get_repo(REPO)
-    pr = repo.get_pull(PR_NUM)
-
-    if pr.draft:
-        return False
-
     return True
 
 

--- a/tests/test_live_convert_recipe_to_v1.py
+++ b/tests/test_live_convert_recipe_to_v1.py
@@ -6,6 +6,7 @@ import uuid
 
 import github
 import requests
+from flaky import flaky
 
 import conda_forge_webservices
 from conda_forge_webservices.utils import pushd
@@ -292,7 +293,7 @@ def _run_test_try_finally(branch):
                     _set_pr_not_draft()
 
 
-# @flaky
+@flaky
 def test_live_convert_recipe_to_vi(pytestconfig, skip_if_no_tokens):
     global GH
     GH = github.Github(auth=github.Auth.Token(os.environ["GH_TOKEN"]))

--- a/tests/test_live_rerender.py
+++ b/tests/test_live_rerender.py
@@ -48,7 +48,7 @@ def _rerender_is_ok(verbose=False):
                 output = c.stdout.decode("utf-8")
                 if verbose:
                     print("    last commit:", output.strip(), flush=True)
-                if "MNT:" not in output:
+                if "chore:" not in output:
                     return False
 
                 if verbose:

--- a/tests/test_live_rerender.py
+++ b/tests/test_live_rerender.py
@@ -48,7 +48,7 @@ def _rerender_is_ok(verbose=False):
                 output = c.stdout.decode("utf-8")
                 if verbose:
                     print("    last commit:", output.strip(), flush=True)
-                if "chore:" not in output:
+                if ("chore:" not in output) and ("MNT:" not in output):
                     return False
 
                 if verbose:


### PR DESCRIPTION
### Description

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->

This PR adds a v1 conversion command.