### PR TITLE
fix: set automerge status only in GHA job

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -52,7 +52,7 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.CF_CURATOR_APP_ID }}
+          client-id: ${{ secrets.CF_CURATOR_APP_ID }}
           private-key: ${{ secrets.CF_CURATOR_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 

--- a/.github/workflows/clean-and-update.yml
+++ b/.github/workflows/clean-and-update.yml
@@ -44,7 +44,7 @@ jobs:
         if: github.event_name != 'issue_comment' && steps.relock.outputs.relocked == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.CF_CURATOR_APP_ID }}
+          client-id: ${{ secrets.CF_CURATOR_APP_ID }}
           private-key: ${{ secrets.CF_CURATOR_PRIVATE_KEY }}
           owner: conda-forge
           repositories: docker-images
@@ -91,7 +91,7 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.CF_CURATOR_APP_ID }}
+          client-id: ${{ secrets.CF_CURATOR_APP_ID }}
           private-key: ${{ secrets.CF_CURATOR_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 

--- a/conda_forge_webservices/github_actions_integration/__main__.py
+++ b/conda_forge_webservices/github_actions_integration/__main__.py
@@ -11,7 +11,7 @@ from conda_forge_feedstock_ops import setup_logging
 from conda_forge_feedstock_ops.lint import lint as lint_feedstock
 from git import Repo
 
-from .automerge import automerge_pr, set_automerge_status
+from .automerge import automerge_pr
 from .utils import (
     comment_and_push_if_changed,
     dedent_with_escaped_continue,
@@ -642,16 +642,8 @@ def main_automerge(repo, sha):
             _, gh_for_admin = create_api_sessions_for_admin()
             gh_repo_for_admin = gh_for_admin.get_repo(full_repo_name)
             pr_for_admin = gh_repo_for_admin.get_pull(pr.number)
-            did_merge, _ = automerge_pr(gh_repo, pr, pr_for_admin)
+            automerge_pr(gh_repo, pr, pr_for_admin, target_url)
             found_pr = True
-
-            if did_merge:
-                status = "success"
-            elif did_merge is None:
-                status = "pending"
-            else:
-                status = "failure"
-            set_automerge_status(gh_repo, None, status, target_url=target_url, sha=sha)
 
     if not found_pr:
         LOGGER.error(f"No PR found for {full_repo_name}@{sha}!")
@@ -660,4 +652,3 @@ def main_automerge(repo, sha):
             f"No PR found for {full_repo_name}@{sha}",
             flush=True,
         )
-        set_automerge_status(gh_repo, None, "error", target_url=target_url, sha=sha)

--- a/conda_forge_webservices/github_actions_integration/automerge.py
+++ b/conda_forge_webservices/github_actions_integration/automerge.py
@@ -499,12 +499,8 @@ def _automerge_pr(
     repo: Repository,
     pr: PullRequest,
     pr_for_admin: PullRequest,
+    cfg: dict,
 ) -> tuple[bool | None, str | None]:
-    cfg = _get_conda_forge_config(pr)
-    allowed, msg = _check_pr(pr, pr_for_admin, cfg)
-
-    if not allowed:
-        return False, msg
 
     # get checks and statuses
     status_states = _get_github_statuses(repo, pr)
@@ -580,7 +576,10 @@ def _automerge_pr(
 
 
 def automerge_pr(
-    repo: Repository, pr: PullRequest, pr_for_admin: PullRequest
+    repo: Repository,
+    pr: PullRequest,
+    pr_for_admin: PullRequest,
+    target_url: str | None = None,
 ) -> tuple[bool | None, str | None]:
     """Possibly automerge a PR.
 
@@ -594,6 +593,8 @@ def automerge_pr(
     pr_for_admin : github.PullRequest.PullRequest
         A `PullRequest` object for the given PR from the PyGithub package
         that is used only to comment on and/or merge the PR.
+    target_url : str | None
+        The URL used for setting the status on the commit.
 
     Returns
     -------
@@ -603,7 +604,54 @@ def automerge_pr(
     reason : str
         The reason the merge worked or did not work.
     """
-    did_merge, reason = _automerge_pr(repo, pr, pr_for_admin)
+    # check if allowed and exit if not
+    # do not set any statuses
+    cfg = _get_conda_forge_config(pr)
+    allowed, reason = _check_pr(pr, pr_for_admin, cfg)
+
+    if not allowed:
+        LOGGER.info(
+            "AUTOMERGE NOT ALLOWED FOR PR %s on %s: %s",
+            pr.number,
+            repo.full_name,
+            reason,
+        )
+        return False, reason
+
+    if pr.is_merged():
+        LOGGER.info("ALREADY MERGED PR %s on %s: %s", pr.number, repo.full_name, reason)
+        set_automerge_status(
+            repo, pr.number, "success", target_url=target_url, sha=pr.head.sha
+        )
+        return True, "PR has already been merged"
+
+    # set pending status if not already successful
+    set_pending = True
+    commit = repo.get_commit(pr.head.sha)
+    combined_status = commit.get_combined_status()
+    for status in combined_status.statuses:
+        if status.context == "conda-forge-automerge-service":
+            if status.state == "success":
+                set_pending = False
+            break
+    if set_pending:
+        set_automerge_status(
+            repo, pr.number, "pending", target_url=target_url, sha=pr.head.sha
+        )
+
+    # attempt to merge
+    did_merge, reason = _automerge_pr(repo, pr, pr_for_admin, cfg)
+
+    # set final status
+    if did_merge:
+        status = "success"
+    elif did_merge is None:
+        status = "pending"
+    else:
+        status = "failure"
+    set_automerge_status(
+        repo, pr.number, status, target_url=target_url, sha=pr.head.sha
+    )
 
     if did_merge:
         LOGGER.info("MERGED PR %s on %s: %s", pr.number, repo.full_name, reason)

--- a/conda_forge_webservices/github_actions_integration/tests/test_automerge_pr.py
+++ b/conda_forge_webservices/github_actions_integration/tests/test_automerge_pr.py
@@ -120,6 +120,7 @@ def test_automerge_pr_feedstock_status_or_check_fail(
     pr = MagicMock()
     pr.user.login = "regro-cf-autotick-bot"
     pr.title = "[bot-automerge] blah"
+    pr.is_merged.return_value = False
 
     pr_for_admin = MagicMock()
     pr_for_admin.user.login = "regro-cf-autotick-bot"
@@ -170,6 +171,7 @@ def test_automerge_pr_feedstock_status_or_check_fail_and_pending(
     pr = MagicMock()
     pr.user.login = "regro-cf-autotick-bot"
     pr.title = "[bot-automerge] blah"
+    pr.is_merged.return_value = False
 
     pr_for_admin = MagicMock()
     pr_for_admin.user.login = "regro-cf-autotick-bot"
@@ -214,6 +216,7 @@ def test_automerge_pr_feedstock_no_statuses_or_checks(
     pr = MagicMock()
     pr.user.login = "regro-cf-autotick-bot"
     pr.title = "[bot-automerge] blah"
+    pr.is_merged.return_value = False
 
     pr_for_admin = MagicMock()
     pr_for_admin.user.login = "regro-cf-autotick-bot"

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -1244,7 +1244,6 @@ def _dispatch_automerge_job(repo, sha):
                 "sha": sha,
                 "uuid": uid,
             },
-            return_run_details=True,
         )
 
         if running:
@@ -1301,8 +1300,7 @@ class StatusMonitorPayloadHookHandler(WriteErrorAsJSONRequestHandler):
                 and body["repository"]["full_name"].endswith("-feedstock")
                 and body["context"] != "conda-forge-automerge-status"
             ):
-                await tornado.ioloop.IOLoop.current().run_in_executor(
-                    _worker_pool("command"),
+                tornado.ioloop.IOLoop.current().spawn_callback(
                     _dispatch_automerge_job,
                     body["repository"]["name"],
                     body["sha"],
@@ -1314,8 +1312,7 @@ class StatusMonitorPayloadHookHandler(WriteErrorAsJSONRequestHandler):
             if body["action"] == "completed" and body["repository"][
                 "full_name"
             ].endswith("-feedstock"):
-                await tornado.ioloop.IOLoop.current().run_in_executor(
-                    _worker_pool("command"),
+                tornado.ioloop.IOLoop.current().spawn_callback(
                     _dispatch_automerge_job,
                     body["repository"]["name"],
                     body["check_suite"]["head_sha"],
@@ -1335,8 +1332,7 @@ class StatusMonitorPayloadHookHandler(WriteErrorAsJSONRequestHandler):
             # )
 
             if body["repository"]["full_name"].endswith("-feedstock"):
-                await tornado.ioloop.IOLoop.current().run_in_executor(
-                    _worker_pool("command"),
+                tornado.ioloop.IOLoop.current().spawn_callback(
                     _dispatch_automerge_job,
                     body["repository"]["name"],
                     body["pull_request"]["head"]["sha"],

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -58,9 +58,6 @@ from conda_forge_webservices.tokens import (
     get_app_token_for_webservices_only,
     get_gh_client,
 )
-# from conda_forge_webservices.github_actions_integration.automerge import (
-#     set_automerge_status,
-# )
 
 LOGGER = logging.getLogger("conda_forge_webservices")
 
@@ -1250,23 +1247,10 @@ def _dispatch_automerge_job(repo, sha):
             return_run_details=True,
         )
 
-        # target_url = None
         if running:
             msg = f"automerge job dispatched: uuid={uid}"
-            # target_url = running.html_url
-            # status = "pending"
         else:
             msg = "automerge job dispatch failed"
-            # status = "error"
-
-        # set the commit status
-        # set_automerge_status(
-        #     gh.get_repo(f"conda-forge/{repo}"),
-        #     None,
-        #     status,
-        #     target_url=target_url,
-        #     sha=sha,
-        # )
 
     else:
         msg = "automerge job dispatch skipped for testing"

--- a/tests/test_live_automerge.py
+++ b/tests/test_live_automerge.py
@@ -6,9 +6,6 @@ import uuid
 
 import github
 from conda_forge_webservices.utils import pushd
-from conda_forge_webservices.github_actions_integration.automerge import (
-    set_automerge_status,
-)
 from flaky import flaky
 
 TEST_BASE_BRANCH = "automerge-live-test-base-branch"
@@ -106,13 +103,6 @@ def test_live_automerge(pytestconfig, skip_if_no_tokens):
                             if pr.is_merged():
                                 print("PR was merged!", flush=True)
                                 merged = True
-                                set_automerge_status(
-                                    repo,
-                                    None,
-                                    "success",
-                                    target_url=None,
-                                    sha=pr.head.sha,
-                                )
                                 break
                             elif tot > 0:
                                 uid = uuid.uuid4().hex
@@ -132,13 +122,6 @@ def test_live_automerge(pytestconfig, skip_if_no_tokens):
                                     return_run_details=True,
                                 )
                                 assert running
-                                set_automerge_status(
-                                    repo,
-                                    None,
-                                    "pending",
-                                    target_url=running.html_url,
-                                    sha=pr.head.sha,
-                                )
 
                     if not merged:
                         raise RuntimeError(f"PR {pr.number} was not merged!")


### PR DESCRIPTION
### Description

This PR sets the automerge status only in GHA and so should avoid the issues with performance.

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
