### PR TITLE
fix: only set automerge status if there is a label or bot slug; use ternary logic

### DIFF
--- a/conda_forge_webservices/github_actions_integration/__main__.py
+++ b/conda_forge_webservices/github_actions_integration/__main__.py
@@ -647,6 +647,8 @@ def main_automerge(repo, sha):
 
             if did_merge:
                 status = "success"
+            elif did_merge is None:
+                status = "pending"
             else:
                 status = "failure"
             set_automerge_status(gh_repo, None, status, target_url=target_url, sha=sha)

--- a/conda_forge_webservices/github_actions_integration/automerge.py
+++ b/conda_forge_webservices/github_actions_integration/automerge.py
@@ -495,7 +495,7 @@ def _automerge_pr(
     repo: Repository,
     pr: PullRequest,
     pr_for_admin: PullRequest,
-) -> tuple[bool, str | None]:
+) -> tuple[bool | None, str | None]:
     cfg = _get_conda_forge_config(pr)
     allowed, msg = _check_pr(pr, pr_for_admin, cfg)
 
@@ -516,14 +516,16 @@ def _automerge_pr(
     )
     if not ok:
         _comment_on_pr(pr_for_admin, final_statuses, "not passing and not merged.")
-        return False, "PR has failing or pending statuses/checks"
+        return None if any(
+            v is None for v in final_statuses.values()
+        ) else False, "PR has failing or pending statuses/checks"
 
     # make sure PR is mergeable and not already merged
     # we have to get the PR again to ensure we have updated mergeable status
     pr = repo.get_pull(pr.number)
 
     if pr.is_merged():
-        return False, "PR has already been merged"
+        return True, "PR has already been merged"
 
     if pr.mergeable is None or not pr.mergeable:
         _comment_on_pr(
@@ -575,7 +577,7 @@ def _automerge_pr(
 
 def automerge_pr(
     repo: Repository, pr: PullRequest, pr_for_admin: PullRequest
-) -> tuple[bool, str | None]:
+) -> tuple[bool | None, str | None]:
     """Possibly automerge a PR.
 
     Parameters
@@ -591,8 +593,9 @@ def automerge_pr(
 
     Returns
     -------
-    did_merge : bool
-        If `True`, the merge was done, `False` if not.
+    did_merge : bool or None
+        If `True`, the merge was done, `False` if not. If `None`
+        checks/status are still pending.
     reason : str
         The reason the merge worked or did not work.
     """

--- a/conda_forge_webservices/github_actions_integration/automerge.py
+++ b/conda_forge_webservices/github_actions_integration/automerge.py
@@ -45,24 +45,37 @@ def set_automerge_status(repo, pr_num, status, target_url=None, sha=None):
     else:
         kwargs = {}
 
+    pull = None
     if sha is None:
         pull = repo.get_pull(int(pr_num))
         sha = pull.head.sha
     commit = repo.get_commit(sha)
+    if pull is None:
+        for pull in commit.get_pulls():
+            pr_num = pull.number
+            break
 
-    if status == "success":
-        msg = "Automerge job successful."
-    elif status == "failure" or status == "error":
-        msg = "Automerge job failed."
-    else:
-        msg = "Automerge job in progress..."
+    set_status = False
+    for label in pull.get_labels():
+        if label.name == "automerge":
+            set_status = True
+    if pull.user.login in ALLOWED_USERS and pull.title.startswith("[bot-automerge]"):
+        set_status = True
 
-    commit.create_status(
-        status,
-        description=msg,
-        context="conda-forge-automerge-service",
-        **kwargs,
-    )
+    if set_status:
+        if status == "success":
+            msg = "Automerge job successful."
+        elif status == "failure" or status == "error":
+            msg = "Automerge job failed."
+        else:
+            msg = "Automerge job in progress..."
+
+        commit.create_status(
+            status,
+            description=msg,
+            context="conda-forge-automerge-service",
+            **kwargs,
+        )
 
 
 # https://stackoverflow.com/questions/6194499/pushd-through-os-system

--- a/conda_forge_webservices/github_actions_integration/tests/test_automerge_pr.py
+++ b/conda_forge_webservices/github_actions_integration/tests/test_automerge_pr.py
@@ -127,7 +127,7 @@ def test_automerge_pr_feedstock_status_or_check_fail(
 
     did_merge, reason = automerge_pr(repo, pr, pr_for_admin)
 
-    assert not did_merge
+    assert did_merge is None
     assert "pending statuses" in reason
     get_cfg_mock.assert_called_once_with(pr)
     check_mock.assert_called_once_with(repo, pr)

--- a/conda_forge_webservices/github_actions_integration/tests/test_automerge_pr.py
+++ b/conda_forge_webservices/github_actions_integration/tests/test_automerge_pr.py
@@ -22,7 +22,7 @@ def test_automerge_pr_bad_user(get_cfg_mock):
 
     did_merge, reason = automerge_pr(repo, pr, pr_for_admin)
 
-    assert not did_merge
+    assert did_merge is False
     assert "user blah" in reason
     get_cfg_mock.assert_called_once_with(pr)
     pr_for_admin.create_issue_comment.assert_not_called()
@@ -47,7 +47,7 @@ def test_automerge_pr_no_title_slug(get_cfg_mock):
 
     did_merge, reason = automerge_pr(repo, pr, pr_for_admin)
 
-    assert not did_merge
+    assert did_merge is False
     assert "slug in the title" in reason
     get_cfg_mock.assert_called_once_with(pr)
     pr_for_admin.create_issue_comment.assert_not_called()
@@ -80,7 +80,7 @@ def test_automerge_pr_feedstock_off(get_cfg_mock, cfg):
 
     did_merge, reason = automerge_pr(repo, pr, pr_for_admin)
 
-    assert not did_merge
+    assert did_merge is False
     assert "off for this feedstock" in reason
     get_cfg_mock.assert_called_once_with(pr)
     pr_for_admin.create_issue_comment.assert_not_called()
@@ -127,7 +127,7 @@ def test_automerge_pr_feedstock_status_or_check_fail(
 
     did_merge, reason = automerge_pr(repo, pr, pr_for_admin)
 
-    assert did_merge is None
+    assert did_merge is False
     assert "pending statuses" in reason
     get_cfg_mock.assert_called_once_with(pr)
     check_mock.assert_called_once_with(repo, pr)
@@ -135,6 +135,56 @@ def test_automerge_pr_feedstock_status_or_check_fail(
     req_mock.assert_called_once_with(pr, get_cfg_mock.return_value)
     pr_for_admin.create_issue_comment.assert_called_once()
     pr_for_admin.get_issue_comments.assert_called()
+    pr_for_admin.merge.assert_not_called()
+
+
+@pytest.mark.parametrize("fail", ["check", "status"])
+@unittest.mock.patch(
+    "conda_forge_webservices.github_actions_integration.automerge._get_conda_forge_config"
+)
+@unittest.mock.patch(
+    "conda_forge_webservices.github_actions_integration.automerge._get_required_checks_and_statuses"
+)
+@unittest.mock.patch(
+    "conda_forge_webservices.github_actions_integration.automerge._get_github_checks"
+)
+@unittest.mock.patch(
+    "conda_forge_webservices.github_actions_integration.automerge._get_github_statuses"
+)
+def test_automerge_pr_feedstock_status_or_check_fail_and_pending(
+    stat_mock, check_mock, req_mock, get_cfg_mock, fail
+):
+    check_mock.return_value = {"check1": True, "check2": None, "check3": None}
+    stat_mock.return_value = {"status1": True, "status2": True, "status3": True}
+    req_mock.return_value = ["check1", "check2", "status1", "status3"]
+    get_cfg_mock.return_value = {"bot": {"automerge": True}}
+
+    if fail == "check":
+        check_mock.return_value["check1"] = False
+    else:
+        stat_mock.return_value["status1"] = False
+
+    repo = MagicMock()
+    repo.full_name = "go"
+
+    pr = MagicMock()
+    pr.user.login = "regro-cf-autotick-bot"
+    pr.title = "[bot-automerge] blah"
+
+    pr_for_admin = MagicMock()
+    pr_for_admin.user.login = "regro-cf-autotick-bot"
+    pr_for_admin.get_issue_comments.return_value = []
+
+    did_merge, reason = automerge_pr(repo, pr, pr_for_admin)
+
+    assert did_merge is None
+    assert "pending statuses" in reason
+    get_cfg_mock.assert_called_once_with(pr)
+    check_mock.assert_called_once_with(repo, pr)
+    stat_mock.assert_called_once_with(repo, pr)
+    req_mock.assert_called_once_with(pr, get_cfg_mock.return_value)
+    pr_for_admin.create_issue_comment.assert_not_called()
+    pr_for_admin.get_issue_comments.assert_not_called()
     pr_for_admin.merge.assert_not_called()
 
 
@@ -170,7 +220,7 @@ def test_automerge_pr_feedstock_no_statuses_or_checks(
 
     did_merge, reason = automerge_pr(repo, pr, pr_for_admin)
 
-    assert not did_merge
+    assert did_merge is False
     assert "At least one status or check must be required" in reason
     get_cfg_mock.assert_called_once_with(pr)
     check_mock.assert_called_once_with(repo, pr)

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -1317,7 +1317,8 @@ class StatusMonitorPayloadHookHandler(WriteErrorAsJSONRequestHandler):
             if event == "status" and body["repository"]["full_name"].endswith(
                 "-feedstock"
             ):
-                tornado.ioloop.IOLoop.current().spawn_callback(
+                await tornado.ioloop.IOLoop.current().run_in_executor(
+                    _worker_pool("command"),
                     _dispatch_automerge_job,
                     body["repository"]["name"],
                     body["sha"],
@@ -1329,7 +1330,8 @@ class StatusMonitorPayloadHookHandler(WriteErrorAsJSONRequestHandler):
             if body["action"] == "completed" and body["repository"][
                 "full_name"
             ].endswith("-feedstock"):
-                tornado.ioloop.IOLoop.current().spawn_callback(
+                await tornado.ioloop.IOLoop.current().run_in_executor(
+                    _worker_pool("command"),
                     _dispatch_automerge_job,
                     body["repository"]["name"],
                     body["check_suite"]["head_sha"],
@@ -1349,7 +1351,8 @@ class StatusMonitorPayloadHookHandler(WriteErrorAsJSONRequestHandler):
             # )
 
             if body["repository"]["full_name"].endswith("-feedstock"):
-                tornado.ioloop.IOLoop.current().spawn_callback(
+                await tornado.ioloop.IOLoop.current().run_in_executor(
+                    _worker_pool("command"),
                     _dispatch_automerge_job,
                     body["repository"]["name"],
                     body["pull_request"]["head"]["sha"],


### PR DESCRIPTION
### Description

As it says in the title. 

cc @h-vetinari 
