### PR TITLE
fix: look at all pulls for automerge

### DIFF
--- a/conda_forge_webservices/github_actions_integration/__main__.py
+++ b/conda_forge_webservices/github_actions_integration/__main__.py
@@ -637,7 +637,7 @@ def main_automerge(repo, sha):
     full_repo_name = f"conda-forge/{repo}"
     _, gh = create_api_sessions()
     gh_repo = gh.get_repo(full_repo_name)
-    for pr in gh_repo.get_pulls():
+    for pr in gh_repo.get_pulls(state="all", sort="updated", direction="desc"):
         if pr.head.sha == sha:
             _, gh_for_admin = create_api_sessions_for_admin()
             gh_repo_for_admin = gh_for_admin.get_repo(full_repo_name)


### PR DESCRIPTION
### Description

This will help us not miss status updates.

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
