### PR TITLE
feat: set status on commits for automerge

### DIFF
--- a/conda_forge_webservices/github_actions_integration/__main__.py
+++ b/conda_forge_webservices/github_actions_integration/__main__.py
@@ -11,7 +11,7 @@ from conda_forge_feedstock_ops import setup_logging
 from conda_forge_feedstock_ops.lint import lint as lint_feedstock
 from git import Repo
 
-from .automerge import automerge_pr
+from .automerge import automerge_pr, set_automerge_status
 from .utils import (
     comment_and_push_if_changed,
     dedent_with_escaped_continue,
@@ -628,6 +628,11 @@ def main_automerge(repo, sha):
         flush=True,
     )
 
+    target_url = (
+        f"https://github.com/conda-forge/conda-forge-webservices/"
+        f"actions/runs/{os.environ['GITHUB_RUN_ID']}"
+    )
+
     found_pr = False
     full_repo_name = f"conda-forge/{repo}"
     _, gh = create_api_sessions()
@@ -637,8 +642,14 @@ def main_automerge(repo, sha):
             _, gh_for_admin = create_api_sessions_for_admin()
             gh_repo_for_admin = gh_for_admin.get_repo(full_repo_name)
             pr_for_admin = gh_repo_for_admin.get_pull(pr.number)
-            automerge_pr(gh_repo, pr, pr_for_admin)
+            did_merge, _ = automerge_pr(gh_repo, pr, pr_for_admin)
             found_pr = True
+
+            if did_merge:
+                status = "success"
+            else:
+                status = "failure"
+            set_automerge_status(gh_repo, None, status, target_url=target_url, sha=sha)
 
     if not found_pr:
         LOGGER.error(f"No PR found for {full_repo_name}@{sha}!")
@@ -647,3 +658,4 @@ def main_automerge(repo, sha):
             f"No PR found for {full_repo_name}@{sha}",
             flush=True,
         )
+        set_automerge_status(gh_repo, None, "error", target_url=target_url, sha=sha)

--- a/conda_forge_webservices/github_actions_integration/automerge.py
+++ b/conda_forge_webservices/github_actions_integration/automerge.py
@@ -39,6 +39,32 @@ BAD_STATES = [
 ]
 
 
+def set_automerge_status(repo, pr_num, status, target_url=None, sha=None):
+    if target_url is not None:
+        kwargs = {"target_url": target_url}
+    else:
+        kwargs = {}
+
+    if sha is None:
+        pull = repo.get_pull(int(pr_num))
+        sha = pull.head.sha
+    commit = repo.get_commit(sha)
+
+    if status == "success":
+        msg = "Automerge job successful."
+    elif status == "failure" or status == "error":
+        msg = "Automerge job failed."
+    else:
+        msg = "Automerge job in progress..."
+
+    commit.create_status(
+        status,
+        description=msg,
+        context="conda-forge-automerge-service",
+        **kwargs,
+    )
+
+
 # https://stackoverflow.com/questions/6194499/pushd-through-os-system
 @contextlib.contextmanager
 def pushd(new_dir):

--- a/conda_forge_webservices/tests/test_webapp.py
+++ b/conda_forge_webservices/tests/test_webapp.py
@@ -58,8 +58,13 @@ class TestBucketHandler(TestHandlerBase):
         return_value=mock.MagicMock(html_url=mock.sentinel.html_url),
     )
     @mock.patch("conda_forge_webservices.linting.set_pr_status")
+    @mock.patch(
+        "conda_forge_webservices.github_actions_integration.automerge.set_automerge_status",
+        return_value=None,
+    )
     def test_good_header(
         self,
+        set_automerge_status,
         set_pr_status,
         comment_on_pr,
         compute_lint_message,
@@ -134,7 +139,8 @@ class TestBucketHandler(TestHandlerBase):
     )
     @mock.patch("conda_forge_webservices.linting.set_pr_status", return_value=None)
     @mock.patch(
-        "conda_forge_webservices.linting.set_automerge_status", return_value=None
+        "conda_forge_webservices.github_actions_integration.automerge.set_automerge_status",
+        return_value=None,
     )
     @mock.patch("conda_forge_webservices.linting.comment_on_pr", return_value=None)
     @mock.patch(
@@ -358,7 +364,8 @@ class TestBucketHandler(TestHandlerBase):
     )
     @mock.patch("conda_forge_webservices.linting.set_pr_status")
     @mock.patch(
-        "conda_forge_webservices.linting.set_automerge_status", return_value=None
+        "conda_forge_webservices.github_actions_integration.automerge.set_automerge_status",
+        return_value=None,
     )
     def test_staged_recipes(
         self,
@@ -442,7 +449,8 @@ class TestBucketHandler(TestHandlerBase):
     )
     @mock.patch("conda_forge_webservices.linting.set_pr_status")
     @mock.patch(
-        "conda_forge_webservices.linting.set_automerge_status", return_value=None
+        "conda_forge_webservices.github_actions_integration.automerge.set_automerge_status",
+        return_value=None,
     )
     def test_staged_recipes_merge_group(
         self,
@@ -505,7 +513,8 @@ class TestBucketHandler(TestHandlerBase):
     )
     @mock.patch("conda_forge_webservices.linting.set_pr_status")
     @mock.patch(
-        "conda_forge_webservices.linting.set_automerge_status", return_value=None
+        "conda_forge_webservices.github_actions_integration.automerge.set_automerge_status",
+        return_value=None,
     )
     def test_staged_recipes_stale(
         self, set_automerge_status, set_pr_status, comment_on_pr, compute_lint_message

--- a/conda_forge_webservices/tests/test_webapp.py
+++ b/conda_forge_webservices/tests/test_webapp.py
@@ -133,6 +133,9 @@ class TestBucketHandler(TestHandlerBase):
         "conda_forge_webservices.linting.compute_lint_message", return_value=None
     )
     @mock.patch("conda_forge_webservices.linting.set_pr_status", return_value=None)
+    @mock.patch(
+        "conda_forge_webservices.linting.set_automerge_status", return_value=None
+    )
     @mock.patch("conda_forge_webservices.linting.comment_on_pr", return_value=None)
     @mock.patch(
         "conda_forge_webservices.feedstocks_service.update_feedstock", return_value=None
@@ -354,8 +357,16 @@ class TestBucketHandler(TestHandlerBase):
         return_value=mock.MagicMock(html_url=mock.sentinel.html_url),
     )
     @mock.patch("conda_forge_webservices.linting.set_pr_status")
+    @mock.patch(
+        "conda_forge_webservices.linting.set_automerge_status", return_value=None
+    )
     def test_staged_recipes(
-        self, set_pr_status, comment_on_pr, compute_lint_message, lint_via_gha
+        self,
+        set_automerge_status,
+        set_pr_status,
+        comment_on_pr,
+        compute_lint_message,
+        lint_via_gha,
     ):
         PR_number = 16
         body = {
@@ -430,8 +441,16 @@ class TestBucketHandler(TestHandlerBase):
         return_value=mock.MagicMock(html_url=mock.sentinel.html_url),
     )
     @mock.patch("conda_forge_webservices.linting.set_pr_status")
+    @mock.patch(
+        "conda_forge_webservices.linting.set_automerge_status", return_value=None
+    )
     def test_staged_recipes_merge_group(
-        self, set_pr_status, comment_on_pr, compute_lint_message, lint_via_gha
+        self,
+        set_automerge_status,
+        set_pr_status,
+        comment_on_pr,
+        compute_lint_message,
+        lint_via_gha,
     ):
         PR_number = 16
         sha = "blahblahblah"
@@ -485,8 +504,11 @@ class TestBucketHandler(TestHandlerBase):
         return_value=mock.MagicMock(html_url=mock.sentinel.html_url),
     )
     @mock.patch("conda_forge_webservices.linting.set_pr_status")
+    @mock.patch(
+        "conda_forge_webservices.linting.set_automerge_status", return_value=None
+    )
     def test_staged_recipes_stale(
-        self, set_pr_status, comment_on_pr, compute_lint_message
+        self, set_automerge_status, set_pr_status, comment_on_pr, compute_lint_message
     ):
         PR_number = 16
         body = {

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -52,11 +52,15 @@ from conda_forge_webservices.feedstock_outputs import (
 from conda_forge_webservices.utils import (
     ALLOWED_CMD_NON_FEEDSTOCKS,
     log_title_and_message_at_level,
+    get_workflow_run_from_uid,
 )
 from conda_forge_webservices import status_monitor
 from conda_forge_webservices.tokens import (
     get_app_token_for_webservices_only,
     get_gh_client,
+)
+from conda_forge_webservices.github_actions_integration.automerge import (
+    set_automerge_status,
 )
 
 LOGGER = logging.getLogger("conda_forge_webservices")
@@ -1246,10 +1250,26 @@ def _dispatch_automerge_job(repo, sha):
             },
         )
 
+        target_url = None
         if running:
             msg = f"automerge job dispatched: uuid={uid}"
+            run = get_workflow_run_from_uid(workflow, uid, ref)
+            if run:
+                target_url = run.html_url
+            status = "pending"
         else:
             msg = "automerge job dispatch failed"
+            status = "error"
+
+        # set the commit status
+        set_automerge_status(
+            gh.get_repo(f"conda-forge/{repo}"),
+            None,
+            status,
+            target_url=target_url,
+            sha=sha,
+        )
+
     else:
         msg = "automerge job dispatch skipped for testing"
 

--- a/tests/test_live_automerge.py
+++ b/tests/test_live_automerge.py
@@ -6,6 +6,9 @@ import uuid
 
 import github
 from conda_forge_webservices.utils import pushd
+from conda_forge_webservices.github_actions_integration.automerge import (
+    set_automerge_status,
+)
 from flaky import flaky
 
 TEST_BASE_BRANCH = "automerge-live-test-base-branch"
@@ -119,6 +122,13 @@ def test_live_automerge(pytestconfig, skip_if_no_tokens):
                                         "sha": pr.head.sha,
                                         "uuid": uid,
                                     },
+                                )
+                                set_automerge_status(
+                                    repo,
+                                    None,
+                                    "pendinf",
+                                    target_url=None,
+                                    sha=pr.head.sha,
                                 )
 
                     if not merged:

--- a/tests/test_live_automerge.py
+++ b/tests/test_live_automerge.py
@@ -126,7 +126,7 @@ def test_live_automerge(pytestconfig, skip_if_no_tokens):
                                 set_automerge_status(
                                     repo,
                                     None,
-                                    "pendinf",
+                                    "pending",
                                     target_url=None,
                                     sha=pr.head.sha,
                                 )


### PR DESCRIPTION
### Description

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->

This will help us debug problems.

cc @h-vetinari 