### PR TITLE
chore: tidy up GHA by removing uuid stuff and pin on micromamba

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,7 +1,7 @@
 name: automerge
 
 run-name: >-
-  automerge: conda-forge/${{ inputs.repo }}@${{ inputs.sha }} [uuid=${{ inputs.uuid }}]
+  automerge: conda-forge/${{ inputs.repo }}@${{ inputs.sha }}
 
 on:
   workflow_dispatch:
@@ -12,10 +12,6 @@ on:
         type: string
       sha:
         description: 'the commit SHA to possibly merge'
-        required: true
-        type: string
-      uuid:
-        description: 'a unique identifier for this run'
         required: true
         type: string
 
@@ -39,7 +35,6 @@ jobs:
       - name: setup conda
         uses: mamba-org/setup-micromamba@f457c30a868e4760d3a6fcea5f25dc655b8edf39 # v3.2.1
         with:
-          micromamba-version: "2.7.0-0"
           environment-file: conda-lock.yml
           environment-name: webservices
           condarc: |

--- a/.github/workflows/clean-and-update.yml
+++ b/.github/workflows/clean-and-update.yml
@@ -78,7 +78,6 @@ jobs:
       - name: setup conda
         uses: mamba-org/setup-micromamba@f457c30a868e4760d3a6fcea5f25dc655b8edf39 # v3.2.1
         with:
-          micromamba-version: "2.7.0-0"
           environment-file: conda-lock.yml
           environment-name: webservices
           condarc: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,6 @@ jobs:
 
       - uses: mamba-org/setup-micromamba@f457c30a868e4760d3a6fcea5f25dc655b8edf39 # v3.2.1
         with:
-          micromamba-version: "2.7.0-0"
           environment-file: conda-lock.yml
           environment-name: webservices
           condarc: |
@@ -70,7 +69,6 @@ jobs:
 
       - uses: mamba-org/setup-micromamba@f457c30a868e4760d3a6fcea5f25dc655b8edf39 # v3.2.1
         with:
-          micromamba-version: "2.7.0-0"
           environment-file: conda-lock.yml
           environment-name: webservices
           condarc: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -118,7 +118,6 @@ jobs:
         uses: mamba-org/setup-micromamba@f457c30a868e4760d3a6fcea5f25dc655b8edf39 # v3.2.1
         if: ${{ needs.check.outputs.skip-check != 'true' }}
         with:
-          micromamba-version: "2.7.0-0"
           environment-file: conda-lock.yml
           environment-name: webservices
           condarc: |
@@ -189,7 +188,6 @@ jobs:
         uses: mamba-org/setup-micromamba@f457c30a868e4760d3a6fcea5f25dc655b8edf39 # v3.2.1
         if: ${{ needs.check.outputs.skip-check != 'true' }}
         with:
-          micromamba-version: "2.7.0-0"
           environment-file: conda-lock.yml
           environment-name: webservices
           condarc: |
@@ -250,7 +248,6 @@ jobs:
         if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
         uses: mamba-org/setup-micromamba@f457c30a868e4760d3a6fcea5f25dc655b8edf39 # v3.2.1
         with:
-          micromamba-version: "2.7.0-0"
           environment-file: conda-lock.yml
           environment-name: webservices
           condarc: |
@@ -315,7 +312,6 @@ jobs:
         if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
         uses: mamba-org/setup-micromamba@f457c30a868e4760d3a6fcea5f25dc655b8edf39 # v3.2.1
         with:
-          micromamba-version: "2.7.0-0"
           environment-file: conda-lock.yml
           environment-name: webservices
           condarc: |
@@ -383,7 +379,6 @@ jobs:
         if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
         uses: mamba-org/setup-micromamba@f457c30a868e4760d3a6fcea5f25dc655b8edf39 # v3.2.1
         with:
-          micromamba-version: "2.7.0-0"
           environment-file: conda-lock.yml
           environment-name: webservices
           condarc: |
@@ -451,7 +446,6 @@ jobs:
         if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
         uses: mamba-org/setup-micromamba@f457c30a868e4760d3a6fcea5f25dc655b8edf39 # v3.2.1
         with:
-          micromamba-version: "2.7.0-0"
           environment-file: conda-lock.yml
           environment-name: webservices
           condarc: |
@@ -518,7 +512,6 @@ jobs:
         if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
         uses: mamba-org/setup-micromamba@f457c30a868e4760d3a6fcea5f25dc655b8edf39 # v3.2.1
         with:
-          micromamba-version: "2.7.0-0"
           environment-file: conda-lock.yml
           environment-name: webservices
           condarc: |
@@ -579,7 +572,6 @@ jobs:
         if: ${{ needs.check.outputs.skip-check != 'true' && !github.event.pull_request.head.repo.fork }}
         uses: mamba-org/setup-micromamba@f457c30a868e4760d3a6fcea5f25dc655b8edf39 # v3.2.1
         with:
-          micromamba-version: "2.7.0-0"
           environment-file: conda-lock.yml
           environment-name: webservices
           condarc: |

--- a/.github/workflows/webservices-workflow-dispatch.yml
+++ b/.github/workflows/webservices-workflow-dispatch.yml
@@ -1,7 +1,7 @@
 name: webservices-workflow-dispatch
 
 run-name: >-
-  ${{ inputs.task }}: conda-forge/${{ inputs.repo }}#${{ inputs.pr_number }} [container=${{ inputs.container_tag }}, requested_version=${{ inputs.requested_version }}, uuid=${{ inputs.uuid }}]
+  ${{ inputs.task }}: conda-forge/${{ inputs.repo }}#${{ inputs.pr_number }} [container=${{ inputs.container_tag }}, requested_version=${{ inputs.requested_version }}]
 
 on:
   workflow_dispatch:
@@ -27,10 +27,6 @@ on:
         required: false
         type: string
         default: 'null'
-      uuid:
-        description: 'a unique identifier for this run'
-        required: true
-        type: string
       sha:
         description: 'the sha of the commit to run on'
         required: false
@@ -65,7 +61,6 @@ jobs:
       - name: setup conda
         uses: mamba-org/setup-micromamba@f457c30a868e4760d3a6fcea5f25dc655b8edf39 # v3.2.1
         with:
-          micromamba-version: "2.7.0-0"
           environment-file: conda-lock.yml
           environment-name: webservices
           condarc: |
@@ -119,7 +114,6 @@ jobs:
       - name: setup conda
         uses: mamba-org/setup-micromamba@f457c30a868e4760d3a6fcea5f25dc655b8edf39 # v3.2.1
         with:
-          micromamba-version: "2.7.0-0"
           environment-file: conda-lock.yml
           environment-name: webservices
           condarc: |

--- a/conda_forge_webservices/commands.py
+++ b/conda_forge_webservices/commands.py
@@ -7,7 +7,6 @@ import time
 import shutil
 import tempfile
 import textwrap
-import uuid
 from ruamel.yaml import YAML
 import requests
 from requests.exceptions import RequestException
@@ -1221,7 +1220,6 @@ def rerender(full_name, pr_num):
     sha = pull.head.sha
 
     _, repo_name = full_name.split("/")
-    uid = uuid.uuid4().hex
     ref = __version__.replace("+", ".")
     workflow = gh.get_repo("conda-forge/conda-forge-webservices").get_workflow(
         "webservices-workflow-dispatch.yml"
@@ -1233,7 +1231,6 @@ def rerender(full_name, pr_num):
             "repo": repo_name,
             "pr_number": str(pr_num),
             "container_tag": ref,
-            "uuid": uid,
             "sha": sha,
         },
         return_run_details=True,
@@ -1281,7 +1278,6 @@ def convert_v1(full_name, pr_num):
     sha = pull.head.sha
 
     _, repo_name = full_name.split("/")
-    uid = uuid.uuid4().hex
     ref = __version__.replace("+", ".")
     workflow = gh.get_repo("conda-forge/conda-forge-webservices").get_workflow(
         "webservices-workflow-dispatch.yml"
@@ -1293,7 +1289,6 @@ def convert_v1(full_name, pr_num):
             "repo": repo_name,
             "pr_number": str(pr_num),
             "container_tag": ref,
-            "uuid": uid,
             "sha": sha,
         },
         return_run_details=True,
@@ -1342,7 +1337,6 @@ def update_version(full_name, pr_num, input_ver):
     pull = repo.get_pull(int(pr_num))
     sha = pull.head.sha
 
-    uid = uuid.uuid4().hex
     _, repo_name = full_name.split("/")
     ref = __version__.replace("+", ".")
     workflow = gh.get_repo("conda-forge/conda-forge-webservices").get_workflow(
@@ -1356,7 +1350,6 @@ def update_version(full_name, pr_num, input_ver):
             "pr_number": str(pr_num),
             "container_tag": ref,
             "requested_version": str(input_ver) or "null",
-            "uuid": uid,
             "sha": sha,
         },
         return_run_details=True,

--- a/conda_forge_webservices/linting.py
+++ b/conda_forge_webservices/linting.py
@@ -4,7 +4,6 @@ from tempfile import TemporaryDirectory
 import logging
 from pathlib import Path
 from typing import TypedDict
-import uuid
 
 from git import GitCommandError, Repo
 import conda_smithy.lint_recipe
@@ -49,7 +48,6 @@ def lint_via_github_actions(
     if should_skip and sha is None:
         return False
 
-    uid = uuid.uuid4().hex
     ref = __version__.replace("+", ".")
     workflow = gh.get_repo("conda-forge/conda-forge-webservices").get_workflow(
         "webservices-workflow-dispatch.yml"
@@ -61,7 +59,6 @@ def lint_via_github_actions(
             "repo": repo_name,
             "pr_number": str(pr_num),
             "container_tag": ref,
-            "uuid": uid,
             "sha": sha_to_use,
             "merge_queue": "true" if sha is not None else "false",
         },
@@ -69,7 +66,7 @@ def lint_via_github_actions(
     )
 
     if running:
-        msg = f"linting job dispatched: uuid={uid}"
+        msg = f"linting job dispatched: {running.html_url}"
         retval = True
         target_url = running.html_url
         _set_pr_status(

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -1232,7 +1232,6 @@ def _dispatch_automerge_job(repo, sha):
                 break
 
     if not skip_test_pr:
-        uid = uuid.uuid4().hex
         ref = __version__.replace("+", ".")
         workflow = gh.get_repo("conda-forge/conda-forge-webservices").get_workflow(
             "automerge.yml"
@@ -1242,12 +1241,12 @@ def _dispatch_automerge_job(repo, sha):
             inputs={
                 "repo": repo,
                 "sha": sha,
-                "uuid": uid,
             },
+            return_run_details=True,
         )
 
         if running:
-            msg = f"automerge job dispatched: uuid={uid}"
+            msg = f"automerge job dispatched: {running.html_url}"
         else:
             msg = "automerge job dispatch failed"
 

--- a/tests/test_live_automerge.py
+++ b/tests/test_live_automerge.py
@@ -105,7 +105,6 @@ def test_live_automerge(pytestconfig, skip_if_no_tokens):
                                 merged = True
                                 break
                             elif tot > 0:
-                                uid = uuid.uuid4().hex
                                 cfws_repo = gh.get_repo(
                                     "conda-forge/conda-forge-webservices"
                                 )
@@ -117,7 +116,6 @@ def test_live_automerge(pytestconfig, skip_if_no_tokens):
                                             "cf-autotick-bot-test-package-feedstock"
                                         ),
                                         "sha": pr.head.sha,
-                                        "uuid": uid,
                                     },
                                     return_run_details=True,
                                 )

--- a/tests/test_live_convert_recipe_to_v1.py
+++ b/tests/test_live_convert_recipe_to_v1.py
@@ -2,7 +2,6 @@ import os
 import subprocess
 import tempfile
 import time
-import uuid
 
 import github
 import requests
@@ -210,7 +209,6 @@ def _conversion_is_ok(verbose=False):
 def _run_test(branch):
     print("sending workflow dispatch event to recipe converter...", flush=True)
     pr_head_sha = GH.get_repo(REPO).get_pull(PR_NUM).head.sha
-    uid = uuid.uuid4().hex
     repo = GH.get_repo("conda-forge/conda-forge-webservices")
     workflow = repo.get_workflow("webservices-workflow-dispatch.yml")
     running = workflow.create_dispatch(
@@ -221,7 +219,6 @@ def _run_test(branch):
             "pr_number": str(PR_NUM),
             "container_tag": conda_forge_webservices.__version__.replace("+", "."),
             "requested_version": "null",
-            "uuid": uid,
             "sha": pr_head_sha,
         },
         return_run_details=True,

--- a/tests/test_live_linter.py
+++ b/tests/test_live_linter.py
@@ -2,7 +2,6 @@ import os
 import subprocess
 import tempfile
 import time
-import uuid
 
 import github
 import pytest
@@ -207,7 +206,6 @@ def test_linter_pr(target_pr_number, pytestconfig, skip_if_no_tokens):
 
         _make_empty_commit(pr_number)
 
-        uid = uuid.uuid4().hex
         pr = repo.get_pull(pr_number)
         pr_sha = pr.head.sha
         workflow = repo.get_workflow("webservices-workflow-dispatch.yml")
@@ -218,7 +216,6 @@ def test_linter_pr(target_pr_number, pytestconfig, skip_if_no_tokens):
                 "repo": "conda-forge-webservices",
                 "pr_number": str(pr_number),
                 "container_tag": conda_forge_webservices.__version__.replace("+", "."),
-                "uuid": uid,
                 "sha": pr_sha,
             },
             return_run_details=True,

--- a/tests/test_live_rerender.py
+++ b/tests/test_live_rerender.py
@@ -3,7 +3,6 @@ import os
 import subprocess
 import tempfile
 import time
-import uuid
 
 import conda_forge_webservices
 import github
@@ -68,7 +67,6 @@ def _rerender_is_ok(verbose=False):
 def _run_test(branch):
     pr_number = 445
     print("sending workflow dispatch event to rerender...", flush=True)
-    uid = uuid.uuid4().hex
     gh = github.Github(auth=github.Auth.Token(os.environ["GH_TOKEN"]))
     repo = gh.get_repo("conda-forge/conda-forge-webservices")
     workflow = repo.get_workflow("webservices-workflow-dispatch.yml")
@@ -84,7 +82,6 @@ def _run_test(branch):
             "repo": "cf-autotick-bot-test-package-feedstock",
             "pr_number": str(pr_number),
             "container_tag": conda_forge_webservices.__version__.replace("+", "."),
-            "uuid": uid,
             "sha": pr_sha,
         },
         return_run_details=True,

--- a/tests/test_live_version_update.py
+++ b/tests/test_live_version_update.py
@@ -2,7 +2,6 @@ import os
 import subprocess
 import tempfile
 import time
-import uuid
 
 import github
 import requests
@@ -289,7 +288,6 @@ def _version_update_is_ok(version, schema_version, verbose=False):
 def _run_test(branch, version, schema_version):
     print("sending workflow dispatch event to version updater...", flush=True)
     pr_head_sha = GH.get_repo(REPO).get_pull(PR_NUM).head.sha
-    uid = uuid.uuid4().hex
     repo = GH.get_repo("conda-forge/conda-forge-webservices")
     workflow = repo.get_workflow("webservices-workflow-dispatch.yml")
     running = workflow.create_dispatch(
@@ -300,7 +298,6 @@ def _run_test(branch, version, schema_version):
             "pr_number": str(PR_NUM),
             "container_tag": conda_forge_webservices.__version__.replace("+", "."),
             "requested_version": version or "null",
-            "uuid": uid,
             "sha": pr_head_sha,
         },
         return_run_details=True,


### PR DESCRIPTION
### Description

We do not need the uuid stuff anymore, and the latest micromamba fixed some performance regressions.

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
