### PR TITLE
fix: get rate limit right and add test

### DIFF
--- a/conda_forge_webservices/tests/test_webapp.py
+++ b/conda_forge_webservices/tests/test_webapp.py
@@ -8,7 +8,7 @@ import unittest.mock as mock
 
 from tornado.testing import AsyncHTTPTestCase
 
-from conda_forge_webservices.webapp import create_webapp
+from conda_forge_webservices.webapp import create_webapp, _print_rate_limiting_info
 from conda_forge_webservices import linting
 
 
@@ -640,3 +640,7 @@ class TestBucketHandler(TestHandlerBase):
             )
             if full_name is not None and token is not None:
                 linting_mock.assert_any_call(full_name, 10, sha="xyz3123")
+
+
+def test_webapp_print_rate_limiting_info():
+    _print_rate_limiting_info()

--- a/conda_forge_webservices/webapp.py
+++ b/conda_forge_webservices/webapp.py
@@ -151,8 +151,8 @@ def _get_rate_limiting_info_for_token(token):
 
     # Get GitHub API Rate Limit usage and total
     gh = github.Github(auth=github.Auth.Token(token))
-    gh_api_remaining = gh.get_rate_limit().core.remaining
-    gh_api_total = gh.get_rate_limit().core.limit
+    gh_api_remaining = gh.get_rate_limit().rate.remaining
+    gh_api_total = gh.get_rate_limit().rate.limit
 
     try:
         user = gh.get_user().login
@@ -160,7 +160,7 @@ def _get_rate_limiting_info_for_token(token):
         user = "conda-forge-webservices[bot]"
 
     # Compute time until GitHub API Rate Limit reset
-    gh_api_reset_time = gh.get_rate_limit().core.reset
+    gh_api_reset_time = gh.get_rate_limit().rate.reset
     gh_api_reset_time -= datetime.now(timezone.utc)
     msg = f"{user} - remaining {gh_api_remaining} out of {gh_api_total}."
     msg = f"github api requests: {msg} - Will reset in {gh_api_reset_time}."


### PR DESCRIPTION
### Description

This is a bug form the upgrade of pygithub.

<!-- Please put a description of your PR here along with any cross-refs to issues, etc. -->

<!--
Thank you for the pull request! This repo's tests require that the commit be pushed to
a branch on conda-forge/conda-forge-webservices. This is to ensure that there's a GH_TOKEN variable
to test the commenting of the linter and command bot.

To make this easy, we use a merge queue. The tests on your fork will run, but some will be skipped
due to the missing tokens. Once a member of conda-forge/core merges the PR, the complete test suite
will be run on the upstream repo. If this passes, the PR will get merged into `main`. If not, the PR
will get kicked out of the queue for fixes.

If you have push access to this repo, you can use a branch for your PR, but this will not bypass the
merge queue.
-->
